### PR TITLE
fix: use proper module name for go module

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -38,7 +38,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   },
   // Artifact config: Go
   publishToGo: {
-    moduleName: "github.com/cdklabs/cdkmonitoringconstructs",
+    moduleName: "github.com/cdklabs/cdk-monitoring-constructs",
   },
 
   // Auto approval config

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
         "packageId": "Cdklabs.CdkMonitoringConstructs"
       },
       "go": {
-        "moduleName": "github.com/cdklabs/cdkmonitoringconstructs"
+        "moduleName": "github.com/cdklabs/cdk-monitoring-constructs"
       }
     },
     "tsc": {


### PR DESCRIPTION
Addressing [build failure](https://github.com/cdklabs/cdk-monitoring-constructs/runs/7810695971?check_suite_focus=true).

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_