### PR TITLE
feat(dashboard): use INHERIT period by default

### DIFF
--- a/API.md
+++ b/API.md
@@ -24037,7 +24037,7 @@ public readonly detailDashboardPeriodOverride: PeriodOverride;
 ```
 
 - *Type:* aws-cdk-lib.aws_cloudwatch.PeriodOverride
-- *Default:* automatic (period dependent)
+- *Default:* respect individual graphs (PeriodOverride.INHERIT)
 
 Period override for the detail dashboard (and other auxiliary dashboards).
 
@@ -24065,7 +24065,7 @@ public readonly summaryDashboardPeriodOverride: PeriodOverride;
 ```
 
 - *Type:* aws-cdk-lib.aws_cloudwatch.PeriodOverride
-- *Default:* automatic (period dependent)
+- *Default:* respect individual graphs (PeriodOverride.INHERIT)
 
 Period override for the summary dashboard.
 

--- a/lib/dashboard/DefaultDashboardFactory.ts
+++ b/lib/dashboard/DefaultDashboardFactory.ts
@@ -42,7 +42,7 @@ export interface MonitoringDashboardsProps {
   readonly detailDashboardRange?: Duration;
   /**
    * Period override for the detail dashboard (and other auxiliary dashboards).
-   * @default automatic (period dependent)
+   * @default respect individual graphs (PeriodOverride.INHERIT)
    */
   readonly detailDashboardPeriodOverride?: PeriodOverride;
   /**
@@ -52,7 +52,7 @@ export interface MonitoringDashboardsProps {
   readonly summaryDashboardRange?: Duration;
   /**
    * Period override for the summary dashboard.
-   * @default automatic (period dependent)
+   * @default respect individual graphs (PeriodOverride.INHERIT)
    */
   readonly summaryDashboardPeriodOverride?: PeriodOverride;
   /**
@@ -102,7 +102,8 @@ export class DefaultDashboardFactory
         {
           dashboardName: props.dashboardNamePrefix,
           start: detailStart,
-          periodOverride: props.detailDashboardPeriodOverride,
+          periodOverride:
+            props.detailDashboardPeriodOverride ?? PeriodOverride.INHERIT,
         }
       );
     }
@@ -114,7 +115,8 @@ export class DefaultDashboardFactory
         {
           dashboardName: `${props.dashboardNamePrefix}-Summary`,
           start: summaryStart,
-          periodOverride: props.summaryDashboardPeriodOverride,
+          periodOverride:
+            props.summaryDashboardPeriodOverride ?? PeriodOverride.INHERIT,
         }
       );
     }
@@ -126,7 +128,8 @@ export class DefaultDashboardFactory
         {
           dashboardName: `${props.dashboardNamePrefix}-Alarms`,
           start: detailStart,
-          periodOverride: props.detailDashboardPeriodOverride,
+          periodOverride:
+            props.detailDashboardPeriodOverride ?? PeriodOverride.INHERIT,
         }
       );
     }

--- a/test/dashboard/__snapshots__/DefaultDashboardFactory.test.ts.snap
+++ b/test/dashboard/__snapshots__/DefaultDashboardFactory.test.ts.snap
@@ -12,21 +12,21 @@ Object {
   "Resources": Object {
     "DashboardsAlarmDashboard02C1603A": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
     },
     "DashboardsDashboard0712AF28": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard",
       },
       "Type": "AWS::CloudWatch::Dashboard",
     },
     "DashboardsSummaryDashboard1CD44475": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-P14D\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Summary",
       },
       "Type": "AWS::CloudWatch::Dashboard",

--- a/test/facade/__snapshots__/MonitoringAspect.test.ts.snap
+++ b/test/facade/__snapshots__/MonitoringAspect.test.ts.snap
@@ -12,7 +12,7 @@ Object {
   "Resources": Object {
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -23,7 +23,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Certificate **Default/DummyCertificate**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Expiration\\",\\"region\\":\\"",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Certificate **Default/DummyCertificate**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Expiration\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -41,7 +41,7 @@ Object {
     },
     "DashboardFactorySummaryDashboard5F4BC8C5": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-P14D\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Summary",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -130,7 +130,7 @@ Object {
   "Resources": Object {
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -141,7 +141,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### API Gateway Endpoint **DummyRestApi prod**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### API Gateway Endpoint **DummyRestApi prod**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -171,7 +171,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### API Gateway Endpoint **DummyRestApi prod**\\"}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### API Gateway Endpoint **DummyRestApi prod**\\"}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -331,7 +331,7 @@ Object {
   "Resources": Object {
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -342,7 +342,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### API Gateway V2 HTTP Endpoint **",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### API Gateway V2 HTTP Endpoint **",
               Object {
                 "Ref": "DummyHttpApi8EEBCC85",
               },
@@ -420,7 +420,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### API Gateway V2 HTTP Endpoint **",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### API Gateway V2 HTTP Endpoint **",
               Object {
                 "Ref": "DummyHttpApi8EEBCC85",
               },
@@ -540,7 +540,7 @@ Object {
   "Resources": Object {
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -551,7 +551,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### AppSync GraphQL API **Default/DummyGraphqlApi**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### AppSync GraphQL API **Default/DummyGraphqlApi**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -637,7 +637,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### AppSync GraphQL API **Default/DummyGraphqlApi**\\"}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### AppSync GraphQL API **Default/DummyGraphqlApi**\\"}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -902,7 +902,7 @@ Object {
     },
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -913,7 +913,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Auto Scaling Group **ASG**\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Group Size\\",\\"region\\":\\"",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Auto Scaling Group **ASG**\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Group Size\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -967,7 +967,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Auto Scaling Group **ASG**\\"}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Group Size\\",\\"region\\":\\"",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Auto Scaling Group **ASG**\\"}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Group Size\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -1421,21 +1421,21 @@ Object {
   "Resources": Object {
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
     },
     "DashboardFactoryDashboard3E20AD6E": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### AWS Account Billing **Billing**\\"}},{\\"type\\":\\"metric\\",\\"width\\":18,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"bar\\",\\"title\\":\\"Most Expensive Services (USD)\\",\\"region\\":\\"us-east-1\\",\\"metrics\\":[[{\\"label\\":\\" \\",\\"region\\":\\"us-east-1\\",\\"expression\\":\\"SORT(search, MAX, DESC, 10)\\",\\"period\\":86400}],[{\\"label\\":\\" \\",\\"region\\":\\"us-east-1\\",\\"expression\\":\\"SEARCH('{AWS/Billing,Currency,ServiceName} MetricName=\\\\\\"EstimatedCharges\\\\\\"', 'Maximum', 86400)\\",\\"period\\":86400,\\"visible\\":false,\\"id\\":\\"search\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"USD\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":1,\\"properties\\":{\\"view\\":\\"singleValue\\",\\"title\\":\\"Total Cost (USD)\\",\\"region\\":\\"us-east-1\\",\\"metrics\\":[[\\"AWS/Billing\\",\\"EstimatedCharges\\",\\"Currency\\",\\"USD\\",{\\"label\\":\\"Estimated Charges\\",\\"region\\":\\"us-east-1\\",\\"period\\":86400,\\"stat\\":\\"Maximum\\"}]],\\"setPeriodToTimeRange\\":false,\\"singleValueFullPrecision\\":false}}]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### AWS Account Billing **Billing**\\"}},{\\"type\\":\\"metric\\",\\"width\\":18,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"bar\\",\\"title\\":\\"Most Expensive Services (USD)\\",\\"region\\":\\"us-east-1\\",\\"metrics\\":[[{\\"label\\":\\" \\",\\"region\\":\\"us-east-1\\",\\"expression\\":\\"SORT(search, MAX, DESC, 10)\\",\\"period\\":86400}],[{\\"label\\":\\" \\",\\"region\\":\\"us-east-1\\",\\"expression\\":\\"SEARCH('{AWS/Billing,Currency,ServiceName} MetricName=\\\\\\"EstimatedCharges\\\\\\"', 'Maximum', 86400)\\",\\"period\\":86400,\\"visible\\":false,\\"id\\":\\"search\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"USD\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":1,\\"properties\\":{\\"view\\":\\"singleValue\\",\\"title\\":\\"Total Cost (USD)\\",\\"region\\":\\"us-east-1\\",\\"metrics\\":[[\\"AWS/Billing\\",\\"EstimatedCharges\\",\\"Currency\\",\\"USD\\",{\\"label\\":\\"Estimated Charges\\",\\"region\\":\\"us-east-1\\",\\"period\\":86400,\\"stat\\":\\"Maximum\\"}]],\\"setPeriodToTimeRange\\":false,\\"singleValueFullPrecision\\":false}}]}",
         "DashboardName": "DummyDashboard",
       },
       "Type": "AWS::CloudWatch::Dashboard",
     },
     "DashboardFactorySummaryDashboard5F4BC8C5": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### AWS Account Billing **Billing**\\"}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"singleValue\\",\\"title\\":\\"Total Cost (USD)\\",\\"region\\":\\"us-east-1\\",\\"metrics\\":[[\\"AWS/Billing\\",\\"EstimatedCharges\\",\\"Currency\\",\\"USD\\",{\\"label\\":\\"Estimated Charges\\",\\"region\\":\\"us-east-1\\",\\"period\\":86400,\\"stat\\":\\"Maximum\\"}]],\\"setPeriodToTimeRange\\":false,\\"singleValueFullPrecision\\":false}}]}",
+        "DashboardBody": "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### AWS Account Billing **Billing**\\"}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"singleValue\\",\\"title\\":\\"Total Cost (USD)\\",\\"region\\":\\"us-east-1\\",\\"metrics\\":[[\\"AWS/Billing\\",\\"EstimatedCharges\\",\\"Currency\\",\\"USD\\",{\\"label\\":\\"Estimated Charges\\",\\"region\\":\\"us-east-1\\",\\"period\\":86400,\\"stat\\":\\"Maximum\\"}]],\\"setPeriodToTimeRange\\":false,\\"singleValueFullPrecision\\":false}}]}",
         "DashboardName": "DummyDashboard-Summary",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -1677,7 +1677,7 @@ Object {
     },
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -1688,7 +1688,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Synthetics Canary **Canary**\\"}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Synthetics Canary **Canary**\\"}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -1758,7 +1758,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Synthetics Canary **Canary**\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors\\",\\"region\\":\\"",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Synthetics Canary **Canary**\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -1901,7 +1901,7 @@ Object {
     },
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -1912,7 +1912,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### S3 Bucket **[Bucket](https://s3.console.aws.amazon.com/s3/buckets/",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### S3 Bucket **[Bucket](https://s3.console.aws.amazon.com/s3/buckets/",
               Object {
                 "Ref": "Bucket83908E77",
               },
@@ -1994,7 +1994,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### S3 Bucket **[Bucket](https://s3.console.aws.amazon.com/s3/buckets/",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### S3 Bucket **[Bucket](https://s3.console.aws.amazon.com/s3/buckets/",
               Object {
                 "Ref": "Bucket83908E77",
               },
@@ -2141,7 +2141,7 @@ Object {
   "Resources": Object {
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -2152,7 +2152,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### CodeBuild Project **[DummyProject](https://",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### CodeBuild Project **[DummyProject](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -2218,7 +2218,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### CodeBuild Project **[DummyProject](https://",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### CodeBuild Project **[DummyProject](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -2475,7 +2475,7 @@ Object {
   "Resources": Object {
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -2486,7 +2486,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Dynamo Table **[DummyTable](https://",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Dynamo Table **[DummyTable](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -2596,7 +2596,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Dynamo Table **[DummyTable](https://",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Dynamo Table **[DummyTable](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -2710,7 +2710,7 @@ Object {
   "Resources": Object {
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -2721,7 +2721,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### EC2 **All Instances**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CPU Utilization\\",\\"region\\":\\"",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### EC2 **All Instances**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CPU Utilization\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -2751,7 +2751,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### EC2 **All Instances**\\"}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CPU Utilization\\",\\"region\\":\\"",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### EC2 **All Instances**\\"}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CPU Utilization\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -3305,7 +3305,7 @@ Object {
   "Resources": Object {
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -3316,7 +3316,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### ElastiCache Cluster **Memcached-ALL**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CPU Utilization\\",\\"region\\":\\"",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### ElastiCache Cluster **Memcached-ALL**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CPU Utilization\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -3362,7 +3362,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### ElastiCache Cluster **Memcached-ALL**\\"}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CPU Utilization\\",\\"region\\":\\"",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### ElastiCache Cluster **Memcached-ALL**\\"}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CPU Utilization\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -3445,7 +3445,7 @@ Object {
   "Resources": Object {
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -3456,7 +3456,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Glue Job **DummyJob**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Job Execution\\",\\"region\\":\\"",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Glue Job **DummyJob**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Job Execution\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -3490,7 +3490,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Glue Job **DummyJob**\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Job Execution\\",\\"region\\":\\"",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Glue Job **DummyJob**\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Job Execution\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -3561,7 +3561,7 @@ Object {
   "Resources": Object {
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -3572,7 +3572,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Kinesis Data Analytics **[Default/DummyAnalyticsApplication](https://",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Kinesis Data Analytics **[Default/DummyAnalyticsApplication](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -3626,7 +3626,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Kinesis Data Analytics **[Default/DummyAnalyticsApplication](https://",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Kinesis Data Analytics **[Default/DummyAnalyticsApplication](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -3744,7 +3744,7 @@ Object {
   "Resources": Object {
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -3755,7 +3755,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Kinesis Data Stream **[Default/DummyStream/Resource](https://",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Kinesis Data Stream **[Default/DummyStream/Resource](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -3805,7 +3805,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Kinesis Data Stream **[Default/DummyStream/Resource](https://",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Kinesis Data Stream **[Default/DummyStream/Resource](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -3902,7 +3902,7 @@ Object {
   "Resources": Object {
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -3913,7 +3913,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Firehose Delivery Stream **[Default/DummyDeliveryStream](https://",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Firehose Delivery Stream **[Default/DummyDeliveryStream](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -3947,7 +3947,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Firehose Delivery Stream **[Default/DummyDeliveryStream](https://",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Firehose Delivery Stream **[Default/DummyDeliveryStream](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -4017,7 +4017,7 @@ Object {
   "Resources": Object {
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -4028,7 +4028,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Lambda Function **[DummyFunction](https://",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Lambda Function **[DummyFunction](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -4126,7 +4126,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Lambda Function **[DummyFunction](https://",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Lambda Function **[DummyFunction](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -4271,7 +4271,7 @@ Object {
   "Resources": Object {
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -4282,7 +4282,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Elasticsearch Domain **[DummyOSDomain](https://",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Elasticsearch Domain **[DummyOSDomain](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -4880,7 +4880,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Elasticsearch Domain **[DummyOSDomain](https://",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Elasticsearch Domain **[DummyOSDomain](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -5414,7 +5414,7 @@ Object {
   "Resources": Object {
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -5425,7 +5425,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### RDS Cluster **[Default/DummyDBCluster](https://",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### RDS Cluster **[Default/DummyDBCluster](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -5557,7 +5557,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### RDS Cluster **[Default/DummyDBCluster](https://",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### RDS Cluster **[Default/DummyDBCluster](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -6499,7 +6499,7 @@ Object {
   "Resources": Object {
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -6510,7 +6510,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Redshift Cluster **[Default/DummyCluster](https://",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Redshift Cluster **[Default/DummyCluster](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -6592,7 +6592,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Redshift Cluster **[Default/DummyCluster](https://",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Redshift Cluster **[Default/DummyCluster](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -7134,7 +7134,7 @@ Object {
   "Resources": Object {
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -7145,7 +7145,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### S3 Bucket **[DummyBucket](https://s3.console.aws.amazon.com/s3/buckets/",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### S3 Bucket **[DummyBucket](https://s3.console.aws.amazon.com/s3/buckets/",
               Object {
                 "Ref": "DummyBucket7EFB6D9F",
               },
@@ -7183,7 +7183,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### S3 Bucket **[DummyBucket](https://s3.console.aws.amazon.com/s3/buckets/",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### S3 Bucket **[DummyBucket](https://s3.console.aws.amazon.com/s3/buckets/",
               Object {
                 "Ref": "DummyBucket7EFB6D9F",
               },
@@ -7263,7 +7263,7 @@ Object {
   "Resources": Object {
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -7274,7 +7274,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### SNS Topic **[DummyTopic](https://",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### SNS Topic **[DummyTopic](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -7340,7 +7340,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### SNS Topic **[DummyTopic](https://",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### SNS Topic **[DummyTopic](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -7435,7 +7435,7 @@ Object {
   "Resources": Object {
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -7446,7 +7446,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### SQS Queue **[DummyQueue](https://",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### SQS Queue **[DummyQueue](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -7555,7 +7555,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### SQS Queue **[DummyQueue](https://",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### SQS Queue **[DummyQueue](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -7695,7 +7695,7 @@ Object {
   "Resources": Object {
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -7706,7 +7706,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Secret **DummySecret**\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Days since last change\\",\\"region\\":\\"",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Secret **DummySecret**\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Days since last change\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -7778,7 +7778,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Secret **DummySecret**\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Days since last change\\",\\"region\\":\\"",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Secret **DummySecret**\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Days since last change\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -7989,7 +7989,7 @@ Object {
   "Resources": Object {
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -8000,7 +8000,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### State Machine **[DummyStateMachine](https://",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### State Machine **[DummyStateMachine](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -8078,7 +8078,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### State Machine **[DummyStateMachine](https://",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### State Machine **[DummyStateMachine](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -8225,7 +8225,7 @@ Object {
   "Resources": Object {
     "DashboardFactoryAlarmDashboard6286FAD3": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[]}",
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Alarms",
       },
       "Type": "AWS::CloudWatch::Dashboard",
@@ -8236,7 +8236,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Web Application Firewall **DummyAcl**\\"}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Allowed Requests\\",\\"region\\":\\"",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Web Application Firewall **DummyAcl**\\"}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Allowed Requests\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -8262,7 +8262,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Web Application Firewall **DummyAcl**\\"}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Allowed Requests\\",\\"region\\":\\"",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Web Application Firewall **DummyAcl**\\"}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Allowed Requests\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },


### PR DESCRIPTION
We should set INHERIT by default to ensure that every graph has the preferred time resolution instead of the AUTO one (which can be 5m or 1h based on the range). It is better to have it set like this, since it will better correspond to alarms.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_