### PR TITLE
chore: send notification to Slack on release [skip ci]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,3 +195,27 @@ jobs:
         run: npx -p publib@latest publib-nuget
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+  notify_slack:
+    name: Send Slack notification
+    needs:
+      - release
+      - release_github
+      - release_maven
+      - release_npm
+      - release_nuget
+      - release_pypi
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    steps:
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@v1.2.3
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Send notification
+        uses: slackapi/slack-github-action@v1.18.0
+        with:
+          payload: '{"html_url": "${{ steps.get_release.outputs.html_url }}", "tag_name": "${{ steps.get_release.outputs.tag_name }}"}'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
I don't have a particularly good way of testing this.

Based on:
- https://github.com/cdklabs/construct-hub-webapp/pull/501/files

Using:
- https://github.com/bruceadams/get-release
- https://github.com/slackapi/slack-github-action

The webhook secret has already been added to the repo.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_