### PR TITLE
feat(cloudfront): allow disabling dashboard widgets based on additional metrics

### DIFF
--- a/API.md
+++ b/API.md
@@ -8125,6 +8125,7 @@ const cloudFrontDistributionMetricFactoryProps: CloudFrontDistributionMetricFact
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMetricFactoryProps.property.distribution">distribution</a></code> | <code>aws-cdk-lib.aws_cloudfront.IDistribution</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMetricFactoryProps.property.additionalMetricsEnabled">additionalMetricsEnabled</a></code> | <code>boolean</code> | Generate dashboard charts for additional CloudFront distribution metrics. |
 | <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMetricFactoryProps.property.fillTpsWithZeroes">fillTpsWithZeroes</a></code> | <code>boolean</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMetricFactoryProps.property.rateComputationMethod">rateComputationMethod</a></code> | <code><a href="#cdk-monitoring-constructs.RateComputationMethod">RateComputationMethod</a></code> | *No description.* |
 
@@ -8137,6 +8138,22 @@ public readonly distribution: IDistribution;
 ```
 
 - *Type:* aws-cdk-lib.aws_cloudfront.IDistribution
+
+---
+
+##### `additionalMetricsEnabled`<sup>Optional</sup> <a name="additionalMetricsEnabled" id="cdk-monitoring-constructs.CloudFrontDistributionMetricFactoryProps.property.additionalMetricsEnabled"></a>
+
+```typescript
+public readonly additionalMetricsEnabled: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Generate dashboard charts for additional CloudFront distribution metrics.
+
+To enable additional metrics on your CloudFront distribution, see
+https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/viewing-cloudfront-metrics.html#monitoring-console.distributions-additional
 
 ---
 
@@ -8299,6 +8316,7 @@ const cloudFrontDistributionMonitoringProps: CloudFrontDistributionMonitoringPro
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMonitoringProps.property.distribution">distribution</a></code> | <code>aws-cdk-lib.aws_cloudfront.IDistribution</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMonitoringProps.property.additionalMetricsEnabled">additionalMetricsEnabled</a></code> | <code>boolean</code> | Generate dashboard charts for additional CloudFront distribution metrics. |
 | <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMonitoringProps.property.fillTpsWithZeroes">fillTpsWithZeroes</a></code> | <code>boolean</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMonitoringProps.property.rateComputationMethod">rateComputationMethod</a></code> | <code><a href="#cdk-monitoring-constructs.RateComputationMethod">RateComputationMethod</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMonitoringProps.property.alarmFriendlyName">alarmFriendlyName</a></code> | <code>string</code> | Plain name, used in naming alarms. |
@@ -8322,6 +8340,22 @@ public readonly distribution: IDistribution;
 ```
 
 - *Type:* aws-cdk-lib.aws_cloudfront.IDistribution
+
+---
+
+##### `additionalMetricsEnabled`<sup>Optional</sup> <a name="additionalMetricsEnabled" id="cdk-monitoring-constructs.CloudFrontDistributionMonitoringProps.property.additionalMetricsEnabled"></a>
+
+```typescript
+public readonly additionalMetricsEnabled: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Generate dashboard charts for additional CloudFront distribution metrics.
+
+To enable additional metrics on your CloudFront distribution, see
+https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/viewing-cloudfront-metrics.html#monitoring-console.distributions-additional
 
 ---
 
@@ -37336,7 +37370,7 @@ new CloudFrontDistributionMetricFactory(metricFactory: MetricFactory, props: Clo
 | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMetricFactory.metric4xxErrorRateAverage">metric4xxErrorRateAverage</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMetricFactory.metric5xxErrorRateAverage">metric5xxErrorRateAverage</a></code> | *No description.* |
-| <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMetricFactory.metricCacheHitRateAverageInPercent">metricCacheHitRateAverageInPercent</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMetricFactory.metricCacheHitRateAverageInPercent">metricCacheHitRateAverageInPercent</a></code> | Cache hit rate metric. |
 | <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMetricFactory.metricRequestCount">metricRequestCount</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMetricFactory.metricRequestRate">metricRequestRate</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.CloudFrontDistributionMetricFactory.metricRequestTps">metricRequestTps</a></code> | *No description.* |
@@ -37363,6 +37397,12 @@ public metric5xxErrorRateAverage(): Metric | MathExpression
 ```typescript
 public metricCacheHitRateAverageInPercent(): Metric | MathExpression
 ```
+
+Cache hit rate metric.
+
+This is an additional metric that needs to be explicitly enabled for an additional cost.
+
+> [https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/viewing-cloudfront-metrics.html#monitoring-console.distributions-additional](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/viewing-cloudfront-metrics.html#monitoring-console.distributions-additional)
 
 ##### `metricRequestCount` <a name="metricRequestCount" id="cdk-monitoring-constructs.CloudFrontDistributionMetricFactory.metricRequestCount"></a>
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You can also browse the documentation at https://constructs.dev/packages/cdk-mon
 | Item | Monitoring | Alarms | Notes |
 | ---- | ---------- | ------ | ----- |
 | AWS API Gateway (REST API) (`.monitorApiGateway()`) | TPS, latency, errors | Latency, error count/rate |  To see metrics, you have to enable Advanced Monitoring |
-| AWS API Gateway V2 (HTTP API) (`.monitorApiGatewayV2HttpApi()`) | TPS, latency, errors | Latency, error count/rate | To see route level metrics, you have to enable Advanced Monitoring|
+| AWS API Gateway V2 (HTTP API) (`.monitorApiGatewayV2HttpApi()`) | TPS, latency, errors | Latency, error count/rate | To see route level metrics, you have to enable Advanced Monitoring |
 | AWS AppSync (GraphQL API) (`.monitorAppSyncApi()`) | TPS, latency, errors | Latency, error count/rate, low/high TPS | |
 | AWS Billing (`.monitorBilling()`) | AWS account cost | | [Requires enabling](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/gs_monitor_estimated_charges_with_cloudwatch.html#gs_turning_on_billing_metrics) the **Receive Billing Alerts** option in AWS Console / Billing Preferences |
 | AWS Certificate Manager (`.monitorCertificate()`) | Certificate expiration | Days until expiration | |

--- a/lib/monitoring/aws-cloudfront/CloudFrontDistributionMetricFactory.ts
+++ b/lib/monitoring/aws-cloudfront/CloudFrontDistributionMetricFactory.ts
@@ -13,14 +13,26 @@ const CloudFrontDefaultMetricRegion = "us-east-1";
 
 export interface CloudFrontDistributionMetricFactoryProps {
   readonly distribution: IDistribution;
+
   /**
    * @default true
    */
   readonly fillTpsWithZeroes?: boolean;
+
   /**
    * @default average
    */
   readonly rateComputationMethod?: RateComputationMethod;
+
+  /**
+   * Generate dashboard charts for additional CloudFront distribution metrics.
+   *
+   * To enable additional metrics on your CloudFront distribution, see
+   * https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/viewing-cloudfront-metrics.html#monitoring-console.distributions-additional
+   *
+   * @default true
+   */
+  readonly additionalMetricsEnabled?: boolean;
 }
 
 /**
@@ -109,6 +121,11 @@ export class CloudFrontDistributionMetricFactory {
       .with({ region: CloudFrontDefaultMetricRegion });
   }
 
+  /**
+   * Cache hit rate metric. This is an additional metric that needs to be explicitly enabled for an additional cost.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/viewing-cloudfront-metrics.html#monitoring-console.distributions-additional
+   */
   metricCacheHitRateAverageInPercent() {
     return this.metricFactory
       .createMetric(

--- a/test/monitoring/aws-cloudfront/CloudFrontDistribution.test.ts
+++ b/test/monitoring/aws-cloudfront/CloudFrontDistribution.test.ts
@@ -11,68 +11,72 @@ import {
 import { addMonitoringDashboardsToStack } from "../../utils/SnapshotUtil";
 import { TestMonitoringScope } from "../TestMonitoringScope";
 
-test("snapshot test: no alarms", () => {
-  const stack = new Stack();
-  const bucket = new Bucket(stack, "Bucket");
-  const distribution = new Distribution(stack, "Distribution", {
-    defaultBehavior: {
-      origin: new S3Origin(bucket),
-    },
+[undefined, true, false].forEach((additionalMetricsEnabled) => {
+  test(`snapshot test: no alarms with additionalMetricsEnabled=${additionalMetricsEnabled}`, () => {
+    const stack = new Stack();
+    const bucket = new Bucket(stack, "Bucket");
+    const distribution = new Distribution(stack, "Distribution", {
+      defaultBehavior: {
+        origin: new S3Origin(bucket),
+      },
+    });
+
+    const scope = new TestMonitoringScope(stack, "Scope");
+
+    const monitoring = new CloudFrontDistributionMonitoring(scope, {
+      distribution,
+      additionalMetricsEnabled,
+    });
+
+    addMonitoringDashboardsToStack(stack, monitoring);
+    expect(Template.fromStack(stack)).toMatchSnapshot();
   });
 
-  const scope = new TestMonitoringScope(stack, "Scope");
+  test(`snapshot test: all alarms with additionalMetricsEnabled=${additionalMetricsEnabled}`, () => {
+    const stack = new Stack();
+    const bucket = new Bucket(stack, "Bucket");
+    const distribution = new Distribution(stack, "Distribution", {
+      defaultBehavior: {
+        origin: new S3Origin(bucket),
+      },
+    });
 
-  const monitoring = new CloudFrontDistributionMonitoring(scope, {
-    distribution,
+    const scope = new TestMonitoringScope(stack, "Scope");
+
+    let numAlarmsCreated = 0;
+
+    const monitoring = new CloudFrontDistributionMonitoring(scope, {
+      distribution,
+      additionalMetricsEnabled,
+      addLowTpsAlarm: {
+        Warning: {
+          minTps: 10,
+        },
+      },
+      addHighTpsAlarm: {
+        Warning: {
+          maxTps: 20,
+        },
+      },
+      addError4xxRate: {
+        Warning: {
+          maxErrorRate: 0.5,
+        },
+      },
+      addFault5xxRate: {
+        Warning: {
+          maxErrorRate: 0.8,
+        },
+      },
+      useCreatedAlarms: {
+        consume(alarms: AlarmWithAnnotation[]) {
+          numAlarmsCreated = alarms.length;
+        },
+      },
+    });
+
+    addMonitoringDashboardsToStack(stack, monitoring);
+    expect(numAlarmsCreated).toStrictEqual(4);
+    expect(Template.fromStack(stack)).toMatchSnapshot();
   });
-
-  addMonitoringDashboardsToStack(stack, monitoring);
-  expect(Template.fromStack(stack)).toMatchSnapshot();
-});
-
-test("snapshot test: all alarms", () => {
-  const stack = new Stack();
-  const bucket = new Bucket(stack, "Bucket");
-  const distribution = new Distribution(stack, "Distribution", {
-    defaultBehavior: {
-      origin: new S3Origin(bucket),
-    },
-  });
-
-  const scope = new TestMonitoringScope(stack, "Scope");
-
-  let numAlarmsCreated = 0;
-
-  const monitoring = new CloudFrontDistributionMonitoring(scope, {
-    distribution,
-    addLowTpsAlarm: {
-      Warning: {
-        minTps: 10,
-      },
-    },
-    addHighTpsAlarm: {
-      Warning: {
-        maxTps: 20,
-      },
-    },
-    addError4xxRate: {
-      Warning: {
-        maxErrorRate: 0.5,
-      },
-    },
-    addFault5xxRate: {
-      Warning: {
-        maxErrorRate: 0.8,
-      },
-    },
-    useCreatedAlarms: {
-      consume(alarms: AlarmWithAnnotation[]) {
-        numAlarmsCreated = alarms.length;
-      },
-    },
-  });
-
-  addMonitoringDashboardsToStack(stack, monitoring);
-  expect(numAlarmsCreated).toStrictEqual(4);
-  expect(Template.fromStack(stack)).toMatchSnapshot();
 });

--- a/test/monitoring/aws-cloudfront/__snapshots__/CloudFrontDistribution.test.ts.snap
+++ b/test/monitoring/aws-cloudfront/__snapshots__/CloudFrontDistribution.test.ts.snap
@@ -1,6 +1,452 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`snapshot test: all alarms 1`] = `
+exports[`snapshot test: all alarms with additionalMetricsEnabled=false 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "Alarm7103F465": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDistributionMinTPSWarning6CB7ACEE",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":6,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDistributionMaxTPSWarningAC289EB2",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":12,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDistributionErrorRateWarning079D566A",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":18,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDistributionFaultRateWarning02013C05",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "Bucket83908E77": Object {
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "BucketPolicyE9A3008A": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "Bucket83908E77",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Principal": Object {
+                "CanonicalUser": Object {
+                  "Fn::GetAtt": Array [
+                    "DistributionOrigin1S3Origin5F5C0696",
+                    "S3CanonicalUserId",
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "Distribution830FAC52": Object {
+      "Properties": Object {
+        "DistributionConfig": Object {
+          "DefaultCacheBehavior": Object {
+            "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+            "Compress": true,
+            "TargetOriginId": "DistributionOrigin13547B94F",
+            "ViewerProtocolPolicy": "allow-all",
+          },
+          "Enabled": true,
+          "HttpVersion": "http2",
+          "IPV6Enabled": true,
+          "Origins": Array [
+            Object {
+              "DomainName": Object {
+                "Fn::GetAtt": Array [
+                  "Bucket83908E77",
+                  "RegionalDomainName",
+                ],
+              },
+              "Id": "DistributionOrigin13547B94F",
+              "S3OriginConfig": Object {
+                "OriginAccessIdentity": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "origin-access-identity/cloudfront/",
+                      Object {
+                        "Ref": "DistributionOrigin1S3Origin5F5C0696",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      },
+      "Type": "AWS::CloudFront::Distribution",
+    },
+    "DistributionOrigin1S3Origin5F5C0696": Object {
+      "Properties": Object {
+        "CloudFrontOriginAccessIdentityConfig": Object {
+          "Comment": "Identity for DistributionOrigin13547B94F",
+        },
+      },
+      "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
+    },
+    "Resource": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### CloudFront Distribution **[Distribution](https://console.aws.amazon.com/cloudfront/v2/home#/monitoring/",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              ")**\\"}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Uploaded/s\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\"}],[\\"AWS/CloudFront\\",\\"Requests\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"Uploaded\\",\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Uploaded/s < 10 for 3 datapoints within 15 minutes\\",\\"value\\":10,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Uploaded/s > 20 for 3 datapoints within 15 minutes\\",\\"value\\":20,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":8,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Traffic\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/CloudFront\\",\\"BytesDownloaded\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"Downloaded\\",\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/CloudFront\\",\\"BytesUploaded\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"Uploaded\\",\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"bytes\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":16,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/CloudFront\\",\\"4xxErrorRate\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"4XX\\",\\"region\\":\\"us-east-1\\"}],[\\"AWS/CloudFront\\",\\"5xxErrorRate\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"5XX\\",\\"region\\":\\"us-east-1\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"4XX > 0.5 for 3 datapoints within 15 minutes\\",\\"value\\":0.5,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"5XX > 0.8 for 3 datapoints within 15 minutes\\",\\"value\\":0.8,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "ScopeTestDistributionErrorRateWarning079D566A": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Error rate is too high.",
+        "AlarmName": "Test-Distribution-Error-Rate-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "4XX",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "DistributionId",
+                    "Value": Object {
+                      "Ref": "Distribution830FAC52",
+                    },
+                  },
+                  Object {
+                    "Name": "Region",
+                    "Value": "Global",
+                  },
+                ],
+                "MetricName": "4xxErrorRate",
+                "Namespace": "AWS/CloudFront",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.5,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDistributionFaultRateWarning02013C05": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Fault rate is too high.",
+        "AlarmName": "Test-Distribution-Fault-Rate-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "5XX",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "DistributionId",
+                    "Value": Object {
+                      "Ref": "Distribution830FAC52",
+                    },
+                  },
+                  Object {
+                    "Name": "Region",
+                    "Value": "Global",
+                  },
+                ],
+                "MetricName": "5xxErrorRate",
+                "Namespace": "AWS/CloudFront",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.8,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDistributionMaxTPSWarningAC289EB2": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TPS is too high.",
+        "AlarmName": "Test-Distribution-MaxTPS-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Uploaded/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Uploaded",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "DistributionId",
+                    "Value": Object {
+                      "Ref": "Distribution830FAC52",
+                    },
+                  },
+                  Object {
+                    "Name": "Region",
+                    "Value": "Global",
+                  },
+                ],
+                "MetricName": "Requests",
+                "Namespace": "AWS/CloudFront",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 20,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDistributionMinTPSWarning6CB7ACEE": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TPS is too low.",
+        "AlarmName": "Test-Distribution-MinTPS-Warning",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Uploaded/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Uploaded",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "DistributionId",
+                    "Value": Object {
+                      "Ref": "Distribution830FAC52",
+                    },
+                  },
+                  Object {
+                    "Name": "Region",
+                    "Value": "Global",
+                  },
+                ],
+                "MetricName": "Requests",
+                "Namespace": "AWS/CloudFront",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 10,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "Summary68521F81": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### CloudFront Distribution **[Distribution](https://console.aws.amazon.com/cloudfront/v2/home#/monitoring/",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              ")**\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Uploaded/s\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\"}],[\\"AWS/CloudFront\\",\\"Requests\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"Uploaded\\",\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Uploaded/s < 10 for 3 datapoints within 15 minutes\\",\\"value\\":10,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Uploaded/s > 20 for 3 datapoints within 15 minutes\\",\\"value\\":20,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/CloudFront\\",\\"4xxErrorRate\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"4XX\\",\\"region\\":\\"us-east-1\\"}],[\\"AWS/CloudFront\\",\\"5xxErrorRate\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"5XX\\",\\"region\\":\\"us-east-1\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"4XX > 0.5 for 3 datapoints within 15 minutes\\",\\"value\\":0.5,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"5XX > 0.8 for 3 datapoints within 15 minutes\\",\\"value\\":0.8,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`snapshot test: all alarms with additionalMetricsEnabled=true 1`] = `
 Object {
   "Parameters": Object {
     "BootstrapVersion": Object {
@@ -454,7 +900,919 @@ Object {
 }
 `;
 
-exports[`snapshot test: no alarms 1`] = `
+exports[`snapshot test: all alarms with additionalMetricsEnabled=undefined 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "Alarm7103F465": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDistributionMinTPSWarning6CB7ACEE",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":6,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDistributionMaxTPSWarningAC289EB2",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":12,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDistributionErrorRateWarning079D566A",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":18,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDistributionFaultRateWarning02013C05",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "Bucket83908E77": Object {
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "BucketPolicyE9A3008A": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "Bucket83908E77",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Principal": Object {
+                "CanonicalUser": Object {
+                  "Fn::GetAtt": Array [
+                    "DistributionOrigin1S3Origin5F5C0696",
+                    "S3CanonicalUserId",
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "Distribution830FAC52": Object {
+      "Properties": Object {
+        "DistributionConfig": Object {
+          "DefaultCacheBehavior": Object {
+            "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+            "Compress": true,
+            "TargetOriginId": "DistributionOrigin13547B94F",
+            "ViewerProtocolPolicy": "allow-all",
+          },
+          "Enabled": true,
+          "HttpVersion": "http2",
+          "IPV6Enabled": true,
+          "Origins": Array [
+            Object {
+              "DomainName": Object {
+                "Fn::GetAtt": Array [
+                  "Bucket83908E77",
+                  "RegionalDomainName",
+                ],
+              },
+              "Id": "DistributionOrigin13547B94F",
+              "S3OriginConfig": Object {
+                "OriginAccessIdentity": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "origin-access-identity/cloudfront/",
+                      Object {
+                        "Ref": "DistributionOrigin1S3Origin5F5C0696",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      },
+      "Type": "AWS::CloudFront::Distribution",
+    },
+    "DistributionOrigin1S3Origin5F5C0696": Object {
+      "Properties": Object {
+        "CloudFrontOriginAccessIdentityConfig": Object {
+          "Comment": "Identity for DistributionOrigin13547B94F",
+        },
+      },
+      "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
+    },
+    "Resource": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### CloudFront Distribution **[Distribution](https://console.aws.amazon.com/cloudfront/v2/home#/monitoring/",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              ")**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Uploaded/s\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\"}],[\\"AWS/CloudFront\\",\\"Requests\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"Uploaded\\",\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Uploaded/s < 10 for 3 datapoints within 15 minutes\\",\\"value\\":10,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Uploaded/s > 20 for 3 datapoints within 15 minutes\\",\\"value\\":20,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Hit Rate\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/CloudFront\\",\\"CacheHitRate\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"Hit Rate\\",\\"region\\":\\"us-east-1\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":100,\\"label\\":\\"%\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Traffic\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/CloudFront\\",\\"BytesDownloaded\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"Downloaded\\",\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/CloudFront\\",\\"BytesUploaded\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"Uploaded\\",\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"bytes\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/CloudFront\\",\\"4xxErrorRate\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"4XX\\",\\"region\\":\\"us-east-1\\"}],[\\"AWS/CloudFront\\",\\"5xxErrorRate\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"5XX\\",\\"region\\":\\"us-east-1\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"4XX > 0.5 for 3 datapoints within 15 minutes\\",\\"value\\":0.5,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"5XX > 0.8 for 3 datapoints within 15 minutes\\",\\"value\\":0.8,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "ScopeTestDistributionErrorRateWarning079D566A": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Error rate is too high.",
+        "AlarmName": "Test-Distribution-Error-Rate-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "4XX",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "DistributionId",
+                    "Value": Object {
+                      "Ref": "Distribution830FAC52",
+                    },
+                  },
+                  Object {
+                    "Name": "Region",
+                    "Value": "Global",
+                  },
+                ],
+                "MetricName": "4xxErrorRate",
+                "Namespace": "AWS/CloudFront",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.5,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDistributionFaultRateWarning02013C05": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Fault rate is too high.",
+        "AlarmName": "Test-Distribution-Fault-Rate-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "5XX",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "DistributionId",
+                    "Value": Object {
+                      "Ref": "Distribution830FAC52",
+                    },
+                  },
+                  Object {
+                    "Name": "Region",
+                    "Value": "Global",
+                  },
+                ],
+                "MetricName": "5xxErrorRate",
+                "Namespace": "AWS/CloudFront",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.8,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDistributionMaxTPSWarningAC289EB2": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TPS is too high.",
+        "AlarmName": "Test-Distribution-MaxTPS-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Uploaded/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Uploaded",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "DistributionId",
+                    "Value": Object {
+                      "Ref": "Distribution830FAC52",
+                    },
+                  },
+                  Object {
+                    "Name": "Region",
+                    "Value": "Global",
+                  },
+                ],
+                "MetricName": "Requests",
+                "Namespace": "AWS/CloudFront",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 20,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDistributionMinTPSWarning6CB7ACEE": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TPS is too low.",
+        "AlarmName": "Test-Distribution-MinTPS-Warning",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Uploaded/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Uploaded",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "DistributionId",
+                    "Value": Object {
+                      "Ref": "Distribution830FAC52",
+                    },
+                  },
+                  Object {
+                    "Name": "Region",
+                    "Value": "Global",
+                  },
+                ],
+                "MetricName": "Requests",
+                "Namespace": "AWS/CloudFront",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 10,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "Summary68521F81": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### CloudFront Distribution **[Distribution](https://console.aws.amazon.com/cloudfront/v2/home#/monitoring/",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              ")**\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Uploaded/s\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\"}],[\\"AWS/CloudFront\\",\\"Requests\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"Uploaded\\",\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Uploaded/s < 10 for 3 datapoints within 15 minutes\\",\\"value\\":10,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Uploaded/s > 20 for 3 datapoints within 15 minutes\\",\\"value\\":20,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/CloudFront\\",\\"4xxErrorRate\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"4XX\\",\\"region\\":\\"us-east-1\\"}],[\\"AWS/CloudFront\\",\\"5xxErrorRate\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"5XX\\",\\"region\\":\\"us-east-1\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"4XX > 0.5 for 3 datapoints within 15 minutes\\",\\"value\\":0.5,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"5XX > 0.8 for 3 datapoints within 15 minutes\\",\\"value\\":0.8,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`snapshot test: no alarms with additionalMetricsEnabled=false 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "Alarm7103F465": Object {
+      "Properties": Object {
+        "DashboardBody": "{\\"widgets\\":[]}",
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "Bucket83908E77": Object {
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "BucketPolicyE9A3008A": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "Bucket83908E77",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Principal": Object {
+                "CanonicalUser": Object {
+                  "Fn::GetAtt": Array [
+                    "DistributionOrigin1S3Origin5F5C0696",
+                    "S3CanonicalUserId",
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "Distribution830FAC52": Object {
+      "Properties": Object {
+        "DistributionConfig": Object {
+          "DefaultCacheBehavior": Object {
+            "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+            "Compress": true,
+            "TargetOriginId": "DistributionOrigin13547B94F",
+            "ViewerProtocolPolicy": "allow-all",
+          },
+          "Enabled": true,
+          "HttpVersion": "http2",
+          "IPV6Enabled": true,
+          "Origins": Array [
+            Object {
+              "DomainName": Object {
+                "Fn::GetAtt": Array [
+                  "Bucket83908E77",
+                  "RegionalDomainName",
+                ],
+              },
+              "Id": "DistributionOrigin13547B94F",
+              "S3OriginConfig": Object {
+                "OriginAccessIdentity": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "origin-access-identity/cloudfront/",
+                      Object {
+                        "Ref": "DistributionOrigin1S3Origin5F5C0696",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      },
+      "Type": "AWS::CloudFront::Distribution",
+    },
+    "DistributionOrigin1S3Origin5F5C0696": Object {
+      "Properties": Object {
+        "CloudFrontOriginAccessIdentityConfig": Object {
+          "Comment": "Identity for DistributionOrigin13547B94F",
+        },
+      },
+      "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
+    },
+    "Resource": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### CloudFront Distribution **[Distribution](https://console.aws.amazon.com/cloudfront/v2/home#/monitoring/",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              ")**\\"}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Uploaded/s\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\"}],[\\"AWS/CloudFront\\",\\"Requests\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"Uploaded\\",\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":8,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Traffic\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/CloudFront\\",\\"BytesDownloaded\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"Downloaded\\",\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/CloudFront\\",\\"BytesUploaded\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"Uploaded\\",\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"bytes\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":16,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/CloudFront\\",\\"4xxErrorRate\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"4XX\\",\\"region\\":\\"us-east-1\\"}],[\\"AWS/CloudFront\\",\\"5xxErrorRate\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"5XX\\",\\"region\\":\\"us-east-1\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "Summary68521F81": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### CloudFront Distribution **[Distribution](https://console.aws.amazon.com/cloudfront/v2/home#/monitoring/",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              ")**\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Uploaded/s\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\"}],[\\"AWS/CloudFront\\",\\"Requests\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"Uploaded\\",\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/CloudFront\\",\\"4xxErrorRate\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"4XX\\",\\"region\\":\\"us-east-1\\"}],[\\"AWS/CloudFront\\",\\"5xxErrorRate\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"5XX\\",\\"region\\":\\"us-east-1\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`snapshot test: no alarms with additionalMetricsEnabled=true 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "Alarm7103F465": Object {
+      "Properties": Object {
+        "DashboardBody": "{\\"widgets\\":[]}",
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "Bucket83908E77": Object {
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "BucketPolicyE9A3008A": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "Bucket83908E77",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Principal": Object {
+                "CanonicalUser": Object {
+                  "Fn::GetAtt": Array [
+                    "DistributionOrigin1S3Origin5F5C0696",
+                    "S3CanonicalUserId",
+                  ],
+                },
+              },
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    Object {
+                      "Fn::GetAtt": Array [
+                        "Bucket83908E77",
+                        "Arn",
+                      ],
+                    },
+                    "/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
+    "Distribution830FAC52": Object {
+      "Properties": Object {
+        "DistributionConfig": Object {
+          "DefaultCacheBehavior": Object {
+            "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+            "Compress": true,
+            "TargetOriginId": "DistributionOrigin13547B94F",
+            "ViewerProtocolPolicy": "allow-all",
+          },
+          "Enabled": true,
+          "HttpVersion": "http2",
+          "IPV6Enabled": true,
+          "Origins": Array [
+            Object {
+              "DomainName": Object {
+                "Fn::GetAtt": Array [
+                  "Bucket83908E77",
+                  "RegionalDomainName",
+                ],
+              },
+              "Id": "DistributionOrigin13547B94F",
+              "S3OriginConfig": Object {
+                "OriginAccessIdentity": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "origin-access-identity/cloudfront/",
+                      Object {
+                        "Ref": "DistributionOrigin1S3Origin5F5C0696",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      },
+      "Type": "AWS::CloudFront::Distribution",
+    },
+    "DistributionOrigin1S3Origin5F5C0696": Object {
+      "Properties": Object {
+        "CloudFrontOriginAccessIdentityConfig": Object {
+          "Comment": "Identity for DistributionOrigin13547B94F",
+        },
+      },
+      "Type": "AWS::CloudFront::CloudFrontOriginAccessIdentity",
+    },
+    "Resource": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### CloudFront Distribution **[Distribution](https://console.aws.amazon.com/cloudfront/v2/home#/monitoring/",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              ")**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Uploaded/s\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\"}],[\\"AWS/CloudFront\\",\\"Requests\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"Uploaded\\",\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Hit Rate\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/CloudFront\\",\\"CacheHitRate\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"Hit Rate\\",\\"region\\":\\"us-east-1\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":100,\\"label\\":\\"%\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Traffic\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/CloudFront\\",\\"BytesDownloaded\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"Downloaded\\",\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/CloudFront\\",\\"BytesUploaded\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"Uploaded\\",\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"bytes\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/CloudFront\\",\\"4xxErrorRate\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"4XX\\",\\"region\\":\\"us-east-1\\"}],[\\"AWS/CloudFront\\",\\"5xxErrorRate\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"5XX\\",\\"region\\":\\"us-east-1\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "Summary68521F81": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### CloudFront Distribution **[Distribution](https://console.aws.amazon.com/cloudfront/v2/home#/monitoring/",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              ")**\\"}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Uploaded/s\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\"}],[\\"AWS/CloudFront\\",\\"Requests\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"Uploaded\\",\\"region\\":\\"us-east-1\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":12,\\"height\\":6,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/CloudFront\\",\\"4xxErrorRate\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"4XX\\",\\"region\\":\\"us-east-1\\"}],[\\"AWS/CloudFront\\",\\"5xxErrorRate\\",\\"DistributionId\\",\\"",
+              Object {
+                "Ref": "Distribution830FAC52",
+              },
+              "\\",\\"Region\\",\\"Global\\",{\\"label\\":\\"5XX\\",\\"region\\":\\"us-east-1\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`snapshot test: no alarms with additionalMetricsEnabled=undefined 1`] = `
 Object {
   "Parameters": Object {
     "BootstrapVersion": Object {


### PR DESCRIPTION
As pointed out by a user, these metrics are not available by default, so it won't always be relevant.

This is kept as enabled by default to preserve the existing behaviour.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_