### PR TITLE
chore: fix homepage link

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -5,7 +5,7 @@ const CONSTRUCTS_VERSION = "3.3.69";
 
 const project = new awscdk.AwsCdkConstructLibrary({
   name: "cdk-monitoring-constructs",
-  repositoryUrl: "git@github.com:cdklabs/cdk-monitoring-constructs.git",
+  repositoryUrl: "https://github.com/cdklabs/cdk-monitoring-constructs",
   author: "CDK Monitoring Constructs Team",
   authorAddress: "monitoring-cdk-constructs@amazon.com",
   defaultReleaseBranch: "main",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cdk-monitoring-constructs",
   "repository": {
     "type": "git",
-    "url": "git@github.com:cdklabs/cdk-monitoring-constructs.git"
+    "url": "https://github.com/cdklabs/cdk-monitoring-constructs"
   },
   "scripts": {
     "build": "npx projen build",


### PR DESCRIPTION
Fix homepage github repo link since the current format is not supported on pypi