### PR TITLE
fix: avoid noisy dashboard diffs with custom monitoring

### DIFF
--- a/lib/monitoring/custom/CustomMonitoring.ts
+++ b/lib/monitoring/custom/CustomMonitoring.ts
@@ -290,7 +290,7 @@ export class CustomMonitoring extends Monitoring {
       rows.push(
         new Row(
           this.createDescriptionWidget(
-            `▼ ${this.description}`,
+            this.description,
             this.descriptionWidgetHeight
           )
         )


### PR DESCRIPTION
Avoids noisy diffs when doing `cdk diff`, e.g.:

```
Resources
[~] AWS::CloudWatch::Dashboard Monitoring/Dashboards/Dashboard MonitoringDashboardsDashboard7D19B914
 └─ [~] DashboardBody
     └─ [~] .Fn::Join:
         └─ @@ -1,7 +1,7 @@
            [ ] [
            [ ]  "",
            [ ]  [
            [-]    "{\"start\":\"-P7D\",\"periodOverride\":\"inherit\",\"widgets\":[{\"type\":\"text\",\"width\":24,\"height\":2,\"x\":0,\"y\":0,\"properties\":{\"markdown\":\"| Info\\n|---\\n| AWS / Lambda / Test\"}},{\"type\":\"text\",\"width\":24,\"height\":1,\"x\":0,\"y\":2,\"properties\":{\"markdown\":\"# Custom metrics\"}},{\"type\":\"text\",\"width\":24,\"height\":1,\"x\":0,\"y\":3,\"properties\":{\"markdown\":\"### Test-CDK\"}},{\"type\":\"text\",\"width\":24,\"height\":1,\"x\":0,\"y\":4,\"properties\":{\"markdown\":\"? My custom monitor on some metrics\"}},{\"type\":\"metric\",\"width\":24,\"height\":5,\"x\":0,\"y\":5,\"properties\":{\"view\":\"timeSeries\",\"title\":\"My metric\",\"region\":\"",
            [+]    "{\"start\":\"-P7D\",\"periodOverride\":\"inherit\",\"widgets\":[{\"type\":\"text\",\"width\":24,\"height\":2,\"x\":0,\"y\":0,\"properties\":{\"markdown\":\"| Info\\n|---\\n| AWS / Lambda / Test\"}},{\"type\":\"text\",\"width\":24,\"height\":1,\"x\":0,\"y\":2,\"properties\":{\"markdown\":\"# Custom metrics\"}},{\"type\":\"text\",\"width\":24,\"height\":1,\"x\":0,\"y\":3,\"properties\":{\"markdown\":\"### Test-CDK\"}},{\"type\":\"text\",\"width\":24,\"height\":1,\"x\":0,\"y\":4,\"properties\":{\"markdown\":\"▼ My custom monitor on some metrics\"}},{\"type\":\"metric\",\"width\":24,\"height\":5,\"x\":0,\"y\":5,\"properties\":{\"view\":\"timeSeries\",\"title\":\"My metric\",\"region\":\"",
            [ ]    {
            [ ]      "Ref": "AWS::Region"
            [ ]    },
```