### PR TITLE
chore(docs): remove link to API.md from README.md [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # CDK Monitoring Constructs
 
-[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/cdklabs/cdk-monitoring-constructs)
 [![NPM version](https://badge.fury.io/js/cdk-monitoring-constructs.svg)](https://badge.fury.io/js/cdk-monitoring-constructs)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.github.cdklabs/cdkmonitoringconstructs/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.github.cdklabs/cdkmonitoringconstructs)
 [![PyPI version](https://badge.fury.io/py/cdk-monitoring-constructs.svg)](https://badge.fury.io/py/cdk-monitoring-constructs)
 [![NuGet version](https://badge.fury.io/nu/Cdklabs.CdkMonitoringConstructs.svg)](https://badge.fury.io/nu/Cdklabs.CdkMonitoringConstructs)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.github.cdklabs/cdkmonitoringconstructs/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.github.cdklabs/cdkmonitoringconstructs)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/cdklabs/cdk-monitoring-constructs)
 [![Mergify](https://img.shields.io/endpoint.svg?url=https://gh.mergify.io/badges/cdklabs/cdk-monitoring-constructs&style=flat)](https://mergify.io)
 
 Easy-to-use CDK constructs for monitoring your AWS infrastructure.
@@ -65,9 +65,7 @@ Coming soon!
 
 ## Features
 
-See [API](API.md) for complete auto-generated documentation.
-
-You can also browse the documentation at https://constructs.dev/packages/cdk-monitoring-constructs/
+You can browse the documentation at https://constructs.dev/packages/cdk-monitoring-constructs/
 
 | Item | Monitoring | Alarms | Notes |
 | ---- | ---------- | ------ | ----- |


### PR DESCRIPTION
It was noted that the file is too big for GitHub to render nicely, so there isn't much benefit to linking to it.

Users should instead browse the nicely rendered docs on constructs.dev.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_