### PR TITLE
fix(custom): explicitly throw error when trying to add both a regular and anomaly detection alarm

### DIFF
--- a/lib/monitoring/custom/CustomMonitoring.ts
+++ b/lib/monitoring/custom/CustomMonitoring.ts
@@ -249,6 +249,12 @@ export class CustomMonitoring extends Monitoring {
       }
 
       metricGroup.metrics.forEach((metric) => {
+        if (this.hasAlarm(metric) && this.hasAnomalyDetection(metric)) {
+          throw new Error(
+            "Adding both a regular alarm and an anomoly detection alarm at the same time is not supported"
+          );
+        }
+
         if (this.hasAlarm(metric)) {
           this.setupAlarm(metricGroupWithAnnotation, metric);
         } else if (this.hasAnomalyDetection(metric)) {

--- a/test/monitoring/custom/CustomMonitoring.test.ts
+++ b/test/monitoring/custom/CustomMonitoring.test.ts
@@ -368,5 +368,53 @@ test("throws error if attempting to add alarm on a search query", () => {
           },
         ],
       })
-  ).toThrow();
+  ).toThrow("Alarming on search queries is not supported by CloudWatch");
+});
+
+test("throws error if attempting to add both a regular alarm and an anomoly detection alarm", () => {
+  const stack = new Stack();
+  const scope = new TestMonitoringScope(stack, "Scope");
+
+  expect(
+    () =>
+      new CustomMonitoring(scope, {
+        alarmFriendlyName: "DummyAlarmName",
+        humanReadableName: "DummyName",
+        description: "This is a very long description.",
+        metricGroups: [
+          {
+            title: "DummyGroup1",
+            important: true,
+            metrics: [
+              {
+                metric: new Metric({
+                  metricName: "DNSQueries",
+                  namespace: "AWS/Route53",
+                  dimensions: {
+                    HostedZoneId: "ID",
+                  },
+                }),
+                alarmFriendlyName: "DNSQueries anomaly",
+                addAlarm: {
+                  Warning: {
+                    threshold: 90,
+                    comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,
+                  },
+                },
+                anomalyDetectionStandardDeviationToRender: 1,
+                addAlarmOnAnomaly: {
+                  CriticalAnomaly: {
+                    standardDeviationForAlarm: 1,
+                    alarmWhenBelowTheBand: true,
+                    alarmWhenAboveTheBand: true,
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      })
+  ).toThrow(
+    "Adding both a regular alarm and an anomoly detection alarm at the same time is not supported"
+  );
 });


### PR DESCRIPTION
Instead of silently dropping the anomaly detection alarm config.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_