### PR TITLE
chore(lint): add cdk-nag linter

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -45,6 +45,10 @@
       "type": "build"
     },
     {
+      "name": "cdk-nag",
+      "type": "build"
+    },
+    {
       "name": "constructs",
       "version": "10.0.5",
       "type": "build"

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -342,7 +342,7 @@
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @aws-cdk/aws-apigatewayv2-alpha @aws-cdk/aws-appsync-alpha @aws-cdk/aws-redshift-alpha @aws-cdk/aws-synthetics-alpha @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-cdk-lib constructs eslint-config-prettier eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint jest jest-junit jsii jsii-diff jsii-docgen json-schema npm-check-updates prettier standard-version ts-jest typescript @aws-cdk/aws-apigatewayv2-alpha @aws-cdk/aws-appsync-alpha @aws-cdk/aws-redshift-alpha @aws-cdk/aws-synthetics-alpha @aws-cdk/aws-apigatewayv2-alpha @aws-cdk/aws-appsync-alpha @aws-cdk/aws-redshift-alpha @aws-cdk/aws-synthetics-alpha aws-cdk-lib constructs"
+          "exec": "yarn upgrade @aws-cdk/aws-apigatewayv2-alpha @aws-cdk/aws-appsync-alpha @aws-cdk/aws-redshift-alpha @aws-cdk/aws-synthetics-alpha @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser aws-cdk-lib cdk-nag constructs eslint-config-prettier eslint-import-resolver-node eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint jest jest-junit jsii jsii-diff jsii-docgen json-schema npm-check-updates prettier standard-version ts-jest typescript @aws-cdk/aws-apigatewayv2-alpha @aws-cdk/aws-appsync-alpha @aws-cdk/aws-redshift-alpha @aws-cdk/aws-synthetics-alpha @aws-cdk/aws-apigatewayv2-alpha @aws-cdk/aws-appsync-alpha @aws-cdk/aws-redshift-alpha @aws-cdk/aws-synthetics-alpha aws-cdk-lib constructs"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -21,6 +21,9 @@ const project = new awscdk.AwsCdkConstructLibrary({
 
   cdkVersion: CDK_VERSION,
 
+  // additional linters
+  devDeps: ["cdk-nag"],
+
   srcdir: "lib",
   testdir: "test",
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
     "aws-cdk-lib": "2.18.0",
+    "cdk-nag": "^2.12.13",
     "constructs": "10.0.5",
     "eslint": "^8",
     "eslint-config-prettier": "^8.5.0",

--- a/test/monitoring/aws-glue/GlueJobMonitoring.test.ts
+++ b/test/monitoring/aws-glue/GlueJobMonitoring.test.ts
@@ -2,6 +2,7 @@ import { Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
 
 import { AlarmWithAnnotation, GlueJobMonitoring } from "../../../lib";
+import { lintStack } from "../../utils/LintUtil";
 import { addMonitoringDashboardsToStack } from "../../utils/SnapshotUtil";
 import { TestMonitoringScope } from "../TestMonitoringScope";
 
@@ -15,6 +16,7 @@ test("snapshot test: no alarms", () => {
   });
 
   addMonitoringDashboardsToStack(stack, monitoring);
+  lintStack(stack);
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });
 
@@ -57,5 +59,6 @@ test("snapshot test: all alarms", () => {
 
   expect(numAlarmsCreated).toStrictEqual(4);
   addMonitoringDashboardsToStack(stack, monitoring);
+  lintStack(stack);
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });

--- a/test/monitoring/aws-kinesis/KinesisDataStreamMonitoring.test.ts
+++ b/test/monitoring/aws-kinesis/KinesisDataStreamMonitoring.test.ts
@@ -2,6 +2,7 @@ import { Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
 
 import { KinesisDataStreamMonitoring } from "../../../lib";
+import { lintStack } from "../../utils/LintUtil";
 import { addMonitoringDashboardsToStack } from "../../utils/SnapshotUtil";
 import { TestMonitoringScope } from "../TestMonitoringScope";
 
@@ -15,6 +16,7 @@ test("snapshot test for stream: no alarms", () => {
   });
 
   addMonitoringDashboardsToStack(stack, monitoring);
+  lintStack(stack);
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });
 
@@ -61,5 +63,6 @@ test("snapshot test for stream: all alarms", () => {
 
   expect(numAlarmsCreated).toStrictEqual(5);
   addMonitoringDashboardsToStack(stack, monitoring);
+  lintStack(stack);
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });

--- a/test/monitoring/aws-synthetics/SyntheticsCanaryMonitoring.test.ts
+++ b/test/monitoring/aws-synthetics/SyntheticsCanaryMonitoring.test.ts
@@ -10,6 +10,7 @@ import { Template } from "aws-cdk-lib/assertions";
 
 import { AlarmWithAnnotation } from "../../../lib";
 import { SyntheticsCanaryMonitoring } from "../../../lib/monitoring/aws-synthetics";
+import { lintStack } from "../../utils/LintUtil";
 import { addMonitoringDashboardsToStack } from "../../utils/SnapshotUtil";
 import { TestMonitoringScope } from "../TestMonitoringScope";
 
@@ -29,6 +30,7 @@ test("snapshot test: no alarms", () => {
   const monitoring = new SyntheticsCanaryMonitoring(scope, { canary });
 
   addMonitoringDashboardsToStack(stack, monitoring);
+  lintStack(stack);
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });
 
@@ -83,5 +85,6 @@ test("snapshot test: all alarms", () => {
 
   expect(numAlarmsCreated).toStrictEqual(5);
   addMonitoringDashboardsToStack(stack, monitoring);
+  lintStack(stack);
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });

--- a/test/monitoring/aws-wafv2/WafV2Monitoring.test.ts
+++ b/test/monitoring/aws-wafv2/WafV2Monitoring.test.ts
@@ -3,6 +3,7 @@ import { Template } from "aws-cdk-lib/assertions";
 import { CfnWebACL } from "aws-cdk-lib/aws-wafv2";
 
 import { WafV2Monitoring } from "../../../lib";
+import { lintStack } from "../../utils/LintUtil";
 import { addMonitoringDashboardsToStack } from "../../utils/SnapshotUtil";
 import { TestMonitoringScope } from "../TestMonitoringScope";
 
@@ -23,5 +24,6 @@ test("snapshot test: no alarms", () => {
   const monitoring = new WafV2Monitoring(scope, { acl });
 
   addMonitoringDashboardsToStack(stack, monitoring);
+  lintStack(stack);
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });

--- a/test/utils/LintUtil.ts
+++ b/test/utils/LintUtil.ts
@@ -1,0 +1,18 @@
+import { Aspects, Stack } from "aws-cdk-lib";
+import {
+  AwsSolutionsChecks,
+  HIPAASecurityChecks,
+  NIST80053R5Checks,
+  PCIDSS321Checks,
+} from "cdk-nag";
+
+/**
+ * Executes the automatic linters on the given stack.
+ * @param stack stack to lint
+ */
+export function lintStack(stack: Stack) {
+  Aspects.of(stack).add(new AwsSolutionsChecks({ verbose: true }));
+  Aspects.of(stack).add(new NIST80053R5Checks({ verbose: true }));
+  Aspects.of(stack).add(new HIPAASecurityChecks({ verbose: true }));
+  Aspects.of(stack).add(new PCIDSS321Checks({ verbose: true }));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1388,6 +1388,11 @@ case@1.6.3, case@^1.6.3:
   resolved "https://registry.yarnpkg.com/case/-/case-1.6.3.tgz#0a4386e3e9825351ca2e6216c60467ff5f1ea1c9"
   integrity sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==
 
+cdk-nag@^2.12.13:
+  version "2.12.13"
+  resolved "https://amazon.goshawk.aws.a2z.com:443/npm/shared/cdk-nag/-/cdk-nag-2.12.13.tgz#b54fbde5d5370b45b02954b9616b0215cb176048"
+  integrity sha512-EGwN6E3ri1ebnsMVh4YE01UUGNBlDfntpbDlWZ+OGLB6rB7wAABbaOmbN9v3qg1sodHpyLCEfmZl230EnoB4Cw==
+
 chalk@^2.0.0, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"


### PR DESCRIPTION
Adds the CDK Nag linter. It does not check the source, but the construct tree present in a stack.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_