### PR TITLE
chore: Update reamdme with scope monitoring

### DIFF
--- a/API.md
+++ b/API.md
@@ -22558,7 +22558,7 @@ const monitoringAspectType: MonitoringAspectType = { ... }
 
 ---
 
-##### `enabled`<sup>Required</sup> <a name="enabled" id="cdk-monitoring-constructs.MonitoringAspectType.property.enabled"></a>
+##### `enabled`<sup>Optional</sup> <a name="enabled" id="cdk-monitoring-constructs.MonitoringAspectType.property.enabled"></a>
 
 ```typescript
 public readonly enabled: boolean;

--- a/README.md
+++ b/README.md
@@ -209,6 +209,28 @@ This is a general procedure on how to do it:
 
 Both of these monitoring base classes are dashboard segments, so you can add them to your monitoring by calling `.addSegment()`.
 
+### Monitoring Scopes
+
+With CDK Monitoring Constructs, you can monitor complete CDK construct scopes. It will automatically discover all monitorable resources within the scope (recursively)) and add them to your dashboard.
+
+```ts
+monitoring.monitorScope(stack);
+```
+
+You can also specify default alarms for any specific resource and disable automatic monitoring for it as well.
+
+```ts
+monitoring.monitorScope(stack, {
+  lambda: {
+    props: {
+      addLatencyP50Alarm: {
+        Critical: { maxLatency: Duration.seconds(10) },
+      },
+    },
+  },
+  billing: { enabled: false },
+});
+```
 
 ## Contributing/Security
 

--- a/lib/facade/aspect-types.ts
+++ b/lib/facade/aspect-types.ts
@@ -30,7 +30,7 @@ export interface MonitoringAspectType<T> {
    * If the monitoring aspect is enabled for this resource.
    * @default true
    */
-  readonly enabled: boolean;
+  readonly enabled?: boolean;
 
   /**
    * The monitoring props for this resource.


### PR DESCRIPTION
chore: Update readme with scope monitoring

Also making the `enabled` prop optional.

follow up to #34 