### PR TITLE
chore: only run upgrade deps workflow once weekly [skip ci]

### DIFF
--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -4,7 +4,7 @@ name: upgrade-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 0 * * 1
 jobs:
   upgrade:
     name: Upgrade

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -1,4 +1,4 @@
-const { awscdk, DependencyType } = require("projen");
+const { awscdk, DependencyType, javascript } = require("projen");
 
 const CDK_VERSION = "1.123.0";
 const CONSTRUCTS_VERSION = "3.3.69";
@@ -43,6 +43,13 @@ const project = new awscdk.AwsCdkConstructLibrary({
     secret: "GITHUB_TOKEN",
   },
   autoApproveUpgrades: true,
+  depsUpgradeOptions: {
+    workflowOptions: {
+      schedule: javascript.UpgradeDependenciesSchedule.expressions([
+        "0 0 * * 1",
+      ]),
+    },
+  },
 
   // Code linting config
   prettier: true,


### PR DESCRIPTION
This is up for debate, but daily dependency updates (and therefore new releases) seem like overkill. 

This also increases the risk/likelihood of bringing in new malicious dependency versions (e.g., what happened with `colors`).