### PR TITLE
feat(dashboards): expose anyDashboardCreated from DefaultDashboardFactory

### DIFF
--- a/API.md
+++ b/API.md
@@ -633,6 +633,7 @@ Any object.
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.DefaultDashboardFactory.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
+| <code><a href="#cdk-monitoring-constructs.DefaultDashboardFactory.property.anyDashboardCreated">anyDashboardCreated</a></code> | <code>boolean</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.DefaultDashboardFactory.property.alarmDashboard">alarmDashboard</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Dashboard</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.DefaultDashboardFactory.property.dashboard">dashboard</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Dashboard</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.DefaultDashboardFactory.property.summaryDashboard">summaryDashboard</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Dashboard</code> | *No description.* |
@@ -648,6 +649,16 @@ public readonly node: Node;
 - *Type:* constructs.Node
 
 The tree node.
+
+---
+
+##### `anyDashboardCreated`<sup>Required</sup> <a name="anyDashboardCreated" id="cdk-monitoring-constructs.DefaultDashboardFactory.property.anyDashboardCreated"></a>
+
+```typescript
+public readonly anyDashboardCreated: boolean;
+```
+
+- *Type:* boolean
 
 ---
 

--- a/lib/dashboard/DefaultDashboardFactory.ts
+++ b/lib/dashboard/DefaultDashboardFactory.ts
@@ -91,7 +91,7 @@ export class DefaultDashboardFactory
   readonly dashboard?: Dashboard;
   readonly summaryDashboard?: Dashboard;
   readonly alarmDashboard?: Dashboard;
-  protected readonly anyDashboardCreated: boolean;
+  readonly anyDashboardCreated: boolean;
 
   constructor(scope: Construct, id: string, props: MonitoringDashboardsProps) {
     super(scope, id);

--- a/test/dashboard/DefaultDashboardFactory.test.ts
+++ b/test/dashboard/DefaultDashboardFactory.test.ts
@@ -11,18 +11,19 @@ import {
 test("default dashboards created", () => {
   const stack = new Stack();
 
-  new DefaultDashboardFactory(stack, "Dashboards", {
+  const factory = new DefaultDashboardFactory(stack, "Dashboards", {
     dashboardNamePrefix: "DummyDashboard",
     renderingPreference: DashboardRenderingPreference.INTERACTIVE_ONLY,
   });
 
+  expect(factory.anyDashboardCreated).toEqual(true);
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });
 
 test("all dashboards created", () => {
   const stack = new Stack();
 
-  new DefaultDashboardFactory(stack, "Dashboards", {
+  const factory = new DefaultDashboardFactory(stack, "Dashboards", {
     dashboardNamePrefix: "DummyDashboard",
     createDashboard: true,
     createSummaryDashboard: true,
@@ -30,13 +31,14 @@ test("all dashboards created", () => {
     renderingPreference: DashboardRenderingPreference.INTERACTIVE_ONLY,
   });
 
+  expect(factory.anyDashboardCreated).toEqual(true);
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });
 
 test("no dashboards created", () => {
   const stack = new Stack();
 
-  const dashboards = new DefaultDashboardFactory(stack, "Dashboards", {
+  const factory = new DefaultDashboardFactory(stack, "Dashboards", {
     dashboardNamePrefix: "DummyDashboard",
     createDashboard: false,
     createSummaryDashboard: false,
@@ -44,12 +46,13 @@ test("no dashboards created", () => {
     renderingPreference: DashboardRenderingPreference.INTERACTIVE_ONLY,
   });
 
-  dashboards.addSegment({
+  factory.addSegment({
     segment: new SingleWidgetDashboardSegment(
       new TextWidget({ markdown: "Hello world!" })
     ),
   });
 
+  expect(factory.anyDashboardCreated).toEqual(false);
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });
 


### PR DESCRIPTION
This is useful if you want to conditionally create any constructs based on the existence of dashboards without necessarily checking the input props.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_