### PR TITLE
chore: exclude TS files from final tarball

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -20,3 +20,5 @@ dist
 tsconfig.tsbuildinfo
 /.eslintrc.json
 !.jsii
+*.ts
+!*.d.ts

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -9,6 +9,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   author: "CDK Monitoring Constructs Team",
   authorAddress: "monitoring-cdk-constructs@amazon.com",
   defaultReleaseBranch: "main",
+  stability: "experimental",
 
   cdkVersion: CDK_VERSION,
   cdkVersionPinning: true,
@@ -90,5 +91,10 @@ project.eslint.addRules({
   "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
   "prettier/prettier": "error",
 });
+
+// Don't need to include the TypeScript source files in the tarball; the transpiled JS files and
+// typing files are sufficient.
+project.addPackageIgnore("*.ts");
+project.addPackageIgnore("!*.d.ts");
 
 project.synth();

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     }
   },
   "types": "lib/index.d.ts",
-  "stability": "stable",
+  "stability": "experimental",
   "jsii": {
     "outdir": "dist",
     "targets": {


### PR DESCRIPTION
Partially addresses #18

Verified that tarball (`dist/js/cdk-monitoring-constructs@0.0.0.jsii.tgz`) doesn't include TS files anymore.