### PR TITLE
feat: make MultipleAlarmActionStrategy.actions public

### DIFF
--- a/API.md
+++ b/API.md
@@ -43053,6 +43053,23 @@ public addAlarmActions(props: AlarmActionStrategyProps): void
 ---
 
 
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#cdk-monitoring-constructs.MultipleAlarmActionStrategy.property.actions">actions</a></code> | <code><a href="#cdk-monitoring-constructs.IAlarmActionStrategy">IAlarmActionStrategy</a>[]</code> | *No description.* |
+
+---
+
+##### `actions`<sup>Required</sup> <a name="actions" id="cdk-monitoring-constructs.MultipleAlarmActionStrategy.property.actions"></a>
+
+```typescript
+public readonly actions: IAlarmActionStrategy[];
+```
+
+- *Type:* <a href="#cdk-monitoring-constructs.IAlarmActionStrategy">IAlarmActionStrategy</a>[]
+
+---
 
 
 ### NetworkLoadBalancerMetricFactory <a name="NetworkLoadBalancerMetricFactory" id="cdk-monitoring-constructs.NetworkLoadBalancerMetricFactory"></a>

--- a/lib/common/alarm/MultipleAlarmActionStrategy.ts
+++ b/lib/common/alarm/MultipleAlarmActionStrategy.ts
@@ -11,7 +11,7 @@ export function multipleActions(...actions: IAlarmActionStrategy[]) {
  * Alarm action strategy that combines multiple actions in the same order as they were given.
  */
 export class MultipleAlarmActionStrategy implements IAlarmActionStrategy {
-  protected readonly actions: IAlarmActionStrategy[];
+  readonly actions: IAlarmActionStrategy[];
 
   constructor(actions: IAlarmActionStrategy[]) {
     this.actions = actions;


### PR DESCRIPTION
Made MultipleAlarmActionStrategy.actions public so we can process the actions internally.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_