### PR TITLE
feat(apigateway): support trimmed stats and latency graph configuration

### DIFF
--- a/API.md
+++ b/API.md
@@ -3774,10 +3774,22 @@ const apiGatewayMonitoringOptions: ApiGatewayMonitoringOptions = { ... }
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.add5XXFaultCountAlarm">add5XXFaultCountAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorCountThreshold">ErrorCountThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.add5XXFaultRateAlarm">add5XXFaultRateAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorRateThreshold">ErrorRateThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addHighTpsAlarm">addHighTpsAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.HighTpsThreshold">HighTpsThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyAverageAlarm">addLatencyAverageAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyP100Alarm">addLatencyP100Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyP50Alarm">addLatencyP50Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyP70Alarm">addLatencyP70Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyP90Alarm">addLatencyP90Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyP9999Alarm">addLatencyP9999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyP999Alarm">addLatencyP999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyP99Alarm">addLatencyP99Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyTM50Alarm">addLatencyTM50Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyTM70Alarm">addLatencyTM70Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyTM90Alarm">addLatencyTM90Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyTM9999Alarm">addLatencyTM9999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyTM999Alarm">addLatencyTM999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyTM99Alarm">addLatencyTM99Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLowTpsAlarm">addLowTpsAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LowTpsThreshold">LowTpsThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.latencyTypesToRender">latencyTypesToRender</a></code> | <code><a href="#cdk-monitoring-constructs.LatencyType">LatencyType</a>[]</code> | You can specify what latency types you want to be rendered in the dashboards. |
 
 ---
 
@@ -3928,10 +3940,40 @@ public readonly addHighTpsAlarm: {[ key: string ]: HighTpsThreshold};
 
 ---
 
+##### `addLatencyAverageAlarm`<sup>Optional</sup> <a name="addLatencyAverageAlarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyAverageAlarm"></a>
+
+```typescript
+public readonly addLatencyAverageAlarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyP100Alarm`<sup>Optional</sup> <a name="addLatencyP100Alarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyP100Alarm"></a>
+
+```typescript
+public readonly addLatencyP100Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
 ##### `addLatencyP50Alarm`<sup>Optional</sup> <a name="addLatencyP50Alarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyP50Alarm"></a>
 
 ```typescript
 public readonly addLatencyP50Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyP70Alarm`<sup>Optional</sup> <a name="addLatencyP70Alarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyP70Alarm"></a>
+
+```typescript
+public readonly addLatencyP70Alarm: {[ key: string ]: LatencyThreshold};
 ```
 
 - *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
@@ -3948,10 +3990,90 @@ public readonly addLatencyP90Alarm: {[ key: string ]: LatencyThreshold};
 
 ---
 
+##### `addLatencyP9999Alarm`<sup>Optional</sup> <a name="addLatencyP9999Alarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyP9999Alarm"></a>
+
+```typescript
+public readonly addLatencyP9999Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyP999Alarm`<sup>Optional</sup> <a name="addLatencyP999Alarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyP999Alarm"></a>
+
+```typescript
+public readonly addLatencyP999Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
 ##### `addLatencyP99Alarm`<sup>Optional</sup> <a name="addLatencyP99Alarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyP99Alarm"></a>
 
 ```typescript
 public readonly addLatencyP99Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyTM50Alarm`<sup>Optional</sup> <a name="addLatencyTM50Alarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyTM50Alarm"></a>
+
+```typescript
+public readonly addLatencyTM50Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyTM70Alarm`<sup>Optional</sup> <a name="addLatencyTM70Alarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyTM70Alarm"></a>
+
+```typescript
+public readonly addLatencyTM70Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyTM90Alarm`<sup>Optional</sup> <a name="addLatencyTM90Alarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyTM90Alarm"></a>
+
+```typescript
+public readonly addLatencyTM90Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyTM9999Alarm`<sup>Optional</sup> <a name="addLatencyTM9999Alarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyTM9999Alarm"></a>
+
+```typescript
+public readonly addLatencyTM9999Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyTM999Alarm`<sup>Optional</sup> <a name="addLatencyTM999Alarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyTM999Alarm"></a>
+
+```typescript
+public readonly addLatencyTM999Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyTM99Alarm`<sup>Optional</sup> <a name="addLatencyTM99Alarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.addLatencyTM99Alarm"></a>
+
+```typescript
+public readonly addLatencyTM99Alarm: {[ key: string ]: LatencyThreshold};
 ```
 
 - *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
@@ -3965,6 +4087,23 @@ public readonly addLowTpsAlarm: {[ key: string ]: LowTpsThreshold};
 ```
 
 - *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LowTpsThreshold">LowTpsThreshold</a>}
+
+---
+
+##### `latencyTypesToRender`<sup>Optional</sup> <a name="latencyTypesToRender" id="cdk-monitoring-constructs.ApiGatewayMonitoringOptions.property.latencyTypesToRender"></a>
+
+```typescript
+public readonly latencyTypesToRender: LatencyType[];
+```
+
+- *Type:* <a href="#cdk-monitoring-constructs.LatencyType">LatencyType</a>[]
+- *Default:* p50, p90, p99 (
+
+You can specify what latency types you want to be rendered in the dashboards.
+
+Note: any latency type with an alarm will be also added automatically. If the list is undefined, default values will be shown. If the list is empty, only the latency types with an alarm will be shown (if any).
+
+> [DefaultLatencyTypesShown)](DefaultLatencyTypesShown))
 
 ---
 
@@ -4000,10 +4139,22 @@ const apiGatewayMonitoringProps: ApiGatewayMonitoringProps = { ... }
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.add5XXFaultCountAlarm">add5XXFaultCountAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorCountThreshold">ErrorCountThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.add5XXFaultRateAlarm">add5XXFaultRateAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorRateThreshold">ErrorRateThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addHighTpsAlarm">addHighTpsAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.HighTpsThreshold">HighTpsThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyAverageAlarm">addLatencyAverageAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyP100Alarm">addLatencyP100Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyP50Alarm">addLatencyP50Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyP70Alarm">addLatencyP70Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyP90Alarm">addLatencyP90Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyP9999Alarm">addLatencyP9999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyP999Alarm">addLatencyP999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyP99Alarm">addLatencyP99Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyTM50Alarm">addLatencyTM50Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyTM70Alarm">addLatencyTM70Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyTM90Alarm">addLatencyTM90Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyTM9999Alarm">addLatencyTM9999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyTM999Alarm">addLatencyTM999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyTM99Alarm">addLatencyTM99Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLowTpsAlarm">addLowTpsAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LowTpsThreshold">LowTpsThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.latencyTypesToRender">latencyTypesToRender</a></code> | <code><a href="#cdk-monitoring-constructs.LatencyType">LatencyType</a>[]</code> | You can specify what latency types you want to be rendered in the dashboards. |
 
 ---
 
@@ -4223,10 +4374,40 @@ public readonly addHighTpsAlarm: {[ key: string ]: HighTpsThreshold};
 
 ---
 
+##### `addLatencyAverageAlarm`<sup>Optional</sup> <a name="addLatencyAverageAlarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyAverageAlarm"></a>
+
+```typescript
+public readonly addLatencyAverageAlarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyP100Alarm`<sup>Optional</sup> <a name="addLatencyP100Alarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyP100Alarm"></a>
+
+```typescript
+public readonly addLatencyP100Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
 ##### `addLatencyP50Alarm`<sup>Optional</sup> <a name="addLatencyP50Alarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyP50Alarm"></a>
 
 ```typescript
 public readonly addLatencyP50Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyP70Alarm`<sup>Optional</sup> <a name="addLatencyP70Alarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyP70Alarm"></a>
+
+```typescript
+public readonly addLatencyP70Alarm: {[ key: string ]: LatencyThreshold};
 ```
 
 - *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
@@ -4243,10 +4424,90 @@ public readonly addLatencyP90Alarm: {[ key: string ]: LatencyThreshold};
 
 ---
 
+##### `addLatencyP9999Alarm`<sup>Optional</sup> <a name="addLatencyP9999Alarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyP9999Alarm"></a>
+
+```typescript
+public readonly addLatencyP9999Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyP999Alarm`<sup>Optional</sup> <a name="addLatencyP999Alarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyP999Alarm"></a>
+
+```typescript
+public readonly addLatencyP999Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
 ##### `addLatencyP99Alarm`<sup>Optional</sup> <a name="addLatencyP99Alarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyP99Alarm"></a>
 
 ```typescript
 public readonly addLatencyP99Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyTM50Alarm`<sup>Optional</sup> <a name="addLatencyTM50Alarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyTM50Alarm"></a>
+
+```typescript
+public readonly addLatencyTM50Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyTM70Alarm`<sup>Optional</sup> <a name="addLatencyTM70Alarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyTM70Alarm"></a>
+
+```typescript
+public readonly addLatencyTM70Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyTM90Alarm`<sup>Optional</sup> <a name="addLatencyTM90Alarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyTM90Alarm"></a>
+
+```typescript
+public readonly addLatencyTM90Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyTM9999Alarm`<sup>Optional</sup> <a name="addLatencyTM9999Alarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyTM9999Alarm"></a>
+
+```typescript
+public readonly addLatencyTM9999Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyTM999Alarm`<sup>Optional</sup> <a name="addLatencyTM999Alarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyTM999Alarm"></a>
+
+```typescript
+public readonly addLatencyTM999Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyTM99Alarm`<sup>Optional</sup> <a name="addLatencyTM99Alarm" id="cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.addLatencyTM99Alarm"></a>
+
+```typescript
+public readonly addLatencyTM99Alarm: {[ key: string ]: LatencyThreshold};
 ```
 
 - *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
@@ -4260,6 +4521,23 @@ public readonly addLowTpsAlarm: {[ key: string ]: LowTpsThreshold};
 ```
 
 - *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LowTpsThreshold">LowTpsThreshold</a>}
+
+---
+
+##### `latencyTypesToRender`<sup>Optional</sup> <a name="latencyTypesToRender" id="cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.latencyTypesToRender"></a>
+
+```typescript
+public readonly latencyTypesToRender: LatencyType[];
+```
+
+- *Type:* <a href="#cdk-monitoring-constructs.LatencyType">LatencyType</a>[]
+- *Default:* p50, p90, p99 (
+
+You can specify what latency types you want to be rendered in the dashboards.
+
+Note: any latency type with an alarm will be also added automatically. If the list is undefined, default values will be shown. If the list is empty, only the latency types with an alarm will be shown (if any).
+
+> [DefaultLatencyTypesShown)](DefaultLatencyTypesShown))
 
 ---
 
@@ -4385,13 +4663,36 @@ const apiGatewayV2HttpApiMonitoringProps: ApiGatewayV2HttpApiMonitoringProps = {
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.add5xxCountAlarm">add5xxCountAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorCountThreshold">ErrorCountThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.add5xxRateAlarm">add5xxRateAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorRateThreshold">ErrorRateThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addHighTpsAlarm">addHighTpsAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.HighTpsThreshold">HighTpsThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyAverageAlarm">addIntegrationLatencyAverageAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyP100Alarm">addIntegrationLatencyP100Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyP50Alarm">addIntegrationLatencyP50Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyP70Alarm">addIntegrationLatencyP70Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyP90Alarm">addIntegrationLatencyP90Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyP9999Alarm">addIntegrationLatencyP9999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyP999Alarm">addIntegrationLatencyP999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyP99Alarm">addIntegrationLatencyP99Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyTM50Alarm">addIntegrationLatencyTM50Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyTM70Alarm">addIntegrationLatencyTM70Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyTM90Alarm">addIntegrationLatencyTM90Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyTM9999Alarm">addIntegrationLatencyTM9999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyTM999Alarm">addIntegrationLatencyTM999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyTM99Alarm">addIntegrationLatencyTM99Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyAverageAlarm">addLatencyAverageAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyP100Alarm">addLatencyP100Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyP50Alarm">addLatencyP50Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyP70Alarm">addLatencyP70Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyP90Alarm">addLatencyP90Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyP9999Alarm">addLatencyP9999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyP999Alarm">addLatencyP999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyP99Alarm">addLatencyP99Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyTM50Alarm">addLatencyTM50Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyTM70Alarm">addLatencyTM70Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyTM90Alarm">addLatencyTM90Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyTM9999Alarm">addLatencyTM9999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyTM999Alarm">addLatencyTM999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyTM99Alarm">addLatencyTM99Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLowTpsAlarm">addLowTpsAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LowTpsThreshold">LowTpsThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.latencyTypesToRender">latencyTypesToRender</a></code> | <code><a href="#cdk-monitoring-constructs.LatencyType">LatencyType</a>[]</code> | You can specify what latency types you want to be rendered in the dashboards. |
 
 ---
 
@@ -4609,10 +4910,40 @@ public readonly addHighTpsAlarm: {[ key: string ]: HighTpsThreshold};
 
 ---
 
+##### `addIntegrationLatencyAverageAlarm`<sup>Optional</sup> <a name="addIntegrationLatencyAverageAlarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyAverageAlarm"></a>
+
+```typescript
+public readonly addIntegrationLatencyAverageAlarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addIntegrationLatencyP100Alarm`<sup>Optional</sup> <a name="addIntegrationLatencyP100Alarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyP100Alarm"></a>
+
+```typescript
+public readonly addIntegrationLatencyP100Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
 ##### `addIntegrationLatencyP50Alarm`<sup>Optional</sup> <a name="addIntegrationLatencyP50Alarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyP50Alarm"></a>
 
 ```typescript
 public readonly addIntegrationLatencyP50Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addIntegrationLatencyP70Alarm`<sup>Optional</sup> <a name="addIntegrationLatencyP70Alarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyP70Alarm"></a>
+
+```typescript
+public readonly addIntegrationLatencyP70Alarm: {[ key: string ]: LatencyThreshold};
 ```
 
 - *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
@@ -4629,10 +4960,110 @@ public readonly addIntegrationLatencyP90Alarm: {[ key: string ]: LatencyThreshol
 
 ---
 
+##### `addIntegrationLatencyP9999Alarm`<sup>Optional</sup> <a name="addIntegrationLatencyP9999Alarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyP9999Alarm"></a>
+
+```typescript
+public readonly addIntegrationLatencyP9999Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addIntegrationLatencyP999Alarm`<sup>Optional</sup> <a name="addIntegrationLatencyP999Alarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyP999Alarm"></a>
+
+```typescript
+public readonly addIntegrationLatencyP999Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
 ##### `addIntegrationLatencyP99Alarm`<sup>Optional</sup> <a name="addIntegrationLatencyP99Alarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyP99Alarm"></a>
 
 ```typescript
 public readonly addIntegrationLatencyP99Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addIntegrationLatencyTM50Alarm`<sup>Optional</sup> <a name="addIntegrationLatencyTM50Alarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyTM50Alarm"></a>
+
+```typescript
+public readonly addIntegrationLatencyTM50Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addIntegrationLatencyTM70Alarm`<sup>Optional</sup> <a name="addIntegrationLatencyTM70Alarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyTM70Alarm"></a>
+
+```typescript
+public readonly addIntegrationLatencyTM70Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addIntegrationLatencyTM90Alarm`<sup>Optional</sup> <a name="addIntegrationLatencyTM90Alarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyTM90Alarm"></a>
+
+```typescript
+public readonly addIntegrationLatencyTM90Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addIntegrationLatencyTM9999Alarm`<sup>Optional</sup> <a name="addIntegrationLatencyTM9999Alarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyTM9999Alarm"></a>
+
+```typescript
+public readonly addIntegrationLatencyTM9999Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addIntegrationLatencyTM999Alarm`<sup>Optional</sup> <a name="addIntegrationLatencyTM999Alarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyTM999Alarm"></a>
+
+```typescript
+public readonly addIntegrationLatencyTM999Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addIntegrationLatencyTM99Alarm`<sup>Optional</sup> <a name="addIntegrationLatencyTM99Alarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addIntegrationLatencyTM99Alarm"></a>
+
+```typescript
+public readonly addIntegrationLatencyTM99Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyAverageAlarm`<sup>Optional</sup> <a name="addLatencyAverageAlarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyAverageAlarm"></a>
+
+```typescript
+public readonly addLatencyAverageAlarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyP100Alarm`<sup>Optional</sup> <a name="addLatencyP100Alarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyP100Alarm"></a>
+
+```typescript
+public readonly addLatencyP100Alarm: {[ key: string ]: LatencyThreshold};
 ```
 
 - *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
@@ -4649,10 +5080,40 @@ public readonly addLatencyP50Alarm: {[ key: string ]: LatencyThreshold};
 
 ---
 
+##### `addLatencyP70Alarm`<sup>Optional</sup> <a name="addLatencyP70Alarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyP70Alarm"></a>
+
+```typescript
+public readonly addLatencyP70Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
 ##### `addLatencyP90Alarm`<sup>Optional</sup> <a name="addLatencyP90Alarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyP90Alarm"></a>
 
 ```typescript
 public readonly addLatencyP90Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyP9999Alarm`<sup>Optional</sup> <a name="addLatencyP9999Alarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyP9999Alarm"></a>
+
+```typescript
+public readonly addLatencyP9999Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyP999Alarm`<sup>Optional</sup> <a name="addLatencyP999Alarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyP999Alarm"></a>
+
+```typescript
+public readonly addLatencyP999Alarm: {[ key: string ]: LatencyThreshold};
 ```
 
 - *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
@@ -4669,6 +5130,66 @@ public readonly addLatencyP99Alarm: {[ key: string ]: LatencyThreshold};
 
 ---
 
+##### `addLatencyTM50Alarm`<sup>Optional</sup> <a name="addLatencyTM50Alarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyTM50Alarm"></a>
+
+```typescript
+public readonly addLatencyTM50Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyTM70Alarm`<sup>Optional</sup> <a name="addLatencyTM70Alarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyTM70Alarm"></a>
+
+```typescript
+public readonly addLatencyTM70Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyTM90Alarm`<sup>Optional</sup> <a name="addLatencyTM90Alarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyTM90Alarm"></a>
+
+```typescript
+public readonly addLatencyTM90Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyTM9999Alarm`<sup>Optional</sup> <a name="addLatencyTM9999Alarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyTM9999Alarm"></a>
+
+```typescript
+public readonly addLatencyTM9999Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyTM999Alarm`<sup>Optional</sup> <a name="addLatencyTM999Alarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyTM999Alarm"></a>
+
+```typescript
+public readonly addLatencyTM999Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyTM99Alarm`<sup>Optional</sup> <a name="addLatencyTM99Alarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLatencyTM99Alarm"></a>
+
+```typescript
+public readonly addLatencyTM99Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
 ##### `addLowTpsAlarm`<sup>Optional</sup> <a name="addLowTpsAlarm" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.addLowTpsAlarm"></a>
 
 ```typescript
@@ -4676,6 +5197,23 @@ public readonly addLowTpsAlarm: {[ key: string ]: LowTpsThreshold};
 ```
 
 - *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LowTpsThreshold">LowTpsThreshold</a>}
+
+---
+
+##### `latencyTypesToRender`<sup>Optional</sup> <a name="latencyTypesToRender" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.latencyTypesToRender"></a>
+
+```typescript
+public readonly latencyTypesToRender: LatencyType[];
+```
+
+- *Type:* <a href="#cdk-monitoring-constructs.LatencyType">LatencyType</a>[]
+- *Default:* p50, p90, p99 (
+
+You can specify what latency types you want to be rendered in the dashboards.
+
+Note: any latency type with an alarm will be also added automatically. If the list is undefined, default values will be shown. If the list is empty, only the latency types with an alarm will be shown (if any).
+
+> [DefaultLatencyTypesShown)](DefaultLatencyTypesShown))
 
 ---
 
@@ -4705,13 +5243,36 @@ const apiGatewayV2MonitoringOptions: ApiGatewayV2MonitoringOptions = { ... }
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.add5xxCountAlarm">add5xxCountAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorCountThreshold">ErrorCountThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.add5xxRateAlarm">add5xxRateAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorRateThreshold">ErrorRateThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addHighTpsAlarm">addHighTpsAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.HighTpsThreshold">HighTpsThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyAverageAlarm">addIntegrationLatencyAverageAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyP100Alarm">addIntegrationLatencyP100Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyP50Alarm">addIntegrationLatencyP50Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyP70Alarm">addIntegrationLatencyP70Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyP90Alarm">addIntegrationLatencyP90Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyP9999Alarm">addIntegrationLatencyP9999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyP999Alarm">addIntegrationLatencyP999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyP99Alarm">addIntegrationLatencyP99Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyTM50Alarm">addIntegrationLatencyTM50Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyTM70Alarm">addIntegrationLatencyTM70Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyTM90Alarm">addIntegrationLatencyTM90Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyTM9999Alarm">addIntegrationLatencyTM9999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyTM999Alarm">addIntegrationLatencyTM999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyTM99Alarm">addIntegrationLatencyTM99Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyAverageAlarm">addLatencyAverageAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyP100Alarm">addLatencyP100Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyP50Alarm">addLatencyP50Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyP70Alarm">addLatencyP70Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyP90Alarm">addLatencyP90Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyP9999Alarm">addLatencyP9999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyP999Alarm">addLatencyP999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyP99Alarm">addLatencyP99Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyTM50Alarm">addLatencyTM50Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyTM70Alarm">addLatencyTM70Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyTM90Alarm">addLatencyTM90Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyTM9999Alarm">addLatencyTM9999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyTM999Alarm">addLatencyTM999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyTM99Alarm">addLatencyTM99Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLowTpsAlarm">addLowTpsAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LowTpsThreshold">LowTpsThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.latencyTypesToRender">latencyTypesToRender</a></code> | <code><a href="#cdk-monitoring-constructs.LatencyType">LatencyType</a>[]</code> | You can specify what latency types you want to be rendered in the dashboards. |
 
 ---
 
@@ -4862,10 +5423,40 @@ public readonly addHighTpsAlarm: {[ key: string ]: HighTpsThreshold};
 
 ---
 
+##### `addIntegrationLatencyAverageAlarm`<sup>Optional</sup> <a name="addIntegrationLatencyAverageAlarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyAverageAlarm"></a>
+
+```typescript
+public readonly addIntegrationLatencyAverageAlarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addIntegrationLatencyP100Alarm`<sup>Optional</sup> <a name="addIntegrationLatencyP100Alarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyP100Alarm"></a>
+
+```typescript
+public readonly addIntegrationLatencyP100Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
 ##### `addIntegrationLatencyP50Alarm`<sup>Optional</sup> <a name="addIntegrationLatencyP50Alarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyP50Alarm"></a>
 
 ```typescript
 public readonly addIntegrationLatencyP50Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addIntegrationLatencyP70Alarm`<sup>Optional</sup> <a name="addIntegrationLatencyP70Alarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyP70Alarm"></a>
+
+```typescript
+public readonly addIntegrationLatencyP70Alarm: {[ key: string ]: LatencyThreshold};
 ```
 
 - *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
@@ -4882,10 +5473,110 @@ public readonly addIntegrationLatencyP90Alarm: {[ key: string ]: LatencyThreshol
 
 ---
 
+##### `addIntegrationLatencyP9999Alarm`<sup>Optional</sup> <a name="addIntegrationLatencyP9999Alarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyP9999Alarm"></a>
+
+```typescript
+public readonly addIntegrationLatencyP9999Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addIntegrationLatencyP999Alarm`<sup>Optional</sup> <a name="addIntegrationLatencyP999Alarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyP999Alarm"></a>
+
+```typescript
+public readonly addIntegrationLatencyP999Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
 ##### `addIntegrationLatencyP99Alarm`<sup>Optional</sup> <a name="addIntegrationLatencyP99Alarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyP99Alarm"></a>
 
 ```typescript
 public readonly addIntegrationLatencyP99Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addIntegrationLatencyTM50Alarm`<sup>Optional</sup> <a name="addIntegrationLatencyTM50Alarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyTM50Alarm"></a>
+
+```typescript
+public readonly addIntegrationLatencyTM50Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addIntegrationLatencyTM70Alarm`<sup>Optional</sup> <a name="addIntegrationLatencyTM70Alarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyTM70Alarm"></a>
+
+```typescript
+public readonly addIntegrationLatencyTM70Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addIntegrationLatencyTM90Alarm`<sup>Optional</sup> <a name="addIntegrationLatencyTM90Alarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyTM90Alarm"></a>
+
+```typescript
+public readonly addIntegrationLatencyTM90Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addIntegrationLatencyTM9999Alarm`<sup>Optional</sup> <a name="addIntegrationLatencyTM9999Alarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyTM9999Alarm"></a>
+
+```typescript
+public readonly addIntegrationLatencyTM9999Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addIntegrationLatencyTM999Alarm`<sup>Optional</sup> <a name="addIntegrationLatencyTM999Alarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyTM999Alarm"></a>
+
+```typescript
+public readonly addIntegrationLatencyTM999Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addIntegrationLatencyTM99Alarm`<sup>Optional</sup> <a name="addIntegrationLatencyTM99Alarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addIntegrationLatencyTM99Alarm"></a>
+
+```typescript
+public readonly addIntegrationLatencyTM99Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyAverageAlarm`<sup>Optional</sup> <a name="addLatencyAverageAlarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyAverageAlarm"></a>
+
+```typescript
+public readonly addLatencyAverageAlarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyP100Alarm`<sup>Optional</sup> <a name="addLatencyP100Alarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyP100Alarm"></a>
+
+```typescript
+public readonly addLatencyP100Alarm: {[ key: string ]: LatencyThreshold};
 ```
 
 - *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
@@ -4902,10 +5593,40 @@ public readonly addLatencyP50Alarm: {[ key: string ]: LatencyThreshold};
 
 ---
 
+##### `addLatencyP70Alarm`<sup>Optional</sup> <a name="addLatencyP70Alarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyP70Alarm"></a>
+
+```typescript
+public readonly addLatencyP70Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
 ##### `addLatencyP90Alarm`<sup>Optional</sup> <a name="addLatencyP90Alarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyP90Alarm"></a>
 
 ```typescript
 public readonly addLatencyP90Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyP9999Alarm`<sup>Optional</sup> <a name="addLatencyP9999Alarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyP9999Alarm"></a>
+
+```typescript
+public readonly addLatencyP9999Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyP999Alarm`<sup>Optional</sup> <a name="addLatencyP999Alarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyP999Alarm"></a>
+
+```typescript
+public readonly addLatencyP999Alarm: {[ key: string ]: LatencyThreshold};
 ```
 
 - *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
@@ -4922,6 +5643,66 @@ public readonly addLatencyP99Alarm: {[ key: string ]: LatencyThreshold};
 
 ---
 
+##### `addLatencyTM50Alarm`<sup>Optional</sup> <a name="addLatencyTM50Alarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyTM50Alarm"></a>
+
+```typescript
+public readonly addLatencyTM50Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyTM70Alarm`<sup>Optional</sup> <a name="addLatencyTM70Alarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyTM70Alarm"></a>
+
+```typescript
+public readonly addLatencyTM70Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyTM90Alarm`<sup>Optional</sup> <a name="addLatencyTM90Alarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyTM90Alarm"></a>
+
+```typescript
+public readonly addLatencyTM90Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyTM9999Alarm`<sup>Optional</sup> <a name="addLatencyTM9999Alarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyTM9999Alarm"></a>
+
+```typescript
+public readonly addLatencyTM9999Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyTM999Alarm`<sup>Optional</sup> <a name="addLatencyTM999Alarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyTM999Alarm"></a>
+
+```typescript
+public readonly addLatencyTM999Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
+##### `addLatencyTM99Alarm`<sup>Optional</sup> <a name="addLatencyTM99Alarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLatencyTM99Alarm"></a>
+
+```typescript
+public readonly addLatencyTM99Alarm: {[ key: string ]: LatencyThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}
+
+---
+
 ##### `addLowTpsAlarm`<sup>Optional</sup> <a name="addLowTpsAlarm" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.addLowTpsAlarm"></a>
 
 ```typescript
@@ -4929,6 +5710,23 @@ public readonly addLowTpsAlarm: {[ key: string ]: LowTpsThreshold};
 ```
 
 - *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LowTpsThreshold">LowTpsThreshold</a>}
+
+---
+
+##### `latencyTypesToRender`<sup>Optional</sup> <a name="latencyTypesToRender" id="cdk-monitoring-constructs.ApiGatewayV2MonitoringOptions.property.latencyTypesToRender"></a>
+
+```typescript
+public readonly latencyTypesToRender: LatencyType[];
+```
+
+- *Type:* <a href="#cdk-monitoring-constructs.LatencyType">LatencyType</a>[]
+- *Default:* p50, p90, p99 (
+
+You can specify what latency types you want to be rendered in the dashboards.
+
+Note: any latency type with an alarm will be also added automatically. If the list is undefined, default values will be shown. If the list is empty, only the latency types with an alarm will be shown (if any).
+
+> [DefaultLatencyTypesShown)](DefaultLatencyTypesShown))
 
 ---
 
@@ -33578,6 +34376,7 @@ new ApiGatewayMetricFactory(metricFactory: MetricFactory, props: ApiGatewayMetri
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMetricFactory.metric5XXFaultCount">metric5XXFaultCount</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMetricFactory.metric5XXFaultRate">metric5XXFaultRate</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMetricFactory.metricInvocationCount">metricInvocationCount</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMetricFactory.metricLatencyInMillis">metricLatencyInMillis</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMetricFactory.metricLatencyP50InMillis">metricLatencyP50InMillis</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMetricFactory.metricLatencyP90InMillis">metricLatencyP90InMillis</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMetricFactory.metricLatencyP99InMillis">metricLatencyP99InMillis</a></code> | *No description.* |
@@ -33615,19 +34414,31 @@ public metric5XXFaultRate(): Metric | MathExpression
 public metricInvocationCount(): Metric | MathExpression
 ```
 
-##### `metricLatencyP50InMillis` <a name="metricLatencyP50InMillis" id="cdk-monitoring-constructs.ApiGatewayMetricFactory.metricLatencyP50InMillis"></a>
+##### `metricLatencyInMillis` <a name="metricLatencyInMillis" id="cdk-monitoring-constructs.ApiGatewayMetricFactory.metricLatencyInMillis"></a>
+
+```typescript
+public metricLatencyInMillis(latencyType: LatencyType): Metric | MathExpression
+```
+
+###### `latencyType`<sup>Required</sup> <a name="latencyType" id="cdk-monitoring-constructs.ApiGatewayMetricFactory.metricLatencyInMillis.parameter.latencyType"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.LatencyType">LatencyType</a>
+
+---
+
+##### ~~`metricLatencyP50InMillis`~~ <a name="metricLatencyP50InMillis" id="cdk-monitoring-constructs.ApiGatewayMetricFactory.metricLatencyP50InMillis"></a>
 
 ```typescript
 public metricLatencyP50InMillis(): Metric | MathExpression
 ```
 
-##### `metricLatencyP90InMillis` <a name="metricLatencyP90InMillis" id="cdk-monitoring-constructs.ApiGatewayMetricFactory.metricLatencyP90InMillis"></a>
+##### ~~`metricLatencyP90InMillis`~~ <a name="metricLatencyP90InMillis" id="cdk-monitoring-constructs.ApiGatewayMetricFactory.metricLatencyP90InMillis"></a>
 
 ```typescript
 public metricLatencyP90InMillis(): Metric | MathExpression
 ```
 
-##### `metricLatencyP99InMillis` <a name="metricLatencyP99InMillis" id="cdk-monitoring-constructs.ApiGatewayMetricFactory.metricLatencyP99InMillis"></a>
+##### ~~`metricLatencyP99InMillis`~~ <a name="metricLatencyP99InMillis" id="cdk-monitoring-constructs.ApiGatewayMetricFactory.metricLatencyP99InMillis"></a>
 
 ```typescript
 public metricLatencyP99InMillis(): Metric | MathExpression
@@ -33810,10 +34621,12 @@ new ApiGatewayV2HttpApiMetricFactory(metricFactory: MetricFactory, props: ApiGat
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metric4xxRate">metric4xxRate</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metric5xxCount">metric5xxCount</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metric5xxRate">metric5xxRate</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricIntegrationLatencyInMillis">metricIntegrationLatencyInMillis</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricIntegrationLatencyP50InMillis">metricIntegrationLatencyP50InMillis</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricIntegrationLatencyP90InMillis">metricIntegrationLatencyP90InMillis</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricIntegrationLatencyP99InMillis">metricIntegrationLatencyP99InMillis</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricInvocationCount">metricInvocationCount</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricLatencyInMillis">metricLatencyInMillis</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricLatencyP50InMillis">metricLatencyP50InMillis</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricLatencyP90InMillis">metricLatencyP90InMillis</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricLatencyP99InMillis">metricLatencyP99InMillis</a></code> | *No description.* |
@@ -33845,19 +34658,31 @@ public metric5xxCount(): Metric | MathExpression
 public metric5xxRate(): Metric | MathExpression
 ```
 
-##### `metricIntegrationLatencyP50InMillis` <a name="metricIntegrationLatencyP50InMillis" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricIntegrationLatencyP50InMillis"></a>
+##### `metricIntegrationLatencyInMillis` <a name="metricIntegrationLatencyInMillis" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricIntegrationLatencyInMillis"></a>
+
+```typescript
+public metricIntegrationLatencyInMillis(latencyType: LatencyType): Metric | MathExpression
+```
+
+###### `latencyType`<sup>Required</sup> <a name="latencyType" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricIntegrationLatencyInMillis.parameter.latencyType"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.LatencyType">LatencyType</a>
+
+---
+
+##### ~~`metricIntegrationLatencyP50InMillis`~~ <a name="metricIntegrationLatencyP50InMillis" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricIntegrationLatencyP50InMillis"></a>
 
 ```typescript
 public metricIntegrationLatencyP50InMillis(): Metric | MathExpression
 ```
 
-##### `metricIntegrationLatencyP90InMillis` <a name="metricIntegrationLatencyP90InMillis" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricIntegrationLatencyP90InMillis"></a>
+##### ~~`metricIntegrationLatencyP90InMillis`~~ <a name="metricIntegrationLatencyP90InMillis" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricIntegrationLatencyP90InMillis"></a>
 
 ```typescript
 public metricIntegrationLatencyP90InMillis(): Metric | MathExpression
 ```
 
-##### `metricIntegrationLatencyP99InMillis` <a name="metricIntegrationLatencyP99InMillis" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricIntegrationLatencyP99InMillis"></a>
+##### ~~`metricIntegrationLatencyP99InMillis`~~ <a name="metricIntegrationLatencyP99InMillis" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricIntegrationLatencyP99InMillis"></a>
 
 ```typescript
 public metricIntegrationLatencyP99InMillis(): Metric | MathExpression
@@ -33869,19 +34694,31 @@ public metricIntegrationLatencyP99InMillis(): Metric | MathExpression
 public metricInvocationCount(): Metric | MathExpression
 ```
 
-##### `metricLatencyP50InMillis` <a name="metricLatencyP50InMillis" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricLatencyP50InMillis"></a>
+##### `metricLatencyInMillis` <a name="metricLatencyInMillis" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricLatencyInMillis"></a>
+
+```typescript
+public metricLatencyInMillis(latencyType: LatencyType): Metric | MathExpression
+```
+
+###### `latencyType`<sup>Required</sup> <a name="latencyType" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricLatencyInMillis.parameter.latencyType"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.LatencyType">LatencyType</a>
+
+---
+
+##### ~~`metricLatencyP50InMillis`~~ <a name="metricLatencyP50InMillis" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricLatencyP50InMillis"></a>
 
 ```typescript
 public metricLatencyP50InMillis(): Metric | MathExpression
 ```
 
-##### `metricLatencyP90InMillis` <a name="metricLatencyP90InMillis" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricLatencyP90InMillis"></a>
+##### ~~`metricLatencyP90InMillis`~~ <a name="metricLatencyP90InMillis" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricLatencyP90InMillis"></a>
 
 ```typescript
 public metricLatencyP90InMillis(): Metric | MathExpression
 ```
 
-##### `metricLatencyP99InMillis` <a name="metricLatencyP99InMillis" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricLatencyP99InMillis"></a>
+##### ~~`metricLatencyP99InMillis`~~ <a name="metricLatencyP99InMillis" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricLatencyP99InMillis"></a>
 
 ```typescript
 public metricLatencyP99InMillis(): Metric | MathExpression
@@ -39597,6 +40434,7 @@ new LatencyAlarmFactory(alarmFactory: AlarmFactory)
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.LatencyAlarmFactory.addDurationAlarm">addDurationAlarm</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LatencyAlarmFactory.addIntegrationLatencyAlarm">addIntegrationLatencyAlarm</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LatencyAlarmFactory.addJvmGarbageCollectionDurationAlarm">addJvmGarbageCollectionDurationAlarm</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LatencyAlarmFactory.addLatencyAlarm">addLatencyAlarm</a></code> | *No description.* |
 
@@ -39627,6 +40465,36 @@ public addDurationAlarm(metric: Metric | MathExpression, latencyType: LatencyTyp
 ---
 
 ###### `disambiguator`<sup>Optional</sup> <a name="disambiguator" id="cdk-monitoring-constructs.LatencyAlarmFactory.addDurationAlarm.parameter.disambiguator"></a>
+
+- *Type:* string
+
+---
+
+##### `addIntegrationLatencyAlarm` <a name="addIntegrationLatencyAlarm" id="cdk-monitoring-constructs.LatencyAlarmFactory.addIntegrationLatencyAlarm"></a>
+
+```typescript
+public addIntegrationLatencyAlarm(metric: Metric | MathExpression, latencyType: LatencyType, props: LatencyThreshold, disambiguator?: string): AlarmWithAnnotation
+```
+
+###### `metric`<sup>Required</sup> <a name="metric" id="cdk-monitoring-constructs.LatencyAlarmFactory.addIntegrationLatencyAlarm.parameter.metric"></a>
+
+- *Type:* monocdk.aws_cloudwatch.Metric | monocdk.aws_cloudwatch.MathExpression
+
+---
+
+###### `latencyType`<sup>Required</sup> <a name="latencyType" id="cdk-monitoring-constructs.LatencyAlarmFactory.addIntegrationLatencyAlarm.parameter.latencyType"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.LatencyType">LatencyType</a>
+
+---
+
+###### `props`<sup>Required</sup> <a name="props" id="cdk-monitoring-constructs.LatencyAlarmFactory.addIntegrationLatencyAlarm.parameter.props"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>
+
+---
+
+###### `disambiguator`<sup>Optional</sup> <a name="disambiguator" id="cdk-monitoring-constructs.LatencyAlarmFactory.addIntegrationLatencyAlarm.parameter.disambiguator"></a>
 
 - *Type:* string
 

--- a/API.md
+++ b/API.md
@@ -4103,7 +4103,7 @@ You can specify what latency types you want to be rendered in the dashboards.
 
 Note: any latency type with an alarm will be also added automatically. If the list is undefined, default values will be shown. If the list is empty, only the latency types with an alarm will be shown (if any).
 
-> [DefaultLatencyTypesShown)](DefaultLatencyTypesShown))
+> [DefaultLatencyTypesToRender)](DefaultLatencyTypesToRender))
 
 ---
 
@@ -4537,7 +4537,7 @@ You can specify what latency types you want to be rendered in the dashboards.
 
 Note: any latency type with an alarm will be also added automatically. If the list is undefined, default values will be shown. If the list is empty, only the latency types with an alarm will be shown (if any).
 
-> [DefaultLatencyTypesShown)](DefaultLatencyTypesShown))
+> [DefaultLatencyTypesToRender)](DefaultLatencyTypesToRender))
 
 ---
 

--- a/lib/common/monitoring/alarms/LatencyAlarmFactory.ts
+++ b/lib/common/monitoring/alarms/LatencyAlarmFactory.ts
@@ -148,6 +148,33 @@ export class LatencyAlarmFactory {
     });
   }
 
+  addIntegrationLatencyAlarm(
+    metric: MetricWithAlarmSupport,
+    latencyType: LatencyType,
+    props: LatencyThreshold,
+    disambiguator?: string
+  ) {
+    const alarmNameSuffix = `IntegrationLatency-${latencyType}`;
+
+    return this.alarmFactory.addAlarm(metric, {
+      treatMissingData:
+        props.treatMissingDataOverride ?? TreatMissingData.NOT_BREACHING,
+      comparisonOperator:
+        props.comparisonOperatorOverride ??
+        ComparisonOperator.GREATER_THAN_THRESHOLD,
+      ...props,
+      disambiguator,
+      threshold: props.maxLatency.toMilliseconds(),
+      alarmNameSuffix,
+      // we will dedupe any kind of latency issue to the same ticket
+      alarmDedupeStringSuffix: this.alarmFactory
+        .shouldUseDefaultDedupeForLatency
+        ? "AnyLatency"
+        : alarmNameSuffix,
+      alarmDescription: `${latencyType} integration latency is too high.`,
+    });
+  }
+
   addDurationAlarm(
     metric: MetricWithAlarmSupport,
     latencyType: LatencyType,

--- a/lib/common/monitoring/alarms/LatencyAlarmFactory.ts
+++ b/lib/common/monitoring/alarms/LatencyAlarmFactory.ts
@@ -166,7 +166,7 @@ export class LatencyAlarmFactory {
       disambiguator,
       threshold: props.maxLatency.toMilliseconds(),
       alarmNameSuffix,
-      // we will dedupe any kind of latency issue to the same ticket
+      // we will dedupe any kind of latency issue to the same alarm
       alarmDedupeStringSuffix: this.alarmFactory
         .shouldUseDefaultDedupeForLatency
         ? "AnyLatency"

--- a/lib/monitoring/aws-apigateway/ApiGatewayMetricFactory.ts
+++ b/lib/monitoring/aws-apigateway/ApiGatewayMetricFactory.ts
@@ -126,21 +126,21 @@ export class ApiGatewayMetricFactory {
   }
 
   /**
-   * @deprecated please use metricLatencyInMillis instead
+   * @deprecated use metricLatencyInMillis instead
    */
   metricLatencyP99InMillis() {
     return this.metricLatencyInMillis(LatencyType.P99);
   }
 
   /**
-   * @deprecated please use metricLatencyInMillis instead
+   * @deprecated use metricLatencyInMillis instead
    */
   metricLatencyP90InMillis() {
     return this.metricLatencyInMillis(LatencyType.P90);
   }
 
   /**
-   * @deprecated please use metricLatencyInMillis instead
+   * @deprecated use metricLatencyInMillis instead
    */
   metricLatencyP50InMillis() {
     return this.metricLatencyInMillis(LatencyType.P50);

--- a/lib/monitoring/aws-apigateway/ApiGatewayMetricFactory.ts
+++ b/lib/monitoring/aws-apigateway/ApiGatewayMetricFactory.ts
@@ -2,6 +2,9 @@ import { RestApiBase } from "monocdk/aws-apigateway";
 import { DimensionHash } from "monocdk/aws-cloudwatch";
 
 import {
+  getLatencyTypeLabel,
+  getLatencyTypeStatistic,
+  LatencyType,
   MetricFactory,
   MetricStatistic,
   RateComputationMethod,
@@ -122,33 +125,33 @@ export class ApiGatewayMetricFactory {
     );
   }
 
+  /**
+   * @deprecated please use metricLatencyInMillis instead
+   */
   metricLatencyP99InMillis() {
-    return this.metricFactory.createMetric(
-      "Latency",
-      MetricStatistic.P99,
-      "P99",
-      this.dimensions,
-      undefined,
-      ApiGatewayNamespace
-    );
+    return this.metricLatencyInMillis(LatencyType.P99);
   }
 
+  /**
+   * @deprecated please use metricLatencyInMillis instead
+   */
   metricLatencyP90InMillis() {
-    return this.metricFactory.createMetric(
-      "Latency",
-      MetricStatistic.P90,
-      "P90",
-      this.dimensions,
-      undefined,
-      ApiGatewayNamespace
-    );
+    return this.metricLatencyInMillis(LatencyType.P90);
   }
 
+  /**
+   * @deprecated please use metricLatencyInMillis instead
+   */
   metricLatencyP50InMillis() {
+    return this.metricLatencyInMillis(LatencyType.P50);
+  }
+
+  metricLatencyInMillis(latencyType: LatencyType) {
+    const label = getLatencyTypeLabel(latencyType);
     return this.metricFactory.createMetric(
       "Latency",
-      MetricStatistic.P50,
-      "P50",
+      getLatencyTypeStatistic(latencyType),
+      label,
       this.dimensions,
       undefined,
       ApiGatewayNamespace

--- a/lib/monitoring/aws-apigateway/ApiGatewayMonitoring.ts
+++ b/lib/monitoring/aws-apigateway/ApiGatewayMonitoring.ts
@@ -70,7 +70,7 @@ export interface ApiGatewayMonitoringOptions extends BaseMonitoringProps {
    * Note: any latency type with an alarm will be also added automatically.
    * If the list is undefined, default values will be shown.
    * If the list is empty, only the latency types with an alarm will be shown (if any).
-   * @default p50, p90, p99 (@see DefaultLatencyTypesShown)
+   * @default p50, p90, p99 (@see DefaultLatencyTypesToRender)
    */
   readonly latencyTypesToRender?: LatencyType[];
 }

--- a/lib/monitoring/aws-apigateway/ApiGatewayMonitoring.ts
+++ b/lib/monitoring/aws-apigateway/ApiGatewayMonitoring.ts
@@ -37,16 +37,42 @@ import {
   ApiGatewayMetricFactoryProps,
 } from "./ApiGatewayMetricFactory";
 
+const DefaultLatencyTypesToRender = [
+  LatencyType.P50,
+  LatencyType.P90,
+  LatencyType.P99,
+];
+
 export interface ApiGatewayMonitoringOptions extends BaseMonitoringProps {
   readonly addLatencyP50Alarm?: Record<string, LatencyThreshold>;
+  readonly addLatencyP70Alarm?: Record<string, LatencyThreshold>;
   readonly addLatencyP90Alarm?: Record<string, LatencyThreshold>;
   readonly addLatencyP99Alarm?: Record<string, LatencyThreshold>;
+  readonly addLatencyP999Alarm?: Record<string, LatencyThreshold>;
+  readonly addLatencyP9999Alarm?: Record<string, LatencyThreshold>;
+  readonly addLatencyP100Alarm?: Record<string, LatencyThreshold>;
+  readonly addLatencyTM50Alarm?: Record<string, LatencyThreshold>;
+  readonly addLatencyTM70Alarm?: Record<string, LatencyThreshold>;
+  readonly addLatencyTM90Alarm?: Record<string, LatencyThreshold>;
+  readonly addLatencyTM99Alarm?: Record<string, LatencyThreshold>;
+  readonly addLatencyTM999Alarm?: Record<string, LatencyThreshold>;
+  readonly addLatencyTM9999Alarm?: Record<string, LatencyThreshold>;
+  readonly addLatencyAverageAlarm?: Record<string, LatencyThreshold>;
   readonly add4XXErrorCountAlarm?: Record<string, ErrorCountThreshold>;
   readonly add4XXErrorRateAlarm?: Record<string, ErrorRateThreshold>;
   readonly add5XXFaultCountAlarm?: Record<string, ErrorCountThreshold>;
   readonly add5XXFaultRateAlarm?: Record<string, ErrorRateThreshold>;
   readonly addLowTpsAlarm?: Record<string, LowTpsThreshold>;
   readonly addHighTpsAlarm?: Record<string, HighTpsThreshold>;
+
+  /**
+   * You can specify what latency types you want to be rendered in the dashboards.
+   * Note: any latency type with an alarm will be also added automatically.
+   * If the list is undefined, default values will be shown.
+   * If the list is empty, only the latency types with an alarm will be shown (if any).
+   * @default p50, p90, p99 (@see DefaultLatencyTypesShown)
+   */
+  readonly latencyTypesToRender?: LatencyType[];
 }
 
 export interface ApiGatewayMonitoringProps
@@ -67,13 +93,14 @@ export class ApiGatewayMonitoring extends Monitoring {
   protected readonly errorRateAnnotations: HorizontalAnnotation[];
 
   protected readonly tpsMetric: MetricWithAlarmSupport;
-  protected readonly p50LatencyMetric: MetricWithAlarmSupport;
-  protected readonly p90LatencyMetric: MetricWithAlarmSupport;
-  protected readonly p99LatencyMetric: MetricWithAlarmSupport;
   protected readonly error4XXCountMetric: MetricWithAlarmSupport;
   protected readonly error4XXRateMetric: MetricWithAlarmSupport;
   protected readonly fault5XXCountMetric: MetricWithAlarmSupport;
   protected readonly fault5XXRateMetric: MetricWithAlarmSupport;
+
+  // keys are LatencyType, but JSII doesn't like non-string types
+  protected readonly latencyMetrics: Record<string, MetricWithAlarmSupport>;
+  protected readonly latencyTypesToRender: string[];
 
   constructor(scope: MonitoringScope, props: ApiGatewayMonitoringProps) {
     super(scope, props);
@@ -115,48 +142,69 @@ export class ApiGatewayMonitoring extends Monitoring {
       scope.createMetricFactory(),
       props
     );
+
     this.tpsMetric = metricFactory.metricTps();
-    this.p50LatencyMetric = metricFactory.metricLatencyP50InMillis();
-    this.p90LatencyMetric = metricFactory.metricLatencyP90InMillis();
-    this.p99LatencyMetric = metricFactory.metricLatencyP99InMillis();
+
+    this.latencyMetrics = {};
+    this.latencyTypesToRender = [];
+    if (props.latencyTypesToRender) {
+      // try adding latency types specified by user first
+      props.latencyTypesToRender.forEach((type) =>
+        this.latencyTypesToRender.push(type)
+      );
+    } else {
+      // fallback to default latency types if user does not specify any
+      DefaultLatencyTypesToRender.forEach((type) =>
+        this.latencyTypesToRender.push(type)
+      );
+    }
+
     this.error4XXCountMetric = metricFactory.metric4XXErrorCount();
     this.error4XXRateMetric = metricFactory.metric4XXErrorRate();
     this.fault5XXCountMetric = metricFactory.metric5XXFaultCount();
     this.fault5XXRateMetric = metricFactory.metric5XXFaultRate();
 
-    for (const disambiguator in props.addLatencyP50Alarm) {
-      const alarmProps = props.addLatencyP50Alarm[disambiguator];
-      const createdAlarm = this.latencyAlarmFactory.addLatencyAlarm(
-        this.p50LatencyMetric,
-        LatencyType.P50,
-        alarmProps,
-        disambiguator
-      );
-      this.latencyAnnotations.push(createdAlarm.annotation);
-      this.addAlarm(createdAlarm);
+    const latencyAlarmDefinitions = {
+      [LatencyType.P50]: props.addLatencyP50Alarm,
+      [LatencyType.P70]: props.addLatencyP70Alarm,
+      [LatencyType.P90]: props.addLatencyP90Alarm,
+      [LatencyType.P99]: props.addLatencyP99Alarm,
+      [LatencyType.P999]: props.addLatencyP999Alarm,
+      [LatencyType.P9999]: props.addLatencyP9999Alarm,
+      [LatencyType.P100]: props.addLatencyP100Alarm,
+      [LatencyType.TM50]: props.addLatencyTM50Alarm,
+      [LatencyType.TM70]: props.addLatencyTM70Alarm,
+      [LatencyType.TM90]: props.addLatencyTM90Alarm,
+      [LatencyType.TM99]: props.addLatencyTM99Alarm,
+      [LatencyType.TM999]: props.addLatencyTM999Alarm,
+      [LatencyType.TM9999]: props.addLatencyTM9999Alarm,
+      [LatencyType.AVERAGE]: props.addLatencyAverageAlarm,
+    };
+
+    Object.values(LatencyType).forEach((latencyType) => {
+      this.latencyMetrics[latencyType] =
+        metricFactory.metricLatencyInMillis(latencyType);
+    });
+
+    for (const [latencyType, alarmDefinition] of Object.entries(
+      latencyAlarmDefinitions
+    )) {
+      for (const disambiguator in alarmDefinition) {
+        const alarmProps = alarmDefinition[disambiguator];
+        const latencyTypeEnum = latencyType as LatencyType;
+        const metric = this.latencyMetrics[latencyTypeEnum];
+        const createdAlarm = this.latencyAlarmFactory.addLatencyAlarm(
+          metric,
+          latencyTypeEnum,
+          alarmProps,
+          disambiguator
+        );
+        this.latencyAnnotations.push(createdAlarm.annotation);
+        this.latencyTypesToRender.push(latencyTypeEnum);
+        this.addAlarm(createdAlarm);
+      }
     }
-    for (const disambiguator in props.addLatencyP90Alarm) {
-      const alarmProps = props.addLatencyP90Alarm[disambiguator];
-      const createdAlarm = this.latencyAlarmFactory.addLatencyAlarm(
-        this.p90LatencyMetric,
-        LatencyType.P90,
-        alarmProps,
-        disambiguator
-      );
-      this.latencyAnnotations.push(createdAlarm.annotation);
-      this.addAlarm(createdAlarm);
-    }
-    for (const disambiguator in props.addLatencyP99Alarm) {
-      const alarmProps = props.addLatencyP99Alarm[disambiguator];
-      const createdAlarm = this.latencyAlarmFactory.addLatencyAlarm(
-        this.p99LatencyMetric,
-        LatencyType.P99,
-        alarmProps,
-        disambiguator
-      );
-      this.latencyAnnotations.push(createdAlarm.annotation);
-      this.addAlarm(createdAlarm);
-    }
+
     for (const disambiguator in props.add5XXFaultCountAlarm) {
       const alarmProps = props.add5XXFaultCountAlarm[disambiguator];
       const createdAlarm = this.errorAlarmFactory.addErrorCountAlarm(
@@ -262,15 +310,15 @@ export class ApiGatewayMonitoring extends Monitoring {
   }
 
   protected createLatencyWidget(width: number, height: number) {
+    const left = Array.from(new Set(this.latencyTypesToRender))
+      .sort()
+      .map((type) => this.latencyMetrics[type]);
+
     return new GraphWidget({
       width,
       height,
       title: "Latency",
-      left: [
-        this.p50LatencyMetric,
-        this.p90LatencyMetric,
-        this.p99LatencyMetric,
-      ],
+      left,
       leftYAxis: TimeAxisMillisFromZero,
       leftAnnotations: this.latencyAnnotations,
     });

--- a/lib/monitoring/aws-apigateway/ApiGatewayMonitoring.ts
+++ b/lib/monitoring/aws-apigateway/ApiGatewayMonitoring.ts
@@ -146,18 +146,9 @@ export class ApiGatewayMonitoring extends Monitoring {
     this.tpsMetric = metricFactory.metricTps();
 
     this.latencyMetrics = {};
-    this.latencyTypesToRender = [];
-    if (props.latencyTypesToRender) {
-      // try adding latency types specified by user first
-      props.latencyTypesToRender.forEach((type) =>
-        this.latencyTypesToRender.push(type)
-      );
-    } else {
-      // fallback to default latency types if user does not specify any
-      DefaultLatencyTypesToRender.forEach((type) =>
-        this.latencyTypesToRender.push(type)
-      );
-    }
+    this.latencyTypesToRender = [
+      ...(props.latencyTypesToRender ?? DefaultLatencyTypesToRender),
+    ];
 
     this.error4XXCountMetric = metricFactory.metric4XXErrorCount();
     this.error4XXRateMetric = metricFactory.metric4XXErrorRate();

--- a/lib/monitoring/aws-apigatewayv2/ApiGatewayV2HttpApiMetricFactory.ts
+++ b/lib/monitoring/aws-apigatewayv2/ApiGatewayV2HttpApiMetricFactory.ts
@@ -2,6 +2,9 @@ import { IHttpApi } from "monocdk/aws-apigatewayv2";
 import { DimensionHash } from "monocdk/aws-cloudwatch";
 
 import {
+  getLatencyTypeLabel,
+  getLatencyTypeStatistic,
+  LatencyType,
   MetricFactory,
   MetricStatistic,
   RateComputationMethod,
@@ -118,66 +121,66 @@ export class ApiGatewayV2HttpApiMetricFactory {
     );
   }
 
+  /**
+   * @deprecated please use metricLatencyInMillis instead
+   */
   metricLatencyP50InMillis() {
-    return this.metricFactory.createMetric(
-      "Latency",
-      MetricStatistic.P50,
-      "P50 Latency",
-      this.dimensions,
-      undefined,
-      ApiGatewayNamespace
-    );
+    return this.metricLatencyInMillis(LatencyType.P50);
   }
 
+  /**
+   * @deprecated please use metricLatencyInMillis instead
+   */
   metricLatencyP90InMillis() {
-    return this.metricFactory.createMetric(
-      "Latency",
-      MetricStatistic.P90,
-      "P90 Latency",
-      this.dimensions,
-      undefined,
-      ApiGatewayNamespace
-    );
+    return this.metricLatencyInMillis(LatencyType.P90);
   }
 
+  /**
+   * @deprecated please use metricLatencyInMillis instead
+   */
   metricLatencyP99InMillis() {
+    return this.metricLatencyInMillis(LatencyType.P99);
+  }
+
+  /**
+   * @deprecated please use metricIntegrationLatencyInMillis instead
+   */
+  metricIntegrationLatencyP50InMillis() {
+    return this.metricIntegrationLatencyInMillis(LatencyType.P50);
+  }
+
+  /**
+   * @deprecated please use metricIntegrationLatencyInMillis instead
+   */
+  metricIntegrationLatencyP90InMillis() {
+    return this.metricIntegrationLatencyInMillis(LatencyType.P90);
+  }
+
+  /**
+   * @deprecated please use metricIntegrationLatencyInMillis instead
+   */
+  metricIntegrationLatencyP99InMillis() {
+    return this.metricIntegrationLatencyInMillis(LatencyType.P99);
+  }
+
+  metricIntegrationLatencyInMillis(latencyType: LatencyType) {
+    const label = getLatencyTypeLabel(latencyType);
+    return this.metricFactory.createMetric(
+      "IntegrationLatency",
+      getLatencyTypeStatistic(latencyType),
+      label,
+      this.dimensions,
+      undefined,
+      ApiGatewayNamespace
+    );
+  }
+
+  metricLatencyInMillis(latencyType: LatencyType) {
+    const label = getLatencyTypeLabel(latencyType);
     return this.metricFactory.createMetric(
       "Latency",
-      MetricStatistic.P99,
-      "P99 Latency",
-      this.dimensions,
-      undefined,
-      ApiGatewayNamespace
-    );
-  }
-
-  metricIntegrationLatencyP50InMillis() {
-    return this.metricFactory.createMetric(
-      "IntegrationLatency",
-      MetricStatistic.P50,
-      "P50 Integration Latency",
-      this.dimensions,
-      undefined,
-      ApiGatewayNamespace
-    );
-  }
-
-  metricIntegrationLatencyP90InMillis() {
-    return this.metricFactory.createMetric(
-      "IntegrationLatency",
-      MetricStatistic.P90,
-      "P90 Integration Latency",
-      this.dimensions,
-      undefined,
-      ApiGatewayNamespace
-    );
-  }
-
-  metricIntegrationLatencyP99InMillis() {
-    return this.metricFactory.createMetric(
-      "IntegrationLatency",
-      MetricStatistic.P99,
-      "P99 Integration Latency",
+      getLatencyTypeStatistic(latencyType),
+      label,
       this.dimensions,
       undefined,
       ApiGatewayNamespace

--- a/lib/monitoring/aws-apigatewayv2/ApiGatewayV2HttpApiMetricFactory.ts
+++ b/lib/monitoring/aws-apigatewayv2/ApiGatewayV2HttpApiMetricFactory.ts
@@ -122,42 +122,42 @@ export class ApiGatewayV2HttpApiMetricFactory {
   }
 
   /**
-   * @deprecated please use metricLatencyInMillis instead
+   * @deprecated use metricLatencyInMillis instead
    */
   metricLatencyP50InMillis() {
     return this.metricLatencyInMillis(LatencyType.P50);
   }
 
   /**
-   * @deprecated please use metricLatencyInMillis instead
+   * @deprecated use metricLatencyInMillis instead
    */
   metricLatencyP90InMillis() {
     return this.metricLatencyInMillis(LatencyType.P90);
   }
 
   /**
-   * @deprecated please use metricLatencyInMillis instead
+   * @deprecated use metricLatencyInMillis instead
    */
   metricLatencyP99InMillis() {
     return this.metricLatencyInMillis(LatencyType.P99);
   }
 
   /**
-   * @deprecated please use metricIntegrationLatencyInMillis instead
+   * @deprecated use metricIntegrationLatencyInMillis instead
    */
   metricIntegrationLatencyP50InMillis() {
     return this.metricIntegrationLatencyInMillis(LatencyType.P50);
   }
 
   /**
-   * @deprecated please use metricIntegrationLatencyInMillis instead
+   * @deprecated use metricIntegrationLatencyInMillis instead
    */
   metricIntegrationLatencyP90InMillis() {
     return this.metricIntegrationLatencyInMillis(LatencyType.P90);
   }
 
   /**
-   * @deprecated please use metricIntegrationLatencyInMillis instead
+   * @deprecated use metricIntegrationLatencyInMillis instead
    */
   metricIntegrationLatencyP99InMillis() {
     return this.metricIntegrationLatencyInMillis(LatencyType.P99);

--- a/lib/monitoring/aws-apigatewayv2/ApiGatewayV2HttpApiMonitoring.ts
+++ b/lib/monitoring/aws-apigatewayv2/ApiGatewayV2HttpApiMonitoring.ts
@@ -1,6 +1,7 @@
 import {
   GraphWidget,
   HorizontalAnnotation,
+  IMetric,
   IWidget,
 } from "monocdk/aws-cloudwatch";
 
@@ -37,6 +38,12 @@ import {
   ApiGatewayV2HttpApiMetricFactoryProps,
 } from "./ApiGatewayV2HttpApiMetricFactory";
 
+const DefaultLatencyTypesToRender = [
+  LatencyType.P50,
+  LatencyType.P90,
+  LatencyType.P99,
+];
+
 export interface ApiGatewayV2MonitoringOptions extends BaseMonitoringProps {
   readonly add4xxCountAlarm?: Record<string, ErrorCountThreshold>;
   readonly add4xxRateAlarm?: Record<string, ErrorRateThreshold>;
@@ -45,15 +52,46 @@ export interface ApiGatewayV2MonitoringOptions extends BaseMonitoringProps {
   readonly add5xxRateAlarm?: Record<string, ErrorRateThreshold>;
 
   readonly addLatencyP50Alarm?: Record<string, LatencyThreshold>;
+  readonly addLatencyP70Alarm?: Record<string, LatencyThreshold>;
   readonly addLatencyP90Alarm?: Record<string, LatencyThreshold>;
   readonly addLatencyP99Alarm?: Record<string, LatencyThreshold>;
+  readonly addLatencyP999Alarm?: Record<string, LatencyThreshold>;
+  readonly addLatencyP9999Alarm?: Record<string, LatencyThreshold>;
+  readonly addLatencyP100Alarm?: Record<string, LatencyThreshold>;
+  readonly addLatencyTM50Alarm?: Record<string, LatencyThreshold>;
+  readonly addLatencyTM70Alarm?: Record<string, LatencyThreshold>;
+  readonly addLatencyTM90Alarm?: Record<string, LatencyThreshold>;
+  readonly addLatencyTM99Alarm?: Record<string, LatencyThreshold>;
+  readonly addLatencyTM999Alarm?: Record<string, LatencyThreshold>;
+  readonly addLatencyTM9999Alarm?: Record<string, LatencyThreshold>;
+  readonly addLatencyAverageAlarm?: Record<string, LatencyThreshold>;
 
   readonly addIntegrationLatencyP50Alarm?: Record<string, LatencyThreshold>;
+  readonly addIntegrationLatencyP70Alarm?: Record<string, LatencyThreshold>;
   readonly addIntegrationLatencyP90Alarm?: Record<string, LatencyThreshold>;
   readonly addIntegrationLatencyP99Alarm?: Record<string, LatencyThreshold>;
+  readonly addIntegrationLatencyP999Alarm?: Record<string, LatencyThreshold>;
+  readonly addIntegrationLatencyP9999Alarm?: Record<string, LatencyThreshold>;
+  readonly addIntegrationLatencyP100Alarm?: Record<string, LatencyThreshold>;
+  readonly addIntegrationLatencyTM50Alarm?: Record<string, LatencyThreshold>;
+  readonly addIntegrationLatencyTM70Alarm?: Record<string, LatencyThreshold>;
+  readonly addIntegrationLatencyTM90Alarm?: Record<string, LatencyThreshold>;
+  readonly addIntegrationLatencyTM99Alarm?: Record<string, LatencyThreshold>;
+  readonly addIntegrationLatencyTM999Alarm?: Record<string, LatencyThreshold>;
+  readonly addIntegrationLatencyTM9999Alarm?: Record<string, LatencyThreshold>;
+  readonly addIntegrationLatencyAverageAlarm?: Record<string, LatencyThreshold>;
 
   readonly addLowTpsAlarm?: Record<string, LowTpsThreshold>;
   readonly addHighTpsAlarm?: Record<string, HighTpsThreshold>;
+
+  /**
+   * You can specify what latency types you want to be rendered in the dashboards.
+   * Note: any latency type with an alarm will be also added automatically.
+   * If the list is undefined, default values will be shown.
+   * If the list is empty, only the latency types with an alarm will be shown (if any).
+   * @default p50, p90, p99 (@see DefaultLatencyTypesShown)
+   */
+  readonly latencyTypesToRender?: LatencyType[];
 }
 
 export interface ApiGatewayV2HttpApiMonitoringProps
@@ -81,13 +119,13 @@ export class ApiGatewayV2HttpApiMonitoring extends Monitoring {
   protected readonly error5xxCountMetric: MetricWithAlarmSupport;
   protected readonly error5xxRateMetric: MetricWithAlarmSupport;
 
-  protected readonly p50LatencyMetric: MetricWithAlarmSupport;
-  protected readonly p90LatencyMetric: MetricWithAlarmSupport;
-  protected readonly p99LatencyMetric: MetricWithAlarmSupport;
-
-  protected readonly p50IntegrationLatencyMetric: MetricWithAlarmSupport;
-  protected readonly p90IntegrationLatencyMetric: MetricWithAlarmSupport;
-  protected readonly p99IntegrationLatencyMetric: MetricWithAlarmSupport;
+  // keys are LatencyType, but JSII doesn't like non-string types
+  protected readonly latencyMetrics: Record<string, MetricWithAlarmSupport>;
+  protected readonly integrationLatencyMetrics: Record<
+    string,
+    MetricWithAlarmSupport
+  >;
+  protected readonly latencyTypesToRender: string[];
 
   constructor(
     scope: MonitoringScope,
@@ -98,10 +136,10 @@ export class ApiGatewayV2HttpApiMonitoring extends Monitoring {
     const namingStrategy = new MonitoringNamingStrategy({
       ...props,
       namedConstruct: props.api,
-      fallbackConstructName: props.api.httpApiId,
-      humanReadableName: `${props.api.httpApiId} ${
-        props.apiStage ?? "$default"
-      } ${props.apiMethod ?? ""} ${props.apiResource ?? ""}`,
+      fallbackConstructName: props.api.apiId,
+      humanReadableName: `${props.api.apiId} ${props.apiStage ?? "$default"} ${
+        props.apiMethod ?? ""
+      } ${props.apiResource ?? ""}`,
     });
 
     this.title = namingStrategy.resolveHumanReadableName();
@@ -126,93 +164,105 @@ export class ApiGatewayV2HttpApiMonitoring extends Monitoring {
 
     this.tpsMetric = metricFactory.metricTps();
 
+    this.latencyMetrics = {};
+    this.integrationLatencyMetrics = {};
+    this.latencyTypesToRender = [];
+    if (props.latencyTypesToRender) {
+      // try adding latency types specified by user first
+      props.latencyTypesToRender.forEach((type) =>
+        this.latencyTypesToRender.push(type)
+      );
+    } else {
+      // fallback to default latency types if user does not specify any
+      DefaultLatencyTypesToRender.forEach((type) =>
+        this.latencyTypesToRender.push(type)
+      );
+    }
+
     this.error4xxCountMetric = metricFactory.metric4xxCount();
     this.error4xxRateMetric = metricFactory.metric4xxRate();
 
     this.error5xxCountMetric = metricFactory.metric5xxCount();
     this.error5xxRateMetric = metricFactory.metric5xxRate();
 
-    this.p50LatencyMetric = metricFactory.metricLatencyP50InMillis();
-    this.p90LatencyMetric = metricFactory.metricLatencyP90InMillis();
-    this.p99LatencyMetric = metricFactory.metricLatencyP99InMillis();
+    const latencyAlarmDefinitions = {
+      [LatencyType.P50]: props.addLatencyP50Alarm,
+      [LatencyType.P70]: props.addLatencyP70Alarm,
+      [LatencyType.P90]: props.addLatencyP90Alarm,
+      [LatencyType.P99]: props.addLatencyP99Alarm,
+      [LatencyType.P999]: props.addLatencyP999Alarm,
+      [LatencyType.P9999]: props.addLatencyP9999Alarm,
+      [LatencyType.P100]: props.addLatencyP100Alarm,
+      [LatencyType.TM50]: props.addLatencyTM50Alarm,
+      [LatencyType.TM70]: props.addLatencyTM70Alarm,
+      [LatencyType.TM90]: props.addLatencyTM90Alarm,
+      [LatencyType.TM99]: props.addLatencyTM99Alarm,
+      [LatencyType.TM999]: props.addLatencyTM999Alarm,
+      [LatencyType.TM9999]: props.addLatencyTM9999Alarm,
+      [LatencyType.AVERAGE]: props.addLatencyAverageAlarm,
+    };
 
-    this.p50IntegrationLatencyMetric =
-      metricFactory.metricIntegrationLatencyP50InMillis();
-    this.p90IntegrationLatencyMetric =
-      metricFactory.metricIntegrationLatencyP90InMillis();
-    this.p99IntegrationLatencyMetric =
-      metricFactory.metricIntegrationLatencyP99InMillis();
+    const integrationLatencyAlarmDefinitions = {
+      [LatencyType.P50]: props.addIntegrationLatencyP50Alarm,
+      [LatencyType.P70]: props.addIntegrationLatencyP70Alarm,
+      [LatencyType.P90]: props.addIntegrationLatencyP90Alarm,
+      [LatencyType.P99]: props.addIntegrationLatencyP99Alarm,
+      [LatencyType.P999]: props.addIntegrationLatencyP999Alarm,
+      [LatencyType.P9999]: props.addIntegrationLatencyP9999Alarm,
+      [LatencyType.P100]: props.addIntegrationLatencyP100Alarm,
+      [LatencyType.TM50]: props.addIntegrationLatencyTM50Alarm,
+      [LatencyType.TM70]: props.addIntegrationLatencyTM70Alarm,
+      [LatencyType.TM90]: props.addIntegrationLatencyTM90Alarm,
+      [LatencyType.TM99]: props.addIntegrationLatencyTM99Alarm,
+      [LatencyType.TM999]: props.addIntegrationLatencyTM999Alarm,
+      [LatencyType.TM9999]: props.addIntegrationLatencyTM9999Alarm,
+      [LatencyType.AVERAGE]: props.addIntegrationLatencyAverageAlarm,
+    };
 
-    for (const disambiguator in props.addLatencyP50Alarm) {
-      const alarmProps = props.addLatencyP50Alarm[disambiguator];
-      const createdAlarm = this.latencyAlarmFactory.addLatencyAlarm(
-        this.p50LatencyMetric,
-        LatencyType.P50,
-        alarmProps,
-        disambiguator
-      );
-      this.latencyAnnotations.push(createdAlarm.annotation);
-      this.addAlarm(createdAlarm);
+    Object.values(LatencyType).forEach((latencyType) => {
+      this.latencyMetrics[latencyType] =
+        metricFactory.metricLatencyInMillis(latencyType);
+      this.integrationLatencyMetrics[latencyType] =
+        metricFactory.metricIntegrationLatencyInMillis(latencyType);
+    });
+
+    for (const [latencyType, alarmDefinition] of Object.entries(
+      latencyAlarmDefinitions
+    )) {
+      for (const disambiguator in alarmDefinition) {
+        const alarmProps = alarmDefinition[disambiguator];
+        const latencyTypeEnum = latencyType as LatencyType;
+        const metric = this.latencyMetrics[latencyTypeEnum];
+        const createdAlarm = this.latencyAlarmFactory.addLatencyAlarm(
+          metric,
+          latencyTypeEnum,
+          alarmProps,
+          disambiguator
+        );
+        this.latencyAnnotations.push(createdAlarm.annotation);
+        this.latencyTypesToRender.push(latencyTypeEnum);
+        this.addAlarm(createdAlarm);
+      }
     }
 
-    for (const disambiguator in props.addLatencyP90Alarm) {
-      const alarmProps = props.addLatencyP90Alarm[disambiguator];
-      const createdAlarm = this.latencyAlarmFactory.addLatencyAlarm(
-        this.p90LatencyMetric,
-        LatencyType.P90,
-        alarmProps,
-        disambiguator
-      );
-      this.latencyAnnotations.push(createdAlarm.annotation);
-      this.addAlarm(createdAlarm);
-    }
-
-    for (const disambiguator in props.addLatencyP99Alarm) {
-      const alarmProps = props.addLatencyP99Alarm[disambiguator];
-      const createdAlarm = this.latencyAlarmFactory.addLatencyAlarm(
-        this.p99LatencyMetric,
-        LatencyType.P99,
-        alarmProps,
-        disambiguator
-      );
-      this.latencyAnnotations.push(createdAlarm.annotation);
-      this.addAlarm(createdAlarm);
-    }
-
-    for (const disambiguator in props.addIntegrationLatencyP50Alarm) {
-      const alarmProps = props.addIntegrationLatencyP50Alarm[disambiguator];
-      const createdAlarm = this.latencyAlarmFactory.addLatencyAlarm(
-        this.p50IntegrationLatencyMetric,
-        LatencyType.P50,
-        alarmProps,
-        disambiguator
-      );
-      this.latencyAnnotations.push(createdAlarm.annotation);
-      this.addAlarm(createdAlarm);
-    }
-
-    for (const disambiguator in props.addIntegrationLatencyP90Alarm) {
-      const alarmProps = props.addIntegrationLatencyP90Alarm[disambiguator];
-      const createdAlarm = this.latencyAlarmFactory.addLatencyAlarm(
-        this.p90IntegrationLatencyMetric,
-        LatencyType.P90,
-        alarmProps,
-        disambiguator
-      );
-      this.latencyAnnotations.push(createdAlarm.annotation);
-      this.addAlarm(createdAlarm);
-    }
-
-    for (const disambiguator in props.addIntegrationLatencyP99Alarm) {
-      const alarmProps = props.addIntegrationLatencyP99Alarm[disambiguator];
-      const createdAlarm = this.latencyAlarmFactory.addLatencyAlarm(
-        this.p99IntegrationLatencyMetric,
-        LatencyType.P99,
-        alarmProps,
-        disambiguator
-      );
-      this.latencyAnnotations.push(createdAlarm.annotation);
-      this.addAlarm(createdAlarm);
+    for (const [latencyType, alarmDefinition] of Object.entries(
+      integrationLatencyAlarmDefinitions
+    )) {
+      for (const disambiguator in alarmDefinition) {
+        const alarmProps = alarmDefinition[disambiguator];
+        const latencyTypeEnum = latencyType as LatencyType;
+        const metric = this.integrationLatencyMetrics[latencyTypeEnum];
+        const createdAlarm =
+          this.latencyAlarmFactory.addIntegrationLatencyAlarm(
+            metric,
+            latencyTypeEnum,
+            alarmProps,
+            disambiguator
+          );
+        this.latencyAnnotations.push(createdAlarm.annotation);
+        this.latencyTypesToRender.push(latencyTypeEnum);
+        this.addAlarm(createdAlarm);
+      }
     }
 
     for (const disambiguator in props.add4xxCountAlarm) {
@@ -326,18 +376,20 @@ export class ApiGatewayV2HttpApiMonitoring extends Monitoring {
   }
 
   protected createLatencyWidget(width: number, height: number) {
+    const left: IMetric[] = [];
+
+    Array.from(new Set(this.latencyTypesToRender))
+      .sort()
+      .forEach((type) => {
+        left.push(this.latencyMetrics[type]);
+        left.push(this.integrationLatencyMetrics[type]);
+      });
+
     return new GraphWidget({
       width,
       height,
       title: "Latency",
-      left: [
-        this.p50LatencyMetric,
-        this.p50IntegrationLatencyMetric,
-        this.p90LatencyMetric,
-        this.p90IntegrationLatencyMetric,
-        this.p99LatencyMetric,
-        this.p99IntegrationLatencyMetric,
-      ],
+      left,
       leftYAxis: TimeAxisMillisFromZero,
       leftAnnotations: this.latencyAnnotations,
     });

--- a/lib/monitoring/aws-apigatewayv2/ApiGatewayV2HttpApiMonitoring.ts
+++ b/lib/monitoring/aws-apigatewayv2/ApiGatewayV2HttpApiMonitoring.ts
@@ -166,18 +166,9 @@ export class ApiGatewayV2HttpApiMonitoring extends Monitoring {
 
     this.latencyMetrics = {};
     this.integrationLatencyMetrics = {};
-    this.latencyTypesToRender = [];
-    if (props.latencyTypesToRender) {
-      // try adding latency types specified by user first
-      props.latencyTypesToRender.forEach((type) =>
-        this.latencyTypesToRender.push(type)
-      );
-    } else {
-      // fallback to default latency types if user does not specify any
-      DefaultLatencyTypesToRender.forEach((type) =>
-        this.latencyTypesToRender.push(type)
-      );
-    }
+    this.latencyTypesToRender = [
+      ...(props.latencyTypesToRender ?? DefaultLatencyTypesToRender),
+    ];
 
     this.error4xxCountMetric = metricFactory.metric4xxCount();
     this.error4xxRateMetric = metricFactory.metric4xxRate();

--- a/test/facade/__snapshots__/MonitoringAspect.test.ts.snap
+++ b/test/facade/__snapshots__/MonitoringAspect.test.ts.snap
@@ -108,7 +108,7 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"DummyRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P50\\",\\"stat\\":\\"p50\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"DummyRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P90\\",\\"stat\\":\\"p90\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"DummyRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P99\\",\\"stat\\":\\"p99\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"DummyRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"stat\\":\\"p50\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"DummyRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P90 (avg: \${AVG})\\",\\"stat\\":\\"p90\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"DummyRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P99 (avg: \${AVG})\\",\\"stat\\":\\"p99\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -138,7 +138,7 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"DummyRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P50\\",\\"stat\\":\\"p50\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"DummyRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P90\\",\\"stat\\":\\"p90\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"DummyRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P99\\",\\"stat\\":\\"p99\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"DummyRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"stat\\":\\"p50\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"DummyRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P90 (avg: \${AVG})\\",\\"stat\\":\\"p90\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"DummyRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P99 (avg: \${AVG})\\",\\"stat\\":\\"p99\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -284,27 +284,27 @@ Object {
               Object {
                 "Ref": "DummyHttpApi8EEBCC85",
               },
-              "\\",\\"Stage\\",\\"$default\\",{\\"label\\":\\"P50 Latency\\",\\"stat\\":\\"p50\\"}],[\\"AWS/ApiGateway\\",\\"IntegrationLatency\\",\\"ApiId\\",\\"",
+              "\\",\\"Stage\\",\\"$default\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"stat\\":\\"p50\\"}],[\\"AWS/ApiGateway\\",\\"IntegrationLatency\\",\\"ApiId\\",\\"",
               Object {
                 "Ref": "DummyHttpApi8EEBCC85",
               },
-              "\\",\\"Stage\\",\\"$default\\",{\\"label\\":\\"P50 Integration Latency\\",\\"stat\\":\\"p50\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiId\\",\\"",
+              "\\",\\"Stage\\",\\"$default\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"stat\\":\\"p50\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiId\\",\\"",
               Object {
                 "Ref": "DummyHttpApi8EEBCC85",
               },
-              "\\",\\"Stage\\",\\"$default\\",{\\"label\\":\\"P90 Latency\\",\\"stat\\":\\"p90\\"}],[\\"AWS/ApiGateway\\",\\"IntegrationLatency\\",\\"ApiId\\",\\"",
+              "\\",\\"Stage\\",\\"$default\\",{\\"label\\":\\"P90 (avg: \${AVG})\\",\\"stat\\":\\"p90\\"}],[\\"AWS/ApiGateway\\",\\"IntegrationLatency\\",\\"ApiId\\",\\"",
               Object {
                 "Ref": "DummyHttpApi8EEBCC85",
               },
-              "\\",\\"Stage\\",\\"$default\\",{\\"label\\":\\"P90 Integration Latency\\",\\"stat\\":\\"p90\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiId\\",\\"",
+              "\\",\\"Stage\\",\\"$default\\",{\\"label\\":\\"P90 (avg: \${AVG})\\",\\"stat\\":\\"p90\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiId\\",\\"",
               Object {
                 "Ref": "DummyHttpApi8EEBCC85",
               },
-              "\\",\\"Stage\\",\\"$default\\",{\\"label\\":\\"P99 Latency\\",\\"stat\\":\\"p99\\"}],[\\"AWS/ApiGateway\\",\\"IntegrationLatency\\",\\"ApiId\\",\\"",
+              "\\",\\"Stage\\",\\"$default\\",{\\"label\\":\\"P99 (avg: \${AVG})\\",\\"stat\\":\\"p99\\"}],[\\"AWS/ApiGateway\\",\\"IntegrationLatency\\",\\"ApiId\\",\\"",
               Object {
                 "Ref": "DummyHttpApi8EEBCC85",
               },
-              "\\",\\"Stage\\",\\"$default\\",{\\"label\\":\\"P99 Integration Latency\\",\\"stat\\":\\"p99\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors\\",\\"region\\":\\"",
+              "\\",\\"Stage\\",\\"$default\\",{\\"label\\":\\"P99 (avg: \${AVG})\\",\\"stat\\":\\"p99\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -362,27 +362,27 @@ Object {
               Object {
                 "Ref": "DummyHttpApi8EEBCC85",
               },
-              "\\",\\"Stage\\",\\"$default\\",{\\"label\\":\\"P50 Latency\\",\\"stat\\":\\"p50\\"}],[\\"AWS/ApiGateway\\",\\"IntegrationLatency\\",\\"ApiId\\",\\"",
+              "\\",\\"Stage\\",\\"$default\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"stat\\":\\"p50\\"}],[\\"AWS/ApiGateway\\",\\"IntegrationLatency\\",\\"ApiId\\",\\"",
               Object {
                 "Ref": "DummyHttpApi8EEBCC85",
               },
-              "\\",\\"Stage\\",\\"$default\\",{\\"label\\":\\"P50 Integration Latency\\",\\"stat\\":\\"p50\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiId\\",\\"",
+              "\\",\\"Stage\\",\\"$default\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"stat\\":\\"p50\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiId\\",\\"",
               Object {
                 "Ref": "DummyHttpApi8EEBCC85",
               },
-              "\\",\\"Stage\\",\\"$default\\",{\\"label\\":\\"P90 Latency\\",\\"stat\\":\\"p90\\"}],[\\"AWS/ApiGateway\\",\\"IntegrationLatency\\",\\"ApiId\\",\\"",
+              "\\",\\"Stage\\",\\"$default\\",{\\"label\\":\\"P90 (avg: \${AVG})\\",\\"stat\\":\\"p90\\"}],[\\"AWS/ApiGateway\\",\\"IntegrationLatency\\",\\"ApiId\\",\\"",
               Object {
                 "Ref": "DummyHttpApi8EEBCC85",
               },
-              "\\",\\"Stage\\",\\"$default\\",{\\"label\\":\\"P90 Integration Latency\\",\\"stat\\":\\"p90\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiId\\",\\"",
+              "\\",\\"Stage\\",\\"$default\\",{\\"label\\":\\"P90 (avg: \${AVG})\\",\\"stat\\":\\"p90\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiId\\",\\"",
               Object {
                 "Ref": "DummyHttpApi8EEBCC85",
               },
-              "\\",\\"Stage\\",\\"$default\\",{\\"label\\":\\"P99 Latency\\",\\"stat\\":\\"p99\\"}],[\\"AWS/ApiGateway\\",\\"IntegrationLatency\\",\\"ApiId\\",\\"",
+              "\\",\\"Stage\\",\\"$default\\",{\\"label\\":\\"P99 (avg: \${AVG})\\",\\"stat\\":\\"p99\\"}],[\\"AWS/ApiGateway\\",\\"IntegrationLatency\\",\\"ApiId\\",\\"",
               Object {
                 "Ref": "DummyHttpApi8EEBCC85",
               },
-              "\\",\\"Stage\\",\\"$default\\",{\\"label\\":\\"P99 Integration Latency\\",\\"stat\\":\\"p99\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              "\\",\\"Stage\\",\\"$default\\",{\\"label\\":\\"P99 (avg: \${AVG})\\",\\"stat\\":\\"p99\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },

--- a/test/monitoring/aws-apigateway/ApiGatewayMonitoring.test.ts
+++ b/test/monitoring/aws-apigateway/ApiGatewayMonitoring.test.ts
@@ -60,94 +60,88 @@ test("snapshot test: all alarms", () => {
     },
     addLatencyP50Alarm: {
       Warning: {
-        maxLatency: Duration.millis(110),
-        datapointsToAlarm: 11,
+        maxLatency: Duration.millis(150),
+        datapointsToAlarm: 150,
+      },
+    },
+    addLatencyP70Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(170),
+        datapointsToAlarm: 170,
       },
     },
     addLatencyP90Alarm: {
       Warning: {
-        maxLatency: Duration.millis(220),
-        datapointsToAlarm: 22,
+        maxLatency: Duration.millis(190),
+        datapointsToAlarm: 190,
       },
     },
     addLatencyP99Alarm: {
       Warning: {
-        maxLatency: Duration.millis(330),
-        datapointsToAlarm: 33,
+        maxLatency: Duration.millis(199),
+        datapointsToAlarm: 199,
       },
     },
-    addLowTpsAlarm: {
-      Warning: { minTps: 1 },
-    },
-    addHighTpsAlarm: {
-      Warning: { maxTps: 10 },
-    },
-    useCreatedAlarms: {
-      consume(alarms: AlarmWithAnnotation[]) {
-        numAlarmsCreated = alarms.length;
-      },
-    },
-  });
-
-  expect(numAlarmsCreated).toStrictEqual(9);
-  expect(Template.fromStack(stack)).toMatchSnapshot();
-});
-
-test("snapshot test: all alarms without alarmFriendlyName", () => {
-  const stack = new Stack();
-  const api = new RestApi(stack, "DummyApi");
-  api.root.addMethod("ANY");
-
-  const scope = new TestMonitoringScope(stack, "Scope");
-
-  let numAlarmsCreated = 0;
-
-  new ApiGatewayMonitoring(scope, {
-    api,
-    apiMethod: "GET",
-    apiResource: "dummy/resource",
-    add5XXFaultRateAlarm: {
+    addLatencyP999Alarm: {
       Warning: {
-        maxErrorRate: 1,
-        datapointsToAlarm: 10,
+        maxLatency: Duration.millis(1999),
+        datapointsToAlarm: 1999,
       },
     },
-    add5XXFaultCountAlarm: {
+    addLatencyP9999Alarm: {
       Warning: {
-        maxErrorCount: 2,
+        maxLatency: Duration.millis(19999),
+        datapointsToAlarm: 19999,
+      },
+    },
+    addLatencyP100Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(1100),
+        datapointsToAlarm: 1100,
+      },
+    },
+    addLatencyTM50Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(250),
+        datapointsToAlarm: 250,
+      },
+    },
+    addLatencyTM70Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(270),
+        datapointsToAlarm: 270,
+      },
+    },
+    addLatencyTM90Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(290),
+        datapointsToAlarm: 290,
+      },
+    },
+    addLatencyTM99Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(299),
+        datapointsToAlarm: 299,
+      },
+    },
+    addLatencyTM999Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(2999),
+        datapointsToAlarm: 2999,
+      },
+    },
+    addLatencyTM9999Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(29999),
+        datapointsToAlarm: 29999,
+      },
+    },
+    addLatencyAverageAlarm: {
+      Warning: {
+        maxLatency: Duration.millis(20),
         datapointsToAlarm: 20,
       },
     },
-    add4XXErrorRateAlarm: {
-      Warning: {
-        maxErrorRate: 0.01,
-        datapointsToAlarm: 11,
-      },
-    },
-    add4XXErrorCountAlarm: {
-      Warning: {
-        maxErrorCount: 0.02,
-        datapointsToAlarm: 22,
-      },
-    },
-    addLatencyP50Alarm: {
-      Warning: {
-        maxLatency: Duration.millis(110),
-        datapointsToAlarm: 11,
-      },
-    },
-    addLatencyP90Alarm: {
-      Warning: {
-        maxLatency: Duration.millis(220),
-        datapointsToAlarm: 22,
-      },
-    },
-    addLatencyP99Alarm: {
-      Warning: {
-        maxLatency: Duration.millis(330),
-        datapointsToAlarm: 33,
-      },
-    },
     addLowTpsAlarm: {
       Warning: { minTps: 1 },
     },
@@ -161,6 +155,6 @@ test("snapshot test: all alarms without alarmFriendlyName", () => {
     },
   });
 
-  expect(numAlarmsCreated).toStrictEqual(9);
+  expect(numAlarmsCreated).toStrictEqual(20);
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });

--- a/test/monitoring/aws-apigateway/__snapshots__/ApiGatewayMonitoring.test.ts.snap
+++ b/test/monitoring/aws-apigateway/__snapshots__/ApiGatewayMonitoring.test.ts.snap
@@ -277,14 +277,90 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
+    "ScopeTestDummyApiLatencyAverageWarning27D59767": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Average latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-Average-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 20,
+        "EvaluationPeriods": 20,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Average",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "DummyApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 20,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyP100WarningB48A5E64": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P100 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-P100-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1100,
+        "EvaluationPeriods": 1100,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P100",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "DummyApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p100",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 1100,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "ScopeTestDummyApiLatencyP50Warning7EEB3E57": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmDescription": "P50 latency is too high.",
         "AlarmName": "Test-DummyApi-Latency-P50-Warning",
         "ComparisonOperator": "GreaterThanThreshold",
-        "DatapointsToAlarm": 11,
-        "EvaluationPeriods": 11,
+        "DatapointsToAlarm": 150,
+        "EvaluationPeriods": 150,
         "Metrics": Array [
           Object {
             "Id": "m1",
@@ -310,7 +386,45 @@ Object {
             "ReturnData": true,
           },
         ],
-        "Threshold": 110,
+        "Threshold": 150,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyP70Warning56ABF038": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P70 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-P70-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 170,
+        "EvaluationPeriods": 170,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P70",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "DummyApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p70",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 170,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -321,8 +435,8 @@ Object {
         "AlarmDescription": "P90 latency is too high.",
         "AlarmName": "Test-DummyApi-Latency-P90-Warning",
         "ComparisonOperator": "GreaterThanThreshold",
-        "DatapointsToAlarm": 22,
-        "EvaluationPeriods": 22,
+        "DatapointsToAlarm": 190,
+        "EvaluationPeriods": 190,
         "Metrics": Array [
           Object {
             "Id": "m1",
@@ -348,7 +462,83 @@ Object {
             "ReturnData": true,
           },
         ],
-        "Threshold": 220,
+        "Threshold": 190,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyP9999Warning89E47C72": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P9999 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-P9999-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 19999,
+        "EvaluationPeriods": 19999,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P99.99",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "DummyApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p99.99",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 19999,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyP999Warning8CF0377D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P999 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-P999-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1999,
+        "EvaluationPeriods": 1999,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P99.9",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "DummyApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p99.9",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 1999,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -359,8 +549,8 @@ Object {
         "AlarmDescription": "P99 latency is too high.",
         "AlarmName": "Test-DummyApi-Latency-P99-Warning",
         "ComparisonOperator": "GreaterThanThreshold",
-        "DatapointsToAlarm": 33,
-        "EvaluationPeriods": 33,
+        "DatapointsToAlarm": 199,
+        "EvaluationPeriods": 199,
         "Metrics": Array [
           Object {
             "Id": "m1",
@@ -386,7 +576,235 @@ Object {
             "ReturnData": true,
           },
         ],
-        "Threshold": 330,
+        "Threshold": 199,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyTM50Warning092E86BF": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM50 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-TM50-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 250,
+        "EvaluationPeriods": 250,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM50",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "DummyApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm50",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 250,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyTM70Warning8E657453": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM70 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-TM70-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 270,
+        "EvaluationPeriods": 270,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM70",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "DummyApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm70",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 270,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyTM90Warning0FDD3108": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM90 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-TM90-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 290,
+        "EvaluationPeriods": 290,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM90",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "DummyApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm90",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 290,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyTM9999Warning4181DE97": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM9999 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-TM9999-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 29999,
+        "EvaluationPeriods": 29999,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM99.99",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "DummyApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm99.99",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 29999,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyTM999WarningD73972C6": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM999 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-TM999-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 2999,
+        "EvaluationPeriods": 2999,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM99.9",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "DummyApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm99.9",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 2999,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyTM99WarningFF55C464": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM99 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-TM99-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 299,
+        "EvaluationPeriods": 299,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM99",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "DummyApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm99",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 299,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -457,559 +875,6 @@ Object {
                   Object {
                     "Name": "ApiName",
                     "Value": "DummyApi",
-                  },
-                  Object {
-                    "Name": "Stage",
-                    "Value": "prod",
-                  },
-                ],
-                "MetricName": "Count",
-                "Namespace": "AWS/ApiGateway",
-              },
-              "Period": 300,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-        ],
-        "Threshold": 1,
-        "TreatMissingData": "missing",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-  },
-}
-`;
-
-exports[`snapshot test: all alarms without alarmFriendlyName 1`] = `
-Object {
-  "Outputs": Object {
-    "DummyApiEndpoint2E6B19BE": Object {
-      "Value": Object {
-        "Fn::Join": Array [
-          "",
-          Array [
-            "https://",
-            Object {
-              "Ref": "DummyApi80F1E171",
-            },
-            ".execute-api.",
-            Object {
-              "Ref": "AWS::Region",
-            },
-            ".",
-            Object {
-              "Ref": "AWS::URLSuffix",
-            },
-            "/",
-            Object {
-              "Ref": "DummyApiDeploymentStageprod9EB3D152",
-            },
-            "/",
-          ],
-        ],
-      },
-    },
-  },
-  "Resources": Object {
-    "DummyApi80F1E171": Object {
-      "Properties": Object {
-        "Name": "DummyApi",
-      },
-      "Type": "AWS::ApiGateway::RestApi",
-    },
-    "DummyApiANYCEB66499": Object {
-      "Properties": Object {
-        "AuthorizationType": "NONE",
-        "HttpMethod": "ANY",
-        "Integration": Object {
-          "Type": "MOCK",
-        },
-        "ResourceId": Object {
-          "Fn::GetAtt": Array [
-            "DummyApi80F1E171",
-            "RootResourceId",
-          ],
-        },
-        "RestApiId": Object {
-          "Ref": "DummyApi80F1E171",
-        },
-      },
-      "Type": "AWS::ApiGateway::Method",
-    },
-    "DummyApiAccount7A4341D1": Object {
-      "DependsOn": Array [
-        "DummyApi80F1E171",
-      ],
-      "Properties": Object {
-        "CloudWatchRoleArn": Object {
-          "Fn::GetAtt": Array [
-            "DummyApiCloudWatchRole478A67A7",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::ApiGateway::Account",
-    },
-    "DummyApiCloudWatchRole478A67A7": Object {
-      "Properties": Object {
-        "AssumeRolePolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": Object {
-                "Service": "apigateway.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": Array [
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
-              ],
-            ],
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "DummyApiDeploymentD01F5018548e3dba60631e60c80c03977ce1f18a": Object {
-      "DependsOn": Array [
-        "DummyApiANYCEB66499",
-      ],
-      "Properties": Object {
-        "Description": "Automatically created by the RestApi construct",
-        "RestApiId": Object {
-          "Ref": "DummyApi80F1E171",
-        },
-      },
-      "Type": "AWS::ApiGateway::Deployment",
-    },
-    "DummyApiDeploymentStageprod9EB3D152": Object {
-      "Properties": Object {
-        "DeploymentId": Object {
-          "Ref": "DummyApiDeploymentD01F5018548e3dba60631e60c80c03977ce1f18a",
-        },
-        "RestApiId": Object {
-          "Ref": "DummyApi80F1E171",
-        },
-        "StageName": "prod",
-      },
-      "Type": "AWS::ApiGateway::Stage",
-    },
-    "ScopeTestDummyApiprodGETdummyresourceErrorCountWarningAF0226A6": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmDescription": "Error count is too high.",
-        "AlarmName": "Test-DummyApi-prod-GET-dummyresource-Error-Count-Warning",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "DatapointsToAlarm": 22,
-        "EvaluationPeriods": 22,
-        "Metrics": Array [
-          Object {
-            "Id": "m1",
-            "Label": "4XX Error",
-            "MetricStat": Object {
-              "Metric": Object {
-                "Dimensions": Array [
-                  Object {
-                    "Name": "ApiName",
-                    "Value": "DummyApi",
-                  },
-                  Object {
-                    "Name": "Method",
-                    "Value": "GET",
-                  },
-                  Object {
-                    "Name": "Resource",
-                    "Value": "dummy/resource",
-                  },
-                  Object {
-                    "Name": "Stage",
-                    "Value": "prod",
-                  },
-                ],
-                "MetricName": "4XXError",
-                "Namespace": "AWS/ApiGateway",
-              },
-              "Period": 300,
-              "Stat": "Sum",
-            },
-            "ReturnData": true,
-          },
-        ],
-        "Threshold": 0.02,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "ScopeTestDummyApiprodGETdummyresourceErrorRateWarning016C3EC5": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmDescription": "Error rate is too high.",
-        "AlarmName": "Test-DummyApi-prod-GET-dummyresource-Error-Rate-Warning",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "DatapointsToAlarm": 11,
-        "EvaluationPeriods": 11,
-        "Metrics": Array [
-          Object {
-            "Id": "m1",
-            "Label": "4XX Error (avg)",
-            "MetricStat": Object {
-              "Metric": Object {
-                "Dimensions": Array [
-                  Object {
-                    "Name": "ApiName",
-                    "Value": "DummyApi",
-                  },
-                  Object {
-                    "Name": "Method",
-                    "Value": "GET",
-                  },
-                  Object {
-                    "Name": "Resource",
-                    "Value": "dummy/resource",
-                  },
-                  Object {
-                    "Name": "Stage",
-                    "Value": "prod",
-                  },
-                ],
-                "MetricName": "4XXError",
-                "Namespace": "AWS/ApiGateway",
-              },
-              "Period": 300,
-              "Stat": "Average",
-            },
-            "ReturnData": true,
-          },
-        ],
-        "Threshold": 0.01,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "ScopeTestDummyApiprodGETdummyresourceFaultCountWarning17579B91": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmDescription": "Fault count is too high.",
-        "AlarmName": "Test-DummyApi-prod-GET-dummyresource-Fault-Count-Warning",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "DatapointsToAlarm": 20,
-        "EvaluationPeriods": 20,
-        "Metrics": Array [
-          Object {
-            "Id": "m1",
-            "Label": "5XX Fault",
-            "MetricStat": Object {
-              "Metric": Object {
-                "Dimensions": Array [
-                  Object {
-                    "Name": "ApiName",
-                    "Value": "DummyApi",
-                  },
-                  Object {
-                    "Name": "Method",
-                    "Value": "GET",
-                  },
-                  Object {
-                    "Name": "Resource",
-                    "Value": "dummy/resource",
-                  },
-                  Object {
-                    "Name": "Stage",
-                    "Value": "prod",
-                  },
-                ],
-                "MetricName": "5XXError",
-                "Namespace": "AWS/ApiGateway",
-              },
-              "Period": 300,
-              "Stat": "Sum",
-            },
-            "ReturnData": true,
-          },
-        ],
-        "Threshold": 2,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "ScopeTestDummyApiprodGETdummyresourceFaultRateWarning1991C1B6": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmDescription": "Fault rate is too high.",
-        "AlarmName": "Test-DummyApi-prod-GET-dummyresource-Fault-Rate-Warning",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "DatapointsToAlarm": 10,
-        "EvaluationPeriods": 10,
-        "Metrics": Array [
-          Object {
-            "Id": "m1",
-            "Label": "5XX Fault (avg)",
-            "MetricStat": Object {
-              "Metric": Object {
-                "Dimensions": Array [
-                  Object {
-                    "Name": "ApiName",
-                    "Value": "DummyApi",
-                  },
-                  Object {
-                    "Name": "Method",
-                    "Value": "GET",
-                  },
-                  Object {
-                    "Name": "Resource",
-                    "Value": "dummy/resource",
-                  },
-                  Object {
-                    "Name": "Stage",
-                    "Value": "prod",
-                  },
-                ],
-                "MetricName": "5XXError",
-                "Namespace": "AWS/ApiGateway",
-              },
-              "Period": 300,
-              "Stat": "Average",
-            },
-            "ReturnData": true,
-          },
-        ],
-        "Threshold": 1,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "ScopeTestDummyApiprodGETdummyresourceLatencyP50Warning988CD8FE": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmDescription": "P50 latency is too high.",
-        "AlarmName": "Test-DummyApi-prod-GET-dummyresource-Latency-P50-Warning",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "DatapointsToAlarm": 11,
-        "EvaluationPeriods": 11,
-        "Metrics": Array [
-          Object {
-            "Id": "m1",
-            "Label": "P50",
-            "MetricStat": Object {
-              "Metric": Object {
-                "Dimensions": Array [
-                  Object {
-                    "Name": "ApiName",
-                    "Value": "DummyApi",
-                  },
-                  Object {
-                    "Name": "Method",
-                    "Value": "GET",
-                  },
-                  Object {
-                    "Name": "Resource",
-                    "Value": "dummy/resource",
-                  },
-                  Object {
-                    "Name": "Stage",
-                    "Value": "prod",
-                  },
-                ],
-                "MetricName": "Latency",
-                "Namespace": "AWS/ApiGateway",
-              },
-              "Period": 300,
-              "Stat": "p50",
-            },
-            "ReturnData": true,
-          },
-        ],
-        "Threshold": 110,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "ScopeTestDummyApiprodGETdummyresourceLatencyP90Warning7B53F4CE": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmDescription": "P90 latency is too high.",
-        "AlarmName": "Test-DummyApi-prod-GET-dummyresource-Latency-P90-Warning",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "DatapointsToAlarm": 22,
-        "EvaluationPeriods": 22,
-        "Metrics": Array [
-          Object {
-            "Id": "m1",
-            "Label": "P90",
-            "MetricStat": Object {
-              "Metric": Object {
-                "Dimensions": Array [
-                  Object {
-                    "Name": "ApiName",
-                    "Value": "DummyApi",
-                  },
-                  Object {
-                    "Name": "Method",
-                    "Value": "GET",
-                  },
-                  Object {
-                    "Name": "Resource",
-                    "Value": "dummy/resource",
-                  },
-                  Object {
-                    "Name": "Stage",
-                    "Value": "prod",
-                  },
-                ],
-                "MetricName": "Latency",
-                "Namespace": "AWS/ApiGateway",
-              },
-              "Period": 300,
-              "Stat": "p90",
-            },
-            "ReturnData": true,
-          },
-        ],
-        "Threshold": 220,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "ScopeTestDummyApiprodGETdummyresourceLatencyP99Warning8EE55673": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmDescription": "P99 latency is too high.",
-        "AlarmName": "Test-DummyApi-prod-GET-dummyresource-Latency-P99-Warning",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "DatapointsToAlarm": 33,
-        "EvaluationPeriods": 33,
-        "Metrics": Array [
-          Object {
-            "Id": "m1",
-            "Label": "P99",
-            "MetricStat": Object {
-              "Metric": Object {
-                "Dimensions": Array [
-                  Object {
-                    "Name": "ApiName",
-                    "Value": "DummyApi",
-                  },
-                  Object {
-                    "Name": "Method",
-                    "Value": "GET",
-                  },
-                  Object {
-                    "Name": "Resource",
-                    "Value": "dummy/resource",
-                  },
-                  Object {
-                    "Name": "Stage",
-                    "Value": "prod",
-                  },
-                ],
-                "MetricName": "Latency",
-                "Namespace": "AWS/ApiGateway",
-              },
-              "Period": 300,
-              "Stat": "p99",
-            },
-            "ReturnData": true,
-          },
-        ],
-        "Threshold": 330,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "ScopeTestDummyApiprodGETdummyresourceMaxTPSWarning864CD950": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmDescription": "TPS is too high.",
-        "AlarmName": "Test-DummyApi-prod-GET-dummyresource-MaxTPS-Warning",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "DatapointsToAlarm": 3,
-        "EvaluationPeriods": 3,
-        "Metrics": Array [
-          Object {
-            "Expression": "FILL(requests,0) / PERIOD(requests)",
-            "Id": "expr_1",
-            "Label": "Count/s",
-          },
-          Object {
-            "Id": "requests",
-            "Label": "Count",
-            "MetricStat": Object {
-              "Metric": Object {
-                "Dimensions": Array [
-                  Object {
-                    "Name": "ApiName",
-                    "Value": "DummyApi",
-                  },
-                  Object {
-                    "Name": "Method",
-                    "Value": "GET",
-                  },
-                  Object {
-                    "Name": "Resource",
-                    "Value": "dummy/resource",
-                  },
-                  Object {
-                    "Name": "Stage",
-                    "Value": "prod",
-                  },
-                ],
-                "MetricName": "Count",
-                "Namespace": "AWS/ApiGateway",
-              },
-              "Period": 300,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-        ],
-        "Threshold": 10,
-        "TreatMissingData": "missing",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "ScopeTestDummyApiprodGETdummyresourceMinTPSWarning8ED5EFE3": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmDescription": "TPS is too low.",
-        "AlarmName": "Test-DummyApi-prod-GET-dummyresource-MinTPS-Warning",
-        "ComparisonOperator": "LessThanThreshold",
-        "DatapointsToAlarm": 3,
-        "EvaluationPeriods": 3,
-        "Metrics": Array [
-          Object {
-            "Expression": "FILL(requests,0) / PERIOD(requests)",
-            "Id": "expr_1",
-            "Label": "Count/s",
-          },
-          Object {
-            "Id": "requests",
-            "Label": "Count",
-            "MetricStat": Object {
-              "Metric": Object {
-                "Dimensions": Array [
-                  Object {
-                    "Name": "ApiName",
-                    "Value": "DummyApi",
-                  },
-                  Object {
-                    "Name": "Method",
-                    "Value": "GET",
-                  },
-                  Object {
-                    "Name": "Resource",
-                    "Value": "dummy/resource",
                   },
                   Object {
                     "Name": "Stage",

--- a/test/monitoring/aws-apigatewayv2/ApiGatewayV2HttpApiMonitoring.test.ts
+++ b/test/monitoring/aws-apigatewayv2/ApiGatewayV2HttpApiMonitoring.test.ts
@@ -43,38 +43,170 @@ test("snapshot test: all alarms", () => {
     alarmFriendlyName: "DummyApi",
     addLatencyP50Alarm: {
       Warning: {
-        maxLatency: Duration.millis(110),
-        datapointsToAlarm: 11,
+        maxLatency: Duration.millis(150),
+        datapointsToAlarm: 150,
+      },
+    },
+    addLatencyP70Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(170),
+        datapointsToAlarm: 170,
       },
     },
     addLatencyP90Alarm: {
       Warning: {
-        maxLatency: Duration.millis(220),
-        datapointsToAlarm: 22,
+        maxLatency: Duration.millis(190),
+        datapointsToAlarm: 190,
       },
     },
     addLatencyP99Alarm: {
       Warning: {
-        maxLatency: Duration.millis(330),
-        datapointsToAlarm: 33,
+        maxLatency: Duration.millis(199),
+        datapointsToAlarm: 199,
+      },
+    },
+    addLatencyP999Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(1999),
+        datapointsToAlarm: 1999,
+      },
+    },
+    addLatencyP9999Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(19999),
+        datapointsToAlarm: 19999,
+      },
+    },
+    addLatencyP100Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(1100),
+        datapointsToAlarm: 1100,
+      },
+    },
+    addLatencyTM50Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(250),
+        datapointsToAlarm: 250,
+      },
+    },
+    addLatencyTM70Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(270),
+        datapointsToAlarm: 270,
+      },
+    },
+    addLatencyTM90Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(290),
+        datapointsToAlarm: 290,
+      },
+    },
+    addLatencyTM99Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(299),
+        datapointsToAlarm: 299,
+      },
+    },
+    addLatencyTM999Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(2999),
+        datapointsToAlarm: 2999,
+      },
+    },
+    addLatencyTM9999Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(29999),
+        datapointsToAlarm: 29999,
+      },
+    },
+    addLatencyAverageAlarm: {
+      Warning: {
+        maxLatency: Duration.millis(20),
+        datapointsToAlarm: 20,
       },
     },
     addIntegrationLatencyP50Alarm: {
-      Critical: {
-        maxLatency: Duration.millis(110),
-        datapointsToAlarm: 11,
+      Warning: {
+        maxLatency: Duration.millis(150),
+        datapointsToAlarm: 150,
+      },
+    },
+    addIntegrationLatencyP70Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(170),
+        datapointsToAlarm: 170,
       },
     },
     addIntegrationLatencyP90Alarm: {
-      Critical: {
-        maxLatency: Duration.millis(220),
-        datapointsToAlarm: 22,
+      Warning: {
+        maxLatency: Duration.millis(190),
+        datapointsToAlarm: 190,
       },
     },
     addIntegrationLatencyP99Alarm: {
-      Critical: {
-        maxLatency: Duration.millis(330),
-        datapointsToAlarm: 33,
+      Warning: {
+        maxLatency: Duration.millis(199),
+        datapointsToAlarm: 199,
+      },
+    },
+    addIntegrationLatencyP999Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(1999),
+        datapointsToAlarm: 1999,
+      },
+    },
+    addIntegrationLatencyP9999Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(19999),
+        datapointsToAlarm: 19999,
+      },
+    },
+    addIntegrationLatencyP100Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(1100),
+        datapointsToAlarm: 1100,
+      },
+    },
+    addIntegrationLatencyTM50Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(250),
+        datapointsToAlarm: 250,
+      },
+    },
+    addIntegrationLatencyTM70Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(270),
+        datapointsToAlarm: 270,
+      },
+    },
+    addIntegrationLatencyTM90Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(290),
+        datapointsToAlarm: 290,
+      },
+    },
+    addIntegrationLatencyTM99Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(299),
+        datapointsToAlarm: 299,
+      },
+    },
+    addIntegrationLatencyTM999Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(2999),
+        datapointsToAlarm: 2999,
+      },
+    },
+    addIntegrationLatencyTM9999Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(29999),
+        datapointsToAlarm: 29999,
+      },
+    },
+    addIntegrationLatencyAverageAlarm: {
+      Warning: {
+        maxLatency: Duration.millis(20),
+        datapointsToAlarm: 20,
       },
     },
     add4xxCountAlarm: {
@@ -114,6 +246,6 @@ test("snapshot test: all alarms", () => {
     },
   });
 
-  expect(numAlarmsCreated).toStrictEqual(12);
+  expect(numAlarmsCreated).toStrictEqual(34);
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });

--- a/test/monitoring/aws-apigatewayv2/__snapshots__/ApiGatewayV2HttpApiMonitoring.test.ts.snap
+++ b/test/monitoring/aws-apigatewayv2/__snapshots__/ApiGatewayV2HttpApiMonitoring.test.ts.snap
@@ -163,18 +163,98 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "ScopeTestDummyApiLatencyP50Critical4E10CCCB": Object {
+    "ScopeTestDummyApiIntegrationLatencyAverageWarning1FB2E797": Object {
       "Properties": Object {
         "ActionsEnabled": true,
-        "AlarmDescription": "P50 latency is too high.",
-        "AlarmName": "Test-DummyApi-Latency-P50-Critical",
+        "AlarmDescription": "Average integration latency is too high.",
+        "AlarmName": "Test-DummyApi-IntegrationLatency-Average-Warning",
         "ComparisonOperator": "GreaterThanThreshold",
-        "DatapointsToAlarm": 11,
-        "EvaluationPeriods": 11,
+        "DatapointsToAlarm": 20,
+        "EvaluationPeriods": 20,
         "Metrics": Array [
           Object {
             "Id": "m1",
-            "Label": "P50 Integration Latency",
+            "Label": "Average",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiId",
+                    "Value": Object {
+                      "Ref": "testHttpApiC57B300F",
+                    },
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "$default",
+                  },
+                ],
+                "MetricName": "IntegrationLatency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 20,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiIntegrationLatencyP100Warning347C1F98": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P100 integration latency is too high.",
+        "AlarmName": "Test-DummyApi-IntegrationLatency-P100-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1100,
+        "EvaluationPeriods": 1100,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P100",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiId",
+                    "Value": Object {
+                      "Ref": "testHttpApiC57B300F",
+                    },
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "$default",
+                  },
+                ],
+                "MetricName": "IntegrationLatency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p100",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 1100,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiIntegrationLatencyP50WarningB23B4040": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P50 integration latency is too high.",
+        "AlarmName": "Test-DummyApi-IntegrationLatency-P50-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 150,
+        "EvaluationPeriods": 150,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P50",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -198,7 +278,527 @@ Object {
             "ReturnData": true,
           },
         ],
-        "Threshold": 110,
+        "Threshold": 150,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiIntegrationLatencyP70Warning3CC3EBD5": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P70 integration latency is too high.",
+        "AlarmName": "Test-DummyApi-IntegrationLatency-P70-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 170,
+        "EvaluationPeriods": 170,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P70",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiId",
+                    "Value": Object {
+                      "Ref": "testHttpApiC57B300F",
+                    },
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "$default",
+                  },
+                ],
+                "MetricName": "IntegrationLatency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p70",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 170,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiIntegrationLatencyP90WarningF259FC77": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P90 integration latency is too high.",
+        "AlarmName": "Test-DummyApi-IntegrationLatency-P90-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 190,
+        "EvaluationPeriods": 190,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P90",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiId",
+                    "Value": Object {
+                      "Ref": "testHttpApiC57B300F",
+                    },
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "$default",
+                  },
+                ],
+                "MetricName": "IntegrationLatency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p90",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 190,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiIntegrationLatencyP9999WarningA7C40063": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P9999 integration latency is too high.",
+        "AlarmName": "Test-DummyApi-IntegrationLatency-P9999-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 19999,
+        "EvaluationPeriods": 19999,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P99.99",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiId",
+                    "Value": Object {
+                      "Ref": "testHttpApiC57B300F",
+                    },
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "$default",
+                  },
+                ],
+                "MetricName": "IntegrationLatency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p99.99",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 19999,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiIntegrationLatencyP999Warning9F27E61C": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P999 integration latency is too high.",
+        "AlarmName": "Test-DummyApi-IntegrationLatency-P999-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1999,
+        "EvaluationPeriods": 1999,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P99.9",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiId",
+                    "Value": Object {
+                      "Ref": "testHttpApiC57B300F",
+                    },
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "$default",
+                  },
+                ],
+                "MetricName": "IntegrationLatency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p99.9",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 1999,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiIntegrationLatencyP99WarningC8929BAD": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P99 integration latency is too high.",
+        "AlarmName": "Test-DummyApi-IntegrationLatency-P99-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 199,
+        "EvaluationPeriods": 199,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P99",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiId",
+                    "Value": Object {
+                      "Ref": "testHttpApiC57B300F",
+                    },
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "$default",
+                  },
+                ],
+                "MetricName": "IntegrationLatency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p99",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 199,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiIntegrationLatencyTM50Warning6B4229D0": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM50 integration latency is too high.",
+        "AlarmName": "Test-DummyApi-IntegrationLatency-TM50-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 250,
+        "EvaluationPeriods": 250,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM50",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiId",
+                    "Value": Object {
+                      "Ref": "testHttpApiC57B300F",
+                    },
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "$default",
+                  },
+                ],
+                "MetricName": "IntegrationLatency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm50",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 250,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiIntegrationLatencyTM70WarningB60BC024": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM70 integration latency is too high.",
+        "AlarmName": "Test-DummyApi-IntegrationLatency-TM70-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 270,
+        "EvaluationPeriods": 270,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM70",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiId",
+                    "Value": Object {
+                      "Ref": "testHttpApiC57B300F",
+                    },
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "$default",
+                  },
+                ],
+                "MetricName": "IntegrationLatency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm70",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 270,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiIntegrationLatencyTM90Warning2A0B535F": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM90 integration latency is too high.",
+        "AlarmName": "Test-DummyApi-IntegrationLatency-TM90-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 290,
+        "EvaluationPeriods": 290,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM90",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiId",
+                    "Value": Object {
+                      "Ref": "testHttpApiC57B300F",
+                    },
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "$default",
+                  },
+                ],
+                "MetricName": "IntegrationLatency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm90",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 290,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiIntegrationLatencyTM9999Warning26E553E4": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM9999 integration latency is too high.",
+        "AlarmName": "Test-DummyApi-IntegrationLatency-TM9999-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 29999,
+        "EvaluationPeriods": 29999,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM99.99",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiId",
+                    "Value": Object {
+                      "Ref": "testHttpApiC57B300F",
+                    },
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "$default",
+                  },
+                ],
+                "MetricName": "IntegrationLatency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm99.99",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 29999,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiIntegrationLatencyTM999Warning08B604B1": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM999 integration latency is too high.",
+        "AlarmName": "Test-DummyApi-IntegrationLatency-TM999-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 2999,
+        "EvaluationPeriods": 2999,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM99.9",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiId",
+                    "Value": Object {
+                      "Ref": "testHttpApiC57B300F",
+                    },
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "$default",
+                  },
+                ],
+                "MetricName": "IntegrationLatency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm99.9",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 2999,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiIntegrationLatencyTM99WarningACB026E2": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM99 integration latency is too high.",
+        "AlarmName": "Test-DummyApi-IntegrationLatency-TM99-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 299,
+        "EvaluationPeriods": 299,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM99",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiId",
+                    "Value": Object {
+                      "Ref": "testHttpApiC57B300F",
+                    },
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "$default",
+                  },
+                ],
+                "MetricName": "IntegrationLatency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm99",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 299,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyAverageWarning27D59767": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Average latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-Average-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 20,
+        "EvaluationPeriods": 20,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Average",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiId",
+                    "Value": Object {
+                      "Ref": "testHttpApiC57B300F",
+                    },
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "$default",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 20,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyP100WarningB48A5E64": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P100 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-P100-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1100,
+        "EvaluationPeriods": 1100,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P100",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiId",
+                    "Value": Object {
+                      "Ref": "testHttpApiC57B300F",
+                    },
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "$default",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p100",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 1100,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -209,12 +809,12 @@ Object {
         "AlarmDescription": "P50 latency is too high.",
         "AlarmName": "Test-DummyApi-Latency-P50-Warning",
         "ComparisonOperator": "GreaterThanThreshold",
-        "DatapointsToAlarm": 11,
-        "EvaluationPeriods": 11,
+        "DatapointsToAlarm": 150,
+        "EvaluationPeriods": 150,
         "Metrics": Array [
           Object {
             "Id": "m1",
-            "Label": "P50 Latency",
+            "Label": "P50",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -238,23 +838,23 @@ Object {
             "ReturnData": true,
           },
         ],
-        "Threshold": 110,
+        "Threshold": 150,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "ScopeTestDummyApiLatencyP90Critical72F6910F": Object {
+    "ScopeTestDummyApiLatencyP70Warning56ABF038": Object {
       "Properties": Object {
         "ActionsEnabled": true,
-        "AlarmDescription": "P90 latency is too high.",
-        "AlarmName": "Test-DummyApi-Latency-P90-Critical",
+        "AlarmDescription": "P70 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-P70-Warning",
         "ComparisonOperator": "GreaterThanThreshold",
-        "DatapointsToAlarm": 22,
-        "EvaluationPeriods": 22,
+        "DatapointsToAlarm": 170,
+        "EvaluationPeriods": 170,
         "Metrics": Array [
           Object {
             "Id": "m1",
-            "Label": "P90 Integration Latency",
+            "Label": "P70",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -269,16 +869,16 @@ Object {
                     "Value": "$default",
                   },
                 ],
-                "MetricName": "IntegrationLatency",
+                "MetricName": "Latency",
                 "Namespace": "AWS/ApiGateway",
               },
               "Period": 300,
-              "Stat": "p90",
+              "Stat": "p70",
             },
             "ReturnData": true,
           },
         ],
-        "Threshold": 220,
+        "Threshold": 170,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -289,12 +889,12 @@ Object {
         "AlarmDescription": "P90 latency is too high.",
         "AlarmName": "Test-DummyApi-Latency-P90-Warning",
         "ComparisonOperator": "GreaterThanThreshold",
-        "DatapointsToAlarm": 22,
-        "EvaluationPeriods": 22,
+        "DatapointsToAlarm": 190,
+        "EvaluationPeriods": 190,
         "Metrics": Array [
           Object {
             "Id": "m1",
-            "Label": "P90 Latency",
+            "Label": "P90",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -318,23 +918,23 @@ Object {
             "ReturnData": true,
           },
         ],
-        "Threshold": 220,
+        "Threshold": 190,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "ScopeTestDummyApiLatencyP99Critical6A9D549F": Object {
+    "ScopeTestDummyApiLatencyP9999Warning89E47C72": Object {
       "Properties": Object {
         "ActionsEnabled": true,
-        "AlarmDescription": "P99 latency is too high.",
-        "AlarmName": "Test-DummyApi-Latency-P99-Critical",
+        "AlarmDescription": "P9999 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-P9999-Warning",
         "ComparisonOperator": "GreaterThanThreshold",
-        "DatapointsToAlarm": 33,
-        "EvaluationPeriods": 33,
+        "DatapointsToAlarm": 19999,
+        "EvaluationPeriods": 19999,
         "Metrics": Array [
           Object {
             "Id": "m1",
-            "Label": "P99 Integration Latency",
+            "Label": "P99.99",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -349,16 +949,56 @@ Object {
                     "Value": "$default",
                   },
                 ],
-                "MetricName": "IntegrationLatency",
+                "MetricName": "Latency",
                 "Namespace": "AWS/ApiGateway",
               },
               "Period": 300,
-              "Stat": "p99",
+              "Stat": "p99.99",
             },
             "ReturnData": true,
           },
         ],
-        "Threshold": 330,
+        "Threshold": 19999,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyP999Warning8CF0377D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P999 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-P999-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1999,
+        "EvaluationPeriods": 1999,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P99.9",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiId",
+                    "Value": Object {
+                      "Ref": "testHttpApiC57B300F",
+                    },
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "$default",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p99.9",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 1999,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -369,12 +1009,12 @@ Object {
         "AlarmDescription": "P99 latency is too high.",
         "AlarmName": "Test-DummyApi-Latency-P99-Warning",
         "ComparisonOperator": "GreaterThanThreshold",
-        "DatapointsToAlarm": 33,
-        "EvaluationPeriods": 33,
+        "DatapointsToAlarm": 199,
+        "EvaluationPeriods": 199,
         "Metrics": Array [
           Object {
             "Id": "m1",
-            "Label": "P99 Latency",
+            "Label": "P99",
             "MetricStat": Object {
               "Metric": Object {
                 "Dimensions": Array [
@@ -398,7 +1038,247 @@ Object {
             "ReturnData": true,
           },
         ],
-        "Threshold": 330,
+        "Threshold": 199,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyTM50Warning092E86BF": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM50 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-TM50-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 250,
+        "EvaluationPeriods": 250,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM50",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiId",
+                    "Value": Object {
+                      "Ref": "testHttpApiC57B300F",
+                    },
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "$default",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm50",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 250,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyTM70Warning8E657453": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM70 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-TM70-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 270,
+        "EvaluationPeriods": 270,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM70",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiId",
+                    "Value": Object {
+                      "Ref": "testHttpApiC57B300F",
+                    },
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "$default",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm70",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 270,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyTM90Warning0FDD3108": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM90 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-TM90-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 290,
+        "EvaluationPeriods": 290,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM90",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiId",
+                    "Value": Object {
+                      "Ref": "testHttpApiC57B300F",
+                    },
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "$default",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm90",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 290,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyTM9999Warning4181DE97": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM9999 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-TM9999-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 29999,
+        "EvaluationPeriods": 29999,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM99.99",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiId",
+                    "Value": Object {
+                      "Ref": "testHttpApiC57B300F",
+                    },
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "$default",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm99.99",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 29999,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyTM999WarningD73972C6": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM999 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-TM999-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 2999,
+        "EvaluationPeriods": 2999,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM99.9",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiId",
+                    "Value": Object {
+                      "Ref": "testHttpApiC57B300F",
+                    },
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "$default",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm99.9",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 2999,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyTM99WarningFF55C464": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM99 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-TM99-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 299,
+        "EvaluationPeriods": 299,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM99",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiId",
+                    "Value": Object {
+                      "Ref": "testHttpApiC57B300F",
+                    },
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "$default",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm99",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 299,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",


### PR DESCRIPTION
Introduces latency factory methods with latency type parameter in Api Gateway. It will be useful for creating trimmed-mean alarms, etc.

Closes #65
Closes #47

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_