### PR TITLE
fix(elasticsearch/opensearch): fix ClusterIndexWritesBlocked metric name

### DIFF
--- a/API.md
+++ b/API.md
@@ -43333,6 +43333,7 @@ new OpenSearchBackportedMetrics(domain: IDomain | CfnDomain | IDomain | CfnDomai
 | <code><a href="#cdk-monitoring-constructs.OpenSearchBackportedMetrics.metric">metric</a></code> | Return the given named metric for this Domain. |
 | <code><a href="#cdk-monitoring-constructs.OpenSearchBackportedMetrics.metricAutomatedSnapshotFailure">metricAutomatedSnapshotFailure</a></code> | Metric for automated snapshot failures. |
 | <code><a href="#cdk-monitoring-constructs.OpenSearchBackportedMetrics.metricClusterIndexWriteBlocked">metricClusterIndexWriteBlocked</a></code> | Metric for the cluster blocking index writes. |
+| <code><a href="#cdk-monitoring-constructs.OpenSearchBackportedMetrics.metricClusterIndexWritesBlocked">metricClusterIndexWritesBlocked</a></code> | Metric for the cluster blocking index writes. |
 | <code><a href="#cdk-monitoring-constructs.OpenSearchBackportedMetrics.metricClusterStatusRed">metricClusterStatusRed</a></code> | Metric for the time the cluster status is red. |
 | <code><a href="#cdk-monitoring-constructs.OpenSearchBackportedMetrics.metricClusterStatusYellow">metricClusterStatusYellow</a></code> | Metric for the time the cluster status is yellow. |
 | <code><a href="#cdk-monitoring-constructs.OpenSearchBackportedMetrics.metricCPUUtilization">metricCPUUtilization</a></code> | Metric for CPU utilization. |
@@ -43383,7 +43384,7 @@ Metric for automated snapshot failures.
 
 ---
 
-##### `metricClusterIndexWriteBlocked` <a name="metricClusterIndexWriteBlocked" id="cdk-monitoring-constructs.OpenSearchBackportedMetrics.metricClusterIndexWriteBlocked"></a>
+##### ~~`metricClusterIndexWriteBlocked`~~ <a name="metricClusterIndexWriteBlocked" id="cdk-monitoring-constructs.OpenSearchBackportedMetrics.metricClusterIndexWriteBlocked"></a>
 
 ```typescript
 public metricClusterIndexWriteBlocked(props?: MetricOptions): Metric
@@ -43392,6 +43393,20 @@ public metricClusterIndexWriteBlocked(props?: MetricOptions): Metric
 Metric for the cluster blocking index writes.
 
 ###### `props`<sup>Optional</sup> <a name="props" id="cdk-monitoring-constructs.OpenSearchBackportedMetrics.metricClusterIndexWriteBlocked.parameter.props"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.MetricOptions
+
+---
+
+##### `metricClusterIndexWritesBlocked` <a name="metricClusterIndexWritesBlocked" id="cdk-monitoring-constructs.OpenSearchBackportedMetrics.metricClusterIndexWritesBlocked"></a>
+
+```typescript
+public metricClusterIndexWritesBlocked(props?: MetricOptions): Metric
+```
+
+Metric for the cluster blocking index writes.
+
+###### `props`<sup>Optional</sup> <a name="props" id="cdk-monitoring-constructs.OpenSearchBackportedMetrics.metricClusterIndexWritesBlocked.parameter.props"></a>
 
 - *Type:* aws-cdk-lib.aws_cloudwatch.MetricOptions
 
@@ -43799,6 +43814,7 @@ new OpenSearchClusterMetricFactory(metricFactory: MetricFactory, props: OpenSear
 | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.OpenSearchClusterMetricFactory.metricAutomatedSnapshotFailure">metricAutomatedSnapshotFailure</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.OpenSearchClusterMetricFactory.metricClusterIndexWriteBlocked">metricClusterIndexWriteBlocked</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.OpenSearchClusterMetricFactory.metricClusterIndexWritesBlocked">metricClusterIndexWritesBlocked</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.OpenSearchClusterMetricFactory.metricClusterStatusRed">metricClusterStatusRed</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.OpenSearchClusterMetricFactory.metricClusterStatusYellow">metricClusterStatusYellow</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.OpenSearchClusterMetricFactory.metricCpuUsage">metricCpuUsage</a></code> | *No description.* |
@@ -43827,10 +43843,16 @@ new OpenSearchClusterMetricFactory(metricFactory: MetricFactory, props: OpenSear
 public metricAutomatedSnapshotFailure(): Metric | MathExpression
 ```
 
-##### `metricClusterIndexWriteBlocked` <a name="metricClusterIndexWriteBlocked" id="cdk-monitoring-constructs.OpenSearchClusterMetricFactory.metricClusterIndexWriteBlocked"></a>
+##### ~~`metricClusterIndexWriteBlocked`~~ <a name="metricClusterIndexWriteBlocked" id="cdk-monitoring-constructs.OpenSearchClusterMetricFactory.metricClusterIndexWriteBlocked"></a>
 
 ```typescript
 public metricClusterIndexWriteBlocked(): Metric | MathExpression
+```
+
+##### `metricClusterIndexWritesBlocked` <a name="metricClusterIndexWritesBlocked" id="cdk-monitoring-constructs.OpenSearchClusterMetricFactory.metricClusterIndexWritesBlocked"></a>
+
+```typescript
+public metricClusterIndexWritesBlocked(): Metric | MathExpression
 ```
 
 ##### `metricClusterStatusRed` <a name="metricClusterStatusRed" id="cdk-monitoring-constructs.OpenSearchClusterMetricFactory.metricClusterStatusRed"></a>

--- a/lib/monitoring/aws-opensearch/OpenSearchBackportedMetrics.ts
+++ b/lib/monitoring/aws-opensearch/OpenSearchBackportedMetrics.ts
@@ -87,12 +87,23 @@ export class OpenSearchBackportedMetrics {
    *
    * @default maximum over 1 minute
    */
-  metricClusterIndexWriteBlocked(props?: MetricOptions): Metric {
-    return this.metric("ClusterIndexWriteBlocked", {
+  metricClusterIndexWritesBlocked(props?: MetricOptions): Metric {
+    return this.metric("ClusterIndexWritesBlocked", {
       statistic: Statistic.MAXIMUM,
       period: Duration.minutes(1),
       ...props,
     });
+  }
+
+  /**
+   * Metric for the cluster blocking index writes.
+   *
+   * @default maximum over 1 minute
+   *
+   * @deprecated use metricClusterIndexWritesBlocked instead.
+   */
+  metricClusterIndexWriteBlocked(props?: MetricOptions): Metric {
+    return this.metricClusterIndexWritesBlocked(props);
   }
 
   /**

--- a/lib/monitoring/aws-opensearch/OpenSearchClusterMetricFactory.ts
+++ b/lib/monitoring/aws-opensearch/OpenSearchClusterMetricFactory.ts
@@ -184,12 +184,19 @@ export class OpenSearchClusterMetricFactory {
     );
   }
 
-  metricClusterIndexWriteBlocked() {
+  metricClusterIndexWritesBlocked() {
     return this.metricFactory.adaptMetric(
-      this.domainMetrics.metricClusterIndexWriteBlocked({
+      this.domainMetrics.metricClusterIndexWritesBlocked({
         label: "Index Writes Blocked",
       })
     );
+  }
+
+  /**
+   * @deprecated use metricClusterIndexWritesBlocked instead
+   */
+  metricClusterIndexWriteBlocked() {
+    return this.metricClusterIndexWritesBlocked();
   }
 
   metricNodes() {

--- a/lib/monitoring/aws-opensearch/OpenSearchClusterMonitoring.ts
+++ b/lib/monitoring/aws-opensearch/OpenSearchClusterMonitoring.ts
@@ -183,7 +183,7 @@ export class OpenSearchClusterMonitoring extends Monitoring {
     this.masterJvmMemoryPressureMetric =
       metricFactory.metricMasterJvmMemoryPressure();
     this.indexWriteBlockedMetric =
-      metricFactory.metricClusterIndexWriteBlocked();
+      metricFactory.metricClusterIndexWritesBlocked();
     this.nodesMetric = metricFactory.metricNodes();
     this.automatedSnapshotFailureMetric =
       metricFactory.metricAutomatedSnapshotFailure();

--- a/test/facade/__snapshots__/MonitoringAspect.test.ts.snap
+++ b/test/facade/__snapshots__/MonitoringAspect.test.ts.snap
@@ -4438,7 +4438,7 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/ES\\",\\"ClusterIndexWriteBlocked\\",\\"ClientId\\",\\"",
+              "\\",\\"metrics\\":[[\\"AWS/ES\\",\\"ClusterIndexWritesBlocked\\",\\"ClientId\\",\\"",
               Object {
                 "Ref": "AWS::AccountId",
               },
@@ -4562,7 +4562,7 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/ES\\",\\"ClusterIndexWriteBlocked\\",\\"ClientId\\",\\"",
+              "\\",\\"metrics\\":[[\\"AWS/ES\\",\\"ClusterIndexWritesBlocked\\",\\"ClientId\\",\\"",
               Object {
                 "Ref": "AWS::AccountId",
               },
@@ -4730,7 +4730,7 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/ES\\",\\"ClusterIndexWriteBlocked\\",\\"ClientId\\",\\"",
+              "\\",\\"metrics\\":[[\\"AWS/ES\\",\\"ClusterIndexWritesBlocked\\",\\"ClientId\\",\\"",
               Object {
                 "Ref": "AWS::AccountId",
               },
@@ -4854,7 +4854,7 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/ES\\",\\"ClusterIndexWriteBlocked\\",\\"ClientId\\",\\"",
+              "\\",\\"metrics\\":[[\\"AWS/ES\\",\\"ClusterIndexWritesBlocked\\",\\"ClientId\\",\\"",
               Object {
                 "Ref": "AWS::AccountId",
               },


### PR DESCRIPTION
As reported internally.

The correct metric name should be `ClusterIndexWritesBlocked` according to https://docs.aws.amazon.com/opensearch-service/latest/developerguide/cloudwatch-alarms.html

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_