### PR TITLE
chore: disable weekly dependency updates for monocdk branch

### DIFF
--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -3,8 +3,7 @@
 name: upgrade-main
 on:
   workflow_dispatch: {}
-  schedule:
-    - cron: 0 0 * * 1
+  schedule: []
 jobs:
   upgrade:
     name: Upgrade

--- a/.github/workflows/upgrade-monocdk.yml
+++ b/.github/workflows/upgrade-monocdk.yml
@@ -3,8 +3,7 @@
 name: upgrade-monocdk
 on:
   workflow_dispatch: {}
-  schedule:
-    - cron: 0 0 * * 1
+  schedule: []
 jobs:
   upgrade:
     name: Upgrade

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -54,9 +54,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   autoApproveUpgrades: true,
   depsUpgradeOptions: {
     workflowOptions: {
-      schedule: javascript.UpgradeDependenciesSchedule.expressions([
-        "0 0 * * 1",
-      ]),
+      schedule: javascript.UpgradeDependenciesSchedule.NEVER,
     },
   },
 


### PR DESCRIPTION
Since we're now in maintenance mode for monocdk (see #129), we no longer want weekly updates/releases.

We can still manually invoke the workflow if needed.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_