### PR TITLE
feat(actions): add feature to add multiple actions to an alarm

### DIFF
--- a/API.md
+++ b/API.md
@@ -35506,6 +35506,55 @@ MonitoringNamingStrategy.isAlarmFriendly(str: string)
 
 
 
+### MultipleAlarmActionStrategy <a name="MultipleAlarmActionStrategy" id="cdk-monitoring-constructs.MultipleAlarmActionStrategy"></a>
+
+- *Implements:* <a href="#cdk-monitoring-constructs.IAlarmActionStrategy">IAlarmActionStrategy</a>
+
+Alarm action strategy that combines multiple actions in the same order as they were given.
+
+#### Initializers <a name="Initializers" id="cdk-monitoring-constructs.MultipleAlarmActionStrategy.Initializer"></a>
+
+```typescript
+import { MultipleAlarmActionStrategy } from 'cdk-monitoring-constructs'
+
+new MultipleAlarmActionStrategy(actions: IAlarmActionStrategy[])
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#cdk-monitoring-constructs.MultipleAlarmActionStrategy.Initializer.parameter.actions">actions</a></code> | <code><a href="#cdk-monitoring-constructs.IAlarmActionStrategy">IAlarmActionStrategy</a>[]</code> | *No description.* |
+
+---
+
+##### `actions`<sup>Required</sup> <a name="actions" id="cdk-monitoring-constructs.MultipleAlarmActionStrategy.Initializer.parameter.actions"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.IAlarmActionStrategy">IAlarmActionStrategy</a>[]
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#cdk-monitoring-constructs.MultipleAlarmActionStrategy.addAlarmActions">addAlarmActions</a></code> | *No description.* |
+
+---
+
+##### `addAlarmActions` <a name="addAlarmActions" id="cdk-monitoring-constructs.MultipleAlarmActionStrategy.addAlarmActions"></a>
+
+```typescript
+public addAlarmActions(props: AlarmActionStrategyProps): void
+```
+
+###### `props`<sup>Required</sup> <a name="props" id="cdk-monitoring-constructs.MultipleAlarmActionStrategy.addAlarmActions.parameter.props"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.AlarmActionStrategyProps">AlarmActionStrategyProps</a>
+
+---
+
+
+
+
 ### NetworkLoadBalancerMetricFactory <a name="NetworkLoadBalancerMetricFactory" id="cdk-monitoring-constructs.NetworkLoadBalancerMetricFactory"></a>
 
 - *Implements:* <a href="#cdk-monitoring-constructs.ILoadBalancerMetricFactory">ILoadBalancerMetricFactory</a>
@@ -40155,7 +40204,7 @@ public with(options: MathExpressionOptions): IMetric
 
 ### IAlarmActionStrategy <a name="IAlarmActionStrategy" id="cdk-monitoring-constructs.IAlarmActionStrategy"></a>
 
-- *Implemented By:* <a href="#cdk-monitoring-constructs.NoopAlarmActionStrategy">NoopAlarmActionStrategy</a>, <a href="#cdk-monitoring-constructs.SnsAlarmActionStrategy">SnsAlarmActionStrategy</a>, <a href="#cdk-monitoring-constructs.IAlarmActionStrategy">IAlarmActionStrategy</a>
+- *Implemented By:* <a href="#cdk-monitoring-constructs.MultipleAlarmActionStrategy">MultipleAlarmActionStrategy</a>, <a href="#cdk-monitoring-constructs.NoopAlarmActionStrategy">NoopAlarmActionStrategy</a>, <a href="#cdk-monitoring-constructs.SnsAlarmActionStrategy">SnsAlarmActionStrategy</a>, <a href="#cdk-monitoring-constructs.IAlarmActionStrategy">IAlarmActionStrategy</a>
 
 An object that appends actions to alarms.
 

--- a/lib/common/alarm/MultipleAlarmActionStrategy.ts
+++ b/lib/common/alarm/MultipleAlarmActionStrategy.ts
@@ -1,0 +1,23 @@
+import {
+  AlarmActionStrategyProps,
+  IAlarmActionStrategy,
+} from "./IAlarmActionStrategy";
+
+export function multipleActions(...actions: IAlarmActionStrategy[]) {
+  return new MultipleAlarmActionStrategy(actions);
+}
+
+/**
+ * Alarm action strategy that combines multiple actions in the same order as they were given.
+ */
+export class MultipleAlarmActionStrategy implements IAlarmActionStrategy {
+  protected readonly actions: IAlarmActionStrategy[];
+
+  constructor(actions: IAlarmActionStrategy[]) {
+    this.actions = actions;
+  }
+
+  addAlarmActions(props: AlarmActionStrategyProps): void {
+    this.actions.forEach((action) => action.addAlarmActions(props));
+  }
+}

--- a/lib/common/alarm/index.ts
+++ b/lib/common/alarm/index.ts
@@ -4,5 +4,6 @@ export * from "./CustomAlarmThreshold";
 export * from "./IAlarmActionStrategy";
 export * from "./IAlarmAnnotationStrategy";
 export * from "./IAlarmDedupeStringProcessor";
+export * from "./MultipleAlarmActionStrategy";
 export * from "./NoopAlarmActionStrategy";
 export * from "./SnsAlarmActionStrategy";

--- a/test/common/alarm/MultipleAlarmActionStrategy.test.ts
+++ b/test/common/alarm/MultipleAlarmActionStrategy.test.ts
@@ -1,0 +1,26 @@
+import { SynthUtils } from "@monocdk-experiment/assert";
+import { Stack } from "monocdk";
+import { Alarm, Metric } from "monocdk/aws-cloudwatch";
+import { Topic } from "monocdk/aws-sns";
+
+import { multipleActions, SnsAlarmActionStrategy } from "../../../lib";
+
+test("snapshot test: multiple actions", () => {
+  const stack = new Stack();
+  const topic1 = new Topic(stack, "DummyTopic1");
+  const topic2 = new Topic(stack, "DummyTopic2");
+  const topic3 = new Topic(stack, "DummyTopic3");
+  const alarm = new Alarm(stack, "DummyAlarm", {
+    evaluationPeriods: 1,
+    threshold: 0,
+    metric: new Metric({ namespace: "Dummy", metricName: "Dummy" }),
+  });
+  const action = multipleActions(
+    new SnsAlarmActionStrategy({ onAlarmTopic: topic1 }),
+    new SnsAlarmActionStrategy({ onAlarmTopic: topic2 }),
+    new SnsAlarmActionStrategy({ onAlarmTopic: topic3 })
+  );
+  action.addAlarmActions({ alarm, action });
+
+  expect(SynthUtils.toCloudFormation(stack)).toMatchSnapshot();
+});

--- a/test/common/alarm/__snapshots__/MultipleAlarmActionStrategy.test.ts.snap
+++ b/test/common/alarm/__snapshots__/MultipleAlarmActionStrategy.test.ts.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshot test: multiple actions 1`] = `
+Object {
+  "Resources": Object {
+    "DummyAlarm234203A9": Object {
+      "Properties": Object {
+        "AlarmActions": Array [
+          Object {
+            "Ref": "DummyTopic18541D2D0",
+          },
+          Object {
+            "Ref": "DummyTopic2F00C887A",
+          },
+          Object {
+            "Ref": "DummyTopic389AA825B",
+          },
+        ],
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "EvaluationPeriods": 1,
+        "MetricName": "Dummy",
+        "Namespace": "Dummy",
+        "Period": 300,
+        "Statistic": "Average",
+        "Threshold": 0,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "DummyTopic18541D2D0": Object {
+      "Type": "AWS::SNS::Topic",
+    },
+    "DummyTopic2F00C887A": Object {
+      "Type": "AWS::SNS::Topic",
+    },
+    "DummyTopic389AA825B": Object {
+      "Type": "AWS::SNS::Topic",
+    },
+  },
+}
+`;


### PR DESCRIPTION
Users will be able to use `multipleActions(action1, action2, etc)` to add multiple actions to a single alarm.