### PR TITLE
chore: use action to get release by current SHA for Slack notification [skip ci]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,7 +210,9 @@ jobs:
     steps:
       - name: Get release
         id: get_release
-        uses: bruceadams/get-release@v1.2.3
+        uses: cardinalby/git-get-release-action@v1
+        with:
+          searchLimit: 1
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Send notification

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -131,7 +131,10 @@ project.release.addJobs({
       {
         name: "Get release",
         id: "get_release",
-        uses: "bruceadams/get-release@v1.2.3",
+        uses: "cardinalby/git-get-release-action@v1",
+        with: {
+          searchLimit: 1,
+        },
         env: {
           GITHUB_TOKEN: "${{ github.token }}",
         },


### PR DESCRIPTION
The previous attempted [failed](https://github.com/cdklabs/cdk-monitoring-constructs/runs/5530778333?check_suite_focus=true) since the action tries to get a release for a given tag, except the workflow is actually triggered on push, not by a tag.

This switches to [cardinalby/git-get-release-action](https://github.com/cardinalby/git-get-release-action), which defaults to getting a release based on the current commit SHA.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_