### PR TITLE
fix(dashboards): enforce non-empty dashboardNamePrefix

### DIFF
--- a/lib/dashboard/DefaultDashboardFactory.ts
+++ b/lib/dashboard/DefaultDashboardFactory.ts
@@ -96,6 +96,18 @@ export class DefaultDashboardFactory
   constructor(scope: Construct, id: string, props: MonitoringDashboardsProps) {
     super(scope, id);
 
+    const createDashboard = props.createDashboard ?? true;
+    const createSummaryDashboard = props.createSummaryDashboard ?? false;
+    const createAlarmDashboard = props.createAlarmDashboard ?? false;
+    const shouldCreateDashboards =
+      createDashboard || createAlarmDashboard || createSummaryDashboard;
+
+    if (shouldCreateDashboards && !props.dashboardNamePrefix) {
+      throw Error(
+        "A non-empty dashboardNamePrefix is required if dashboards are being created"
+      );
+    }
+
     const renderingPreference =
       props.renderingPreference ??
       DashboardRenderingPreference.INTERACTIVE_ONLY;
@@ -105,7 +117,7 @@ export class DefaultDashboardFactory
       "-" + (props.summaryDashboardRange ?? Duration.days(14)).toIsoString();
     let anyDashboardCreated = false;
 
-    if (props.createDashboard ?? true) {
+    if (createDashboard) {
       anyDashboardCreated = true;
       this.dashboard = this.createDashboard(renderingPreference, "Dashboard", {
         dashboardName: props.dashboardNamePrefix,
@@ -114,7 +126,7 @@ export class DefaultDashboardFactory
           props.detailDashboardPeriodOverride ?? PeriodOverride.INHERIT,
       });
     }
-    if (props.createSummaryDashboard ?? false) {
+    if (createSummaryDashboard) {
       anyDashboardCreated = true;
       this.summaryDashboard = this.createDashboard(
         renderingPreference,
@@ -127,7 +139,7 @@ export class DefaultDashboardFactory
         }
       );
     }
-    if (props.createAlarmDashboard ?? false) {
+    if (createAlarmDashboard) {
       anyDashboardCreated = true;
       this.alarmDashboard = this.createDashboard(
         renderingPreference,

--- a/test/dashboard/DefaultDashboardFactory.test.ts
+++ b/test/dashboard/DefaultDashboardFactory.test.ts
@@ -13,6 +13,17 @@ test("default dashboards created", () => {
 
   new DefaultDashboardFactory(stack, "Dashboards", {
     dashboardNamePrefix: "DummyDashboard",
+    renderingPreference: DashboardRenderingPreference.INTERACTIVE_ONLY,
+  });
+
+  expect(Template.fromStack(stack)).toMatchSnapshot();
+});
+
+test("all dashboards created", () => {
+  const stack = new Stack();
+
+  new DefaultDashboardFactory(stack, "Dashboards", {
+    dashboardNamePrefix: "DummyDashboard",
     createDashboard: true,
     createSummaryDashboard: true,
     createAlarmDashboard: true,
@@ -40,4 +51,18 @@ test("no dashboards created", () => {
   });
 
   expect(Template.fromStack(stack)).toMatchSnapshot();
+});
+
+test("throws error if an empty dashboardNamePrefix is passed but dashboard are to be created", () => {
+  const stack = new Stack();
+
+  expect(() => {
+    new DefaultDashboardFactory(stack, "Dashboards", {
+      dashboardNamePrefix: "",
+      createDashboard: true,
+      renderingPreference: DashboardRenderingPreference.INTERACTIVE_ONLY,
+    });
+  }).toThrow(
+    "A non-empty dashboardNamePrefix is required if dashboards are being created"
+  );
 });

--- a/test/dashboard/__snapshots__/DefaultDashboardFactory.test.ts.snap
+++ b/test/dashboard/__snapshots__/DefaultDashboardFactory.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`default dashboards created 1`] = `
+exports[`all dashboards created 1`] = `
 Object {
   "Parameters": Object {
     "BootstrapVersion": Object {
@@ -28,6 +28,54 @@ Object {
       "Properties": Object {
         "DashboardBody": "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
         "DashboardName": "DummyDashboard-Summary",
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`default dashboards created 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "DashboardsDashboard0712AF28": Object {
+      "Properties": Object {
+        "DashboardBody": "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[]}",
+        "DashboardName": "DummyDashboard",
       },
       "Type": "AWS::CloudWatch::Dashboard",
     },


### PR DESCRIPTION
We currently have this logic in the internal extension library, but this should be enforced at the core library level.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_