### PR TITLE
Adding Alarms support for CloudFrontDistribution

### DIFF
--- a/API.md
+++ b/API.md
@@ -7126,6 +7126,10 @@ const cloudFrontDistributionMonitoringOptions: CloudFrontDistributionMonitoringO
 | <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMonitoringOptions.property.addToDetailDashboard">addToDetailDashboard</a></code> | <code>boolean</code> | Flag indicating if the widgets should be added to detailed dashboard. |
 | <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMonitoringOptions.property.addToSummaryDashboard">addToSummaryDashboard</a></code> | <code>boolean</code> | Flag indicating if the widgets should be added to summary dashboard. |
 | <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMonitoringOptions.property.useCreatedAlarms">useCreatedAlarms</a></code> | <code><a href="#cdk-monitoring-constructs.IAlarmConsumer">IAlarmConsumer</a></code> | Calls provided function to process all alarms created. |
+| <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMonitoringOptions.property.addError4xxRate">addError4xxRate</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorRateThreshold">ErrorRateThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMonitoringOptions.property.addError5xxRate">addError5xxRate</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorRateThreshold">ErrorRateThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMonitoringOptions.property.addHighTpsAlarm">addHighTpsAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.HighTpsThreshold">HighTpsThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMonitoringOptions.property.addLowTpsAlarm">addLowTpsAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LowTpsThreshold">LowTpsThreshold</a>}</code> | *No description.* |
 
 ---
 
@@ -7226,6 +7230,46 @@ Calls provided function to process all alarms created.
 
 ---
 
+##### `addError4xxRate`<sup>Optional</sup> <a name="addError4xxRate" id="cdk-monitoring-constructs.CloudFrontDistributionMonitoringOptions.property.addError4xxRate"></a>
+
+```typescript
+public readonly addError4xxRate: {[ key: string ]: ErrorRateThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorRateThreshold">ErrorRateThreshold</a>}
+
+---
+
+##### `addError5xxRate`<sup>Optional</sup> <a name="addError5xxRate" id="cdk-monitoring-constructs.CloudFrontDistributionMonitoringOptions.property.addError5xxRate"></a>
+
+```typescript
+public readonly addError5xxRate: {[ key: string ]: ErrorRateThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorRateThreshold">ErrorRateThreshold</a>}
+
+---
+
+##### `addHighTpsAlarm`<sup>Optional</sup> <a name="addHighTpsAlarm" id="cdk-monitoring-constructs.CloudFrontDistributionMonitoringOptions.property.addHighTpsAlarm"></a>
+
+```typescript
+public readonly addHighTpsAlarm: {[ key: string ]: HighTpsThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.HighTpsThreshold">HighTpsThreshold</a>}
+
+---
+
+##### `addLowTpsAlarm`<sup>Optional</sup> <a name="addLowTpsAlarm" id="cdk-monitoring-constructs.CloudFrontDistributionMonitoringOptions.property.addLowTpsAlarm"></a>
+
+```typescript
+public readonly addLowTpsAlarm: {[ key: string ]: LowTpsThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LowTpsThreshold">LowTpsThreshold</a>}
+
+---
+
 ### CloudFrontDistributionMonitoringProps <a name="CloudFrontDistributionMonitoringProps" id="cdk-monitoring-constructs.CloudFrontDistributionMonitoringProps"></a>
 
 #### Initializer <a name="Initializer" id="cdk-monitoring-constructs.CloudFrontDistributionMonitoringProps.Initializer"></a>
@@ -7249,6 +7293,10 @@ const cloudFrontDistributionMonitoringProps: CloudFrontDistributionMonitoringPro
 | <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMonitoringProps.property.addToDetailDashboard">addToDetailDashboard</a></code> | <code>boolean</code> | Flag indicating if the widgets should be added to detailed dashboard. |
 | <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMonitoringProps.property.addToSummaryDashboard">addToSummaryDashboard</a></code> | <code>boolean</code> | Flag indicating if the widgets should be added to summary dashboard. |
 | <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMonitoringProps.property.useCreatedAlarms">useCreatedAlarms</a></code> | <code><a href="#cdk-monitoring-constructs.IAlarmConsumer">IAlarmConsumer</a></code> | Calls provided function to process all alarms created. |
+| <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMonitoringProps.property.addError4xxRate">addError4xxRate</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorRateThreshold">ErrorRateThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMonitoringProps.property.addError5xxRate">addError5xxRate</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorRateThreshold">ErrorRateThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMonitoringProps.property.addHighTpsAlarm">addHighTpsAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.HighTpsThreshold">HighTpsThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMonitoringProps.property.addLowTpsAlarm">addLowTpsAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LowTpsThreshold">LowTpsThreshold</a>}</code> | *No description.* |
 
 ---
 
@@ -7367,6 +7415,46 @@ public readonly useCreatedAlarms: IAlarmConsumer;
 - *Type:* <a href="#cdk-monitoring-constructs.IAlarmConsumer">IAlarmConsumer</a>
 
 Calls provided function to process all alarms created.
+
+---
+
+##### `addError4xxRate`<sup>Optional</sup> <a name="addError4xxRate" id="cdk-monitoring-constructs.CloudFrontDistributionMonitoringProps.property.addError4xxRate"></a>
+
+```typescript
+public readonly addError4xxRate: {[ key: string ]: ErrorRateThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorRateThreshold">ErrorRateThreshold</a>}
+
+---
+
+##### `addError5xxRate`<sup>Optional</sup> <a name="addError5xxRate" id="cdk-monitoring-constructs.CloudFrontDistributionMonitoringProps.property.addError5xxRate"></a>
+
+```typescript
+public readonly addError5xxRate: {[ key: string ]: ErrorRateThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorRateThreshold">ErrorRateThreshold</a>}
+
+---
+
+##### `addHighTpsAlarm`<sup>Optional</sup> <a name="addHighTpsAlarm" id="cdk-monitoring-constructs.CloudFrontDistributionMonitoringProps.property.addHighTpsAlarm"></a>
+
+```typescript
+public readonly addHighTpsAlarm: {[ key: string ]: HighTpsThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.HighTpsThreshold">HighTpsThreshold</a>}
+
+---
+
+##### `addLowTpsAlarm`<sup>Optional</sup> <a name="addLowTpsAlarm" id="cdk-monitoring-constructs.CloudFrontDistributionMonitoringProps.property.addLowTpsAlarm"></a>
+
+```typescript
+public readonly addLowTpsAlarm: {[ key: string ]: LowTpsThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LowTpsThreshold">LowTpsThreshold</a>}
 
 ---
 

--- a/test/monitoring/aws-cloudfront/CloudFrontDistribution.test.ts
+++ b/test/monitoring/aws-cloudfront/CloudFrontDistribution.test.ts
@@ -2,9 +2,13 @@ import { Stack } from "monocdk";
 import { Template } from "monocdk/assertions";
 import { Distribution } from "monocdk/aws-cloudfront";
 import { S3Origin } from "monocdk/aws-cloudfront-origins";
+import { ComparisonOperator } from "monocdk/aws-cloudwatch";
 import { Bucket } from "monocdk/aws-s3";
 
-import { CloudFrontDistributionMonitoring } from "../../../lib";
+import {
+  AlarmWithAnnotation,
+  CloudFrontDistributionMonitoring,
+} from "../../../lib";
 import { TestMonitoringScope } from "../TestMonitoringScope";
 
 test("snapshot test", () => {
@@ -20,5 +24,57 @@ test("snapshot test", () => {
 
   new CloudFrontDistributionMonitoring(scope, { distribution });
 
+  expect(Template.fromStack(stack)).toMatchSnapshot();
+});
+
+test("snapshot test: all alarms", () => {
+  const stack = new Stack();
+  const bucket = new Bucket(stack, "Bucket");
+  const distribution = new Distribution(stack, "Distribution", {
+    defaultBehavior: {
+      origin: new S3Origin(bucket),
+    },
+  });
+
+  const scope = new TestMonitoringScope(stack, "Scope");
+
+  let numAlarmsCreated = 0;
+
+  new CloudFrontDistributionMonitoring(scope, {
+    distribution,
+    addError4xxRate: {
+      Warning: {
+        maxErrorRate: 1,
+        datapointsToAlarm: 10,
+      },
+    },
+    addError5xxRate: {
+      Warning: {
+        maxErrorRate: 1,
+        datapointsToAlarm: 10,
+      },
+    },
+    addLowTpsAlarm: {
+      Warning: {
+        minTps: 0,
+        datapointsToAlarm: 1,
+        comparisonOperatorOverride:
+          ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
+      },
+    },
+    addHighTpsAlarm: {
+      Warning: {
+        maxTps: 20,
+        datapointsToAlarm: 1,
+      },
+    },
+    useCreatedAlarms: {
+      consume(alarms: AlarmWithAnnotation[]) {
+        numAlarmsCreated = alarms.length;
+      },
+    },
+  });
+
+  expect(numAlarmsCreated).toStrictEqual(4);
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });

--- a/test/monitoring/aws-cloudfront/__snapshots__/CloudFrontDistribution.test.ts.snap
+++ b/test/monitoring/aws-cloudfront/__snapshots__/CloudFrontDistribution.test.ts.snap
@@ -98,3 +98,272 @@ Object {
   },
 }
 `;
+
+exports[`snapshot test: all alarms 1`] = `
+Object {
+  "Resources": Object {
+    "Bucket83908E77": Object {
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "BucketPolicyE9A3008A": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "Bucket83908E77",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Principal": Object {
+                "CanonicalUser": Object {
+                  "Fn::GetAtt": Array [
+                    "DistributionOrigin1S3Origin5F5C0696",
+                    "S3CanonicalUserId",
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "Distribution830FAC52": Object {
+      "Properties": Object {
+        "DistributionConfig": Object {
+          "DefaultCacheBehavior": Object {
+            "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+            "Compress": true,
+            "TargetOriginId": "DistributionOrigin13547B94F",
+            "ViewerProtocolPolicy": "allow-all",
+          },
+          "Enabled": true,
+          "HttpVersion": "http2",
+          "IPV6Enabled": true,
+          "Origins": Array [
+            Object {
+              "DomainName": Object {
+                "Fn::GetAtt": Array [
+                  "Bucket83908E77",
+                  "RegionalDomainName",
+                ],
+              },
+              "Id": "DistributionOrigin13547B94F",
+              "S3OriginConfig": Object {
+                "OriginAccessIdentity": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "origin-access-identity/cloudfront/",
+                      Object {
+                        "Ref": "DistributionOrigin1S3Origin5F5C0696",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      },
+      "Type": "AWS::CloudFront::Distribution",
+    },
+    "DistributionOrigin1S3Origin5F5C0696": Object {
+      "Properties": Object {
+        "CloudFrontOriginAccessIdentityConfig": Object {
+          "Comment": "Identity for DistributionOrigin13547B94F",
+        },
+      },
+      "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
+    },
+    "ScopeTestDistributionErrorRateWarning079D566A": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Error rate is too high.",
+        "AlarmName": "Test-Distribution-Error-Rate-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 10,
+        "EvaluationPeriods": 10,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "4XX",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "DistributionId",
+                    "Value": Object {
+                      "Ref": "Distribution830FAC52",
+                    },
+                  },
+                  Object {
+                    "Name": "Region",
+                    "Value": "Global",
+                  },
+                ],
+                "MetricName": "4xxErrorRate",
+                "Namespace": "AWS/CloudFront",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDistributionFaultRateWarning02013C05": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Fault rate is too high.",
+        "AlarmName": "Test-Distribution-Fault-Rate-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 10,
+        "EvaluationPeriods": 10,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "5XX",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "DistributionId",
+                    "Value": Object {
+                      "Ref": "Distribution830FAC52",
+                    },
+                  },
+                  Object {
+                    "Name": "Region",
+                    "Value": "Global",
+                  },
+                ],
+                "MetricName": "5xxErrorRate",
+                "Namespace": "AWS/CloudFront",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDistributionMaxTPSWarningAC289EB2": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TPS is too high.",
+        "AlarmName": "Test-Distribution-MaxTPS-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1,
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Uploaded/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Uploaded",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "DistributionId",
+                    "Value": Object {
+                      "Ref": "Distribution830FAC52",
+                    },
+                  },
+                  Object {
+                    "Name": "Region",
+                    "Value": "Global",
+                  },
+                ],
+                "MetricName": "Requests",
+                "Namespace": "AWS/CloudFront",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 20,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDistributionMinTPSWarning6CB7ACEE": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TPS is too low.",
+        "AlarmName": "Test-Distribution-MinTPS-Warning",
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "DatapointsToAlarm": 1,
+        "EvaluationPeriods": 1,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Uploaded/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Uploaded",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "DistributionId",
+                    "Value": Object {
+                      "Ref": "Distribution830FAC52",
+                    },
+                  },
+                  Object {
+                    "Name": "Region",
+                    "Value": "Global",
+                  },
+                ],
+                "MetricName": "Requests",
+                "Namespace": "AWS/CloudFront",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+  },
+}
+`;


### PR DESCRIPTION
### Notes
Adding Alarms support for CloudFrontDistribution. Enabled alarms:
- addLowTpsAlarm
- addHighTpsAlarm
- addError4xxRate
- addError5xxRate

All the logic has been extracted from the Lambda monitoring constructs

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_