### PR TITLE
fix(dynamo): limit metricSystemErrorsCount to previously defined operations

### DIFF
--- a/API.md
+++ b/API.md
@@ -37995,7 +37995,9 @@ public metricSystemErrorsCount(): Metric | MathExpression
 
 This represents the number of requests that resulted in a 500 (server error) error code.
 
-It summarizes across all operations.
+It summarizes across the basic CRUD operations:
+GetItem, BatchGetItem, Scan, Query, GetRecords, PutItem, DeleteItem, UpdateItem, BatchWriteItem
+
 It’s usually equal to zero.
 
 ##### `metricThrottledReadRequestCount` <a name="metricThrottledReadRequestCount" id="cdk-monitoring-constructs.DynamoTableMetricFactory.metricThrottledReadRequestCount"></a>

--- a/lib/monitoring/aws-dynamo/DynamoTableMetricFactory.ts
+++ b/lib/monitoring/aws-dynamo/DynamoTableMetricFactory.ts
@@ -148,14 +148,26 @@ export class DynamoTableMetricFactory {
 
   /**
    * This represents the number of requests that resulted in a 500 (server error) error code.
-   * It summarizes across all operations.
+   * It summarizes across the basic CRUD operations:
+   * GetItem, BatchGetItem, Scan, Query, GetRecords, PutItem, DeleteItem, UpdateItem, BatchWriteItem
+   *
    * It’s usually equal to zero.
    */
   metricSystemErrorsCount() {
-    const allOperations = Object.values(Operation);
+    const crudOperations = [
+      Operation.GET_ITEM,
+      Operation.BATCH_GET_ITEM,
+      Operation.SCAN,
+      Operation.QUERY,
+      Operation.GET_RECORDS,
+      Operation.PUT_ITEM,
+      Operation.DELETE_ITEM,
+      Operation.UPDATE_ITEM,
+      Operation.BATCH_WRITE_ITEM,
+    ];
     const usingMetrics: Record<string, IMetric> = {};
 
-    allOperations.forEach((operation) => {
+    crudOperations.forEach((operation) => {
       const metric = this.table.metric("SystemErrors", {
         dimensions: { TableName: this.table.tableName, Operation: operation },
         statistic: MetricStatistic.SUM,


### PR DESCRIPTION
Fixes #48

This should unblock the CDK v2 upgrade.

If we want to support the other operations, we can add more metrics/alarms configurations for those.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_