### PR TITLE
chore: convert Lambda handlers to vanilla JS

### DIFF
--- a/assets/BitmapWidgetRenderingSupport/index.js
+++ b/assets/BitmapWidgetRenderingSupport/index.js
@@ -1,18 +1,15 @@
-// Ignoring some checks since the function is in pure JS
-
-/* eslint-disable */
 const aws = require('aws-sdk');
 
 const DOCS = `
           ## Display a CloudWatch bitmap graph
           Displays CloudWatch metrics as a bitmap, for faster display of metrics.
-          
+
           ### Widget parameters
           Param | Description
           ---|---
           **graph** | The graph definition. Use the parameters from the **Source** tab in CloudWatch Console's **Metrics** page.
           **useMonitorPortal** (default = true) | Flag indicating whether we want to use MonitorPortal to render the graph. False will switch to CloudWatch API.
-          
+
           ### Example parameters
           \`\`\` yaml
           useMonitorPortal: boolean
@@ -24,11 +21,11 @@ const DOCS = `
           \`\`\`
           `;
 
-exports.handler = async (event: any) => {
-    async function renderUsingCloudWatch(graph: any, width: number, height: number) {
+exports.handler = async (event) => {
+    async function renderUsingCloudWatch(graph, width, height) {
         const params = {MetricWidget: JSON.stringify(graph)};
         const region = graph.region;
-        const customBackoff = (retryCount: number) => {
+        const customBackoff = (retryCount) => {
             // Keep retrying with a random delay, long enough to overcome throttling from CW
             const delay = 300 + Math.floor(Math.random() * 500);
             console.log(`retry number ${retryCount} with a delay of ${delay} ms`);

--- a/assets/SecretsManagerMetricsPublisher/index.js
+++ b/assets/SecretsManagerMetricsPublisher/index.js
@@ -1,4 +1,4 @@
-import aws = require("aws-sdk");
+const aws = require("aws-sdk");
 
 const region = process.env.AWS_REGION;
 const millisPerDay = 1000 * 60 * 60 * 24;
@@ -15,13 +15,13 @@ const clientOptions = {
 const cloudwatch = new aws.CloudWatch(clientOptions);
 const sm = new aws.SecretsManager(clientOptions);
 
-function daysSince(date: any, now = Date.now()) {
+function daysSince(date, now = Date.now()) {
     const millis = now - date.getTime();
     const days = millis / millisPerDay;
     return Math.floor(days);
 }
 
-exports.handler = async (event: any, context: any) => {
+exports.handler = async (event, context) => {
     console.debug("event:", JSON.stringify(event));
     console.debug("context:", JSON.stringify(context));
 

--- a/test/dashboard/widget/__snapshots__/BitmapWidget.test.ts.snap
+++ b/test/dashboard/widget/__snapshots__/BitmapWidget.test.ts.snap
@@ -3,16 +3,16 @@
 exports[`support 1`] = `
 Object {
   "Parameters": Object {
-    "AssetParameterseac9f1a2a6a50edc9ebbcc076b53208f9c8301fea048f567a92a325a120cf8f9ArtifactHash317DF0EE": Object {
-      "Description": "Artifact hash for asset \\"eac9f1a2a6a50edc9ebbcc076b53208f9c8301fea048f567a92a325a120cf8f9\\"",
+    "AssetParametersdff0bbb363a8df5d486e7bf2ca4eecf91655adf6b3eed20d69cccd01ec347eaeArtifactHash80D4C5AC": Object {
+      "Description": "Artifact hash for asset \\"dff0bbb363a8df5d486e7bf2ca4eecf91655adf6b3eed20d69cccd01ec347eae\\"",
       "Type": "String",
     },
-    "AssetParameterseac9f1a2a6a50edc9ebbcc076b53208f9c8301fea048f567a92a325a120cf8f9S3Bucket0A478D82": Object {
-      "Description": "S3 bucket for asset \\"eac9f1a2a6a50edc9ebbcc076b53208f9c8301fea048f567a92a325a120cf8f9\\"",
+    "AssetParametersdff0bbb363a8df5d486e7bf2ca4eecf91655adf6b3eed20d69cccd01ec347eaeS3Bucket3E21D84F": Object {
+      "Description": "S3 bucket for asset \\"dff0bbb363a8df5d486e7bf2ca4eecf91655adf6b3eed20d69cccd01ec347eae\\"",
       "Type": "String",
     },
-    "AssetParameterseac9f1a2a6a50edc9ebbcc076b53208f9c8301fea048f567a92a325a120cf8f9S3VersionKeyC983BD9E": Object {
-      "Description": "S3 key for asset version \\"eac9f1a2a6a50edc9ebbcc076b53208f9c8301fea048f567a92a325a120cf8f9\\"",
+    "AssetParametersdff0bbb363a8df5d486e7bf2ca4eecf91655adf6b3eed20d69cccd01ec347eaeS3VersionKey10A106DF": Object {
+      "Description": "S3 key for asset version \\"dff0bbb363a8df5d486e7bf2ca4eecf91655adf6b3eed20d69cccd01ec347eae\\"",
       "Type": "String",
     },
     "AssetParametersf3b4457410e8875dce33608b6046e993c1ba6def4d00e9de1ed9681517a35e45ArtifactHash01BA9AF6": Object {
@@ -147,7 +147,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameterseac9f1a2a6a50edc9ebbcc076b53208f9c8301fea048f567a92a325a120cf8f9S3Bucket0A478D82",
+            "Ref": "AssetParametersdff0bbb363a8df5d486e7bf2ca4eecf91655adf6b3eed20d69cccd01ec347eaeS3Bucket3E21D84F",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -160,7 +160,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameterseac9f1a2a6a50edc9ebbcc076b53208f9c8301fea048f567a92a325a120cf8f9S3VersionKeyC983BD9E",
+                          "Ref": "AssetParametersdff0bbb363a8df5d486e7bf2ca4eecf91655adf6b3eed20d69cccd01ec347eaeS3VersionKey10A106DF",
                         },
                       ],
                     },
@@ -173,7 +173,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameterseac9f1a2a6a50edc9ebbcc076b53208f9c8301fea048f567a92a325a120cf8f9S3VersionKeyC983BD9E",
+                          "Ref": "AssetParametersdff0bbb363a8df5d486e7bf2ca4eecf91655adf6b3eed20d69cccd01ec347eaeS3VersionKey10A106DF",
                         },
                       ],
                     },

--- a/test/monitoring/aws-secretsmanager/__snapshots__/SecretsManagerSecretMonitoring.test.ts.snap
+++ b/test/monitoring/aws-secretsmanager/__snapshots__/SecretsManagerSecretMonitoring.test.ts.snap
@@ -3,16 +3,16 @@
 exports[`each stack in an app gets its own publisher instance 1`] = `
 Object {
   "Parameters": Object {
-    "AssetParameters8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477eArtifactHashF641EA97": Object {
-      "Description": "Artifact hash for asset \\"8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477e\\"",
+    "AssetParameters370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3ArtifactHashE2981140": Object {
+      "Description": "Artifact hash for asset \\"370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3\\"",
       "Type": "String",
     },
-    "AssetParameters8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477eS3Bucket0F09F618": Object {
-      "Description": "S3 bucket for asset \\"8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477e\\"",
+    "AssetParameters370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3S3Bucket3FC70718": Object {
+      "Description": "S3 bucket for asset \\"370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3\\"",
       "Type": "String",
     },
-    "AssetParameters8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477eS3VersionKey3B955119": Object {
-      "Description": "S3 key for asset version \\"8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477e\\"",
+    "AssetParameters370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3S3VersionKey3E9D4188": Object {
+      "Description": "S3 key for asset version \\"370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3\\"",
       "Type": "String",
     },
     "AssetParametersf3b4457410e8875dce33608b6046e993c1ba6def4d00e9de1ed9681517a35e45ArtifactHash01BA9AF6": Object {
@@ -147,7 +147,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477eS3Bucket0F09F618",
+            "Ref": "AssetParameters370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3S3Bucket3FC70718",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -160,7 +160,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477eS3VersionKey3B955119",
+                          "Ref": "AssetParameters370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3S3VersionKey3E9D4188",
                         },
                       ],
                     },
@@ -173,7 +173,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477eS3VersionKey3B955119",
+                          "Ref": "AssetParameters370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3S3VersionKey3E9D4188",
                         },
                       ],
                     },
@@ -344,16 +344,16 @@ Object {
 exports[`each stack in an app gets its own publisher instance 2`] = `
 Object {
   "Parameters": Object {
-    "AssetParameters8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477eArtifactHashF641EA97": Object {
-      "Description": "Artifact hash for asset \\"8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477e\\"",
+    "AssetParameters370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3ArtifactHashE2981140": Object {
+      "Description": "Artifact hash for asset \\"370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3\\"",
       "Type": "String",
     },
-    "AssetParameters8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477eS3Bucket0F09F618": Object {
-      "Description": "S3 bucket for asset \\"8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477e\\"",
+    "AssetParameters370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3S3Bucket3FC70718": Object {
+      "Description": "S3 bucket for asset \\"370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3\\"",
       "Type": "String",
     },
-    "AssetParameters8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477eS3VersionKey3B955119": Object {
-      "Description": "S3 key for asset version \\"8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477e\\"",
+    "AssetParameters370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3S3VersionKey3E9D4188": Object {
+      "Description": "S3 key for asset version \\"370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3\\"",
       "Type": "String",
     },
     "AssetParametersf3b4457410e8875dce33608b6046e993c1ba6def4d00e9de1ed9681517a35e45ArtifactHash01BA9AF6": Object {
@@ -488,7 +488,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477eS3Bucket0F09F618",
+            "Ref": "AssetParameters370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3S3Bucket3FC70718",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -501,7 +501,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477eS3VersionKey3B955119",
+                          "Ref": "AssetParameters370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3S3VersionKey3E9D4188",
                         },
                       ],
                     },
@@ -514,7 +514,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477eS3VersionKey3B955119",
+                          "Ref": "AssetParameters370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3S3VersionKey3E9D4188",
                         },
                       ],
                     },
@@ -740,16 +740,16 @@ Object {
 exports[`snapshot test 1`] = `
 Object {
   "Parameters": Object {
-    "AssetParameters8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477eArtifactHashF641EA97": Object {
-      "Description": "Artifact hash for asset \\"8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477e\\"",
+    "AssetParameters370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3ArtifactHashE2981140": Object {
+      "Description": "Artifact hash for asset \\"370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3\\"",
       "Type": "String",
     },
-    "AssetParameters8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477eS3Bucket0F09F618": Object {
-      "Description": "S3 bucket for asset \\"8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477e\\"",
+    "AssetParameters370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3S3Bucket3FC70718": Object {
+      "Description": "S3 bucket for asset \\"370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3\\"",
       "Type": "String",
     },
-    "AssetParameters8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477eS3VersionKey3B955119": Object {
-      "Description": "S3 key for asset version \\"8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477e\\"",
+    "AssetParameters370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3S3VersionKey3E9D4188": Object {
+      "Description": "S3 key for asset version \\"370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3\\"",
       "Type": "String",
     },
     "AssetParametersf3b4457410e8875dce33608b6046e993c1ba6def4d00e9de1ed9681517a35e45ArtifactHash01BA9AF6": Object {
@@ -884,7 +884,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477eS3Bucket0F09F618",
+            "Ref": "AssetParameters370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3S3Bucket3FC70718",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -897,7 +897,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477eS3VersionKey3B955119",
+                          "Ref": "AssetParameters370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3S3VersionKey3E9D4188",
                         },
                       ],
                     },
@@ -910,7 +910,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters8ec3a679d4292e38eee6ef6dd152fb3de8b8f180096ef7e9e9eebae1db02477eS3VersionKey3B955119",
+                          "Ref": "AssetParameters370b9814d54928ec69d6005dd678b0f594a594948aa3322141bf10679ac71ee3S3VersionKey3E9D4188",
                         },
                       ],
                     },


### PR DESCRIPTION
Partially addresses #18

We don't necessarily need JSII (and therefore TS) to process these.