### PR TITLE
chore: remove peer dependency on @aws-cdk/aws-appsync-alpha

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -6,11 +6,6 @@
       "type": "build"
     },
     {
-      "name": "@aws-cdk/aws-appsync-alpha",
-      "version": "2.18.0-alpha.0",
-      "type": "build"
-    },
-    {
       "name": "@aws-cdk/aws-redshift-alpha",
       "version": "2.18.0-alpha.0",
       "type": "build"
@@ -159,11 +154,6 @@
     },
     {
       "name": "@aws-cdk/aws-apigatewayv2-alpha",
-      "version": "^2.18.0-alpha.0",
-      "type": "peer"
-    },
-    {
-      "name": "@aws-cdk/aws-appsync-alpha",
       "version": "^2.18.0-alpha.0",
       "type": "peer"
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -292,19 +292,19 @@
           "exec": "yarn upgrade npm-check-updates"
         },
         {
-          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='@aws-cdk/aws-apigatewayv2-alpha,@aws-cdk/aws-appsync-alpha,@aws-cdk/aws-redshift-alpha,@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs,@types/prettier'"
+          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='@aws-cdk/aws-apigatewayv2-alpha,@aws-cdk/aws-redshift-alpha,@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs,@aws-cdk/aws-appsync-alpha,@types/prettier'"
         },
         {
-          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='@aws-cdk/aws-apigatewayv2-alpha,@aws-cdk/aws-appsync-alpha,@aws-cdk/aws-redshift-alpha,@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs,@types/prettier'"
+          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='@aws-cdk/aws-apigatewayv2-alpha,@aws-cdk/aws-redshift-alpha,@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs,@aws-cdk/aws-appsync-alpha,@types/prettier'"
         },
         {
-          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='@aws-cdk/aws-apigatewayv2-alpha,@aws-cdk/aws-appsync-alpha,@aws-cdk/aws-redshift-alpha,@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs,@types/prettier'"
+          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='@aws-cdk/aws-apigatewayv2-alpha,@aws-cdk/aws-redshift-alpha,@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs,@aws-cdk/aws-appsync-alpha,@types/prettier'"
         },
         {
-          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='@aws-cdk/aws-apigatewayv2-alpha,@aws-cdk/aws-appsync-alpha,@aws-cdk/aws-redshift-alpha,@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs,@types/prettier'"
+          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='@aws-cdk/aws-apigatewayv2-alpha,@aws-cdk/aws-redshift-alpha,@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs,@aws-cdk/aws-appsync-alpha,@types/prettier'"
         },
         {
-          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='@aws-cdk/aws-apigatewayv2-alpha,@aws-cdk/aws-appsync-alpha,@aws-cdk/aws-redshift-alpha,@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs,@types/prettier'"
+          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='@aws-cdk/aws-apigatewayv2-alpha,@aws-cdk/aws-redshift-alpha,@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs,@aws-cdk/aws-appsync-alpha,@types/prettier'"
         },
         {
           "exec": "yarn install --check-files"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -79,7 +79,6 @@ _By submitting this pull request, I confirm that my contribution is made under t
 // Experimental modules
 [
   "@aws-cdk/aws-apigatewayv2-alpha",
-  "@aws-cdk/aws-appsync-alpha",
   "@aws-cdk/aws-redshift-alpha",
   "@aws-cdk/aws-synthetics-alpha",
 ].forEach((dep) => {
@@ -87,6 +86,12 @@ _By submitting this pull request, I confirm that my contribution is made under t
     `${dep}@^${CDK_VERSION}-alpha.0`,
     DependencyType.PEER
   );
+  project.deps.addDependency(
+    `${dep}@${CDK_VERSION}-alpha.0`,
+    DependencyType.DEVENV
+  );
+});
+["@aws-cdk/aws-appsync-alpha"].forEach((dep) => {
   project.deps.addDependency(
     `${dep}@${CDK_VERSION}-alpha.0`,
     DependencyType.DEVENV

--- a/API.md
+++ b/API.md
@@ -6164,7 +6164,7 @@ const appSyncMetricFactoryProps: AppSyncMetricFactoryProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#cdk-monitoring-constructs.AppSyncMetricFactoryProps.property.api">api</a></code> | <code>@aws-cdk/aws-appsync-alpha.GraphqlApi</code> | the GraphQL API to monitor. |
+| <code><a href="#cdk-monitoring-constructs.AppSyncMetricFactoryProps.property.api">api</a></code> | <code><a href="#cdk-monitoring-constructs.GraphqlApi">GraphqlApi</a></code> | the GraphQL API to monitor. |
 | <code><a href="#cdk-monitoring-constructs.AppSyncMetricFactoryProps.property.fillTpsWithZeroes">fillTpsWithZeroes</a></code> | <code>boolean</code> | whether the TPS should be filled with zeroes. |
 | <code><a href="#cdk-monitoring-constructs.AppSyncMetricFactoryProps.property.rateComputationMethod">rateComputationMethod</a></code> | <code><a href="#cdk-monitoring-constructs.RateComputationMethod">RateComputationMethod</a></code> | method to compute TPS. |
 
@@ -6176,7 +6176,7 @@ const appSyncMetricFactoryProps: AppSyncMetricFactoryProps = { ... }
 public readonly api: GraphqlApi;
 ```
 
-- *Type:* @aws-cdk/aws-appsync-alpha.GraphqlApi
+- *Type:* <a href="#cdk-monitoring-constructs.GraphqlApi">GraphqlApi</a>
 
 the GraphQL API to monitor.
 
@@ -6459,7 +6459,7 @@ const appSyncMonitoringProps: AppSyncMonitoringProps = { ... }
 | <code><a href="#cdk-monitoring-constructs.AppSyncMonitoringProps.property.addLatencyP90Alarm">addLatencyP90Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.AppSyncMonitoringProps.property.addLatencyP99Alarm">addLatencyP99Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.AppSyncMonitoringProps.property.addLowTpsAlarm">addLowTpsAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LowTpsThreshold">LowTpsThreshold</a>}</code> | *No description.* |
-| <code><a href="#cdk-monitoring-constructs.AppSyncMonitoringProps.property.api">api</a></code> | <code>@aws-cdk/aws-appsync-alpha.GraphqlApi</code> | the GraphQL API to monitor. |
+| <code><a href="#cdk-monitoring-constructs.AppSyncMonitoringProps.property.api">api</a></code> | <code><a href="#cdk-monitoring-constructs.GraphqlApi">GraphqlApi</a></code> | the GraphQL API to monitor. |
 | <code><a href="#cdk-monitoring-constructs.AppSyncMonitoringProps.property.fillTpsWithZeroes">fillTpsWithZeroes</a></code> | <code>boolean</code> | whether the TPS should be filled with zeroes. |
 | <code><a href="#cdk-monitoring-constructs.AppSyncMonitoringProps.property.rateComputationMethod">rateComputationMethod</a></code> | <code><a href="#cdk-monitoring-constructs.RateComputationMethod">RateComputationMethod</a></code> | method to compute TPS. |
 
@@ -6659,7 +6659,7 @@ public readonly addLowTpsAlarm: {[ key: string ]: LowTpsThreshold};
 public readonly api: GraphqlApi;
 ```
 
-- *Type:* @aws-cdk/aws-appsync-alpha.GraphqlApi
+- *Type:* <a href="#cdk-monitoring-constructs.GraphqlApi">GraphqlApi</a>
 
 the GraphQL API to monitor.
 
@@ -16890,6 +16890,51 @@ public readonly addKilledTaskRateAlarm: {[ key: string ]: ErrorRateThreshold};
 ```
 
 - *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorRateThreshold">ErrorRateThreshold</a>}
+
+---
+
+### GraphqlApi <a name="GraphqlApi" id="cdk-monitoring-constructs.GraphqlApi"></a>
+
+Partial copy of [GraphqlApi] from "@aws-cdk/aws-appsync-alpha".
+
+#### Initializer <a name="Initializer" id="cdk-monitoring-constructs.GraphqlApi.Initializer"></a>
+
+```typescript
+import { GraphqlApi } from 'cdk-monitoring-constructs'
+
+const graphqlApi: GraphqlApi = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#cdk-monitoring-constructs.GraphqlApi.property.apiId">apiId</a></code> | <code>string</code> | an unique AWS AppSync GraphQL API identifier i.e. 'lxz775lwdrgcndgz3nurvac7oa'. |
+| <code><a href="#cdk-monitoring-constructs.GraphqlApi.property.graphqlUrl">graphqlUrl</a></code> | <code>string</code> | the URL of the endpoint created by AppSync. |
+
+---
+
+##### `apiId`<sup>Required</sup> <a name="apiId" id="cdk-monitoring-constructs.GraphqlApi.property.apiId"></a>
+
+```typescript
+public readonly apiId: string;
+```
+
+- *Type:* string
+
+an unique AWS AppSync GraphQL API identifier i.e. 'lxz775lwdrgcndgz3nurvac7oa'.
+
+---
+
+##### `graphqlUrl`<sup>Optional</sup> <a name="graphqlUrl" id="cdk-monitoring-constructs.GraphqlApi.property.graphqlUrl"></a>
+
+```typescript
+public readonly graphqlUrl: string;
+```
+
+- *Type:* string
+
+the URL of the endpoint created by AppSync.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ In your `package.json`:
 
     // peer dependencies of cdk-monitoring-constructs
     "@aws-cdk/aws-apigatewayv2-alpha": "^2.18.0-alpha.0",
-    "@aws-cdk/aws-appsync-alpha": "^2.18.0-alpha.0",
     "@aws-cdk/aws-redshift-alpha": "^2.18.0-alpha.0",
     "@aws-cdk/aws-synthetics-alpha": "^2.18.0-alpha.0",
     "aws-cdk-lib": "^2.18.0",

--- a/lib/facade/MonitoringAspect.ts
+++ b/lib/facade/MonitoringAspect.ts
@@ -1,5 +1,4 @@
 import * as apigwv2 from "@aws-cdk/aws-apigatewayv2-alpha";
-import * as appsync from "@aws-cdk/aws-appsync-alpha";
 import * as redshift from "@aws-cdk/aws-redshift-alpha";
 import * as synthetics from "@aws-cdk/aws-synthetics-alpha";
 import { IAspect } from "aws-cdk-lib";
@@ -26,7 +25,7 @@ import * as stepfunctions from "aws-cdk-lib/aws-stepfunctions";
 import * as wafv2 from "aws-cdk-lib/aws-wafv2";
 import { IConstruct } from "constructs";
 
-import { ElastiCacheClusterType } from "../monitoring";
+import { ElastiCacheClusterType, GraphqlApi } from "../monitoring";
 import { MonitoringAspectProps, MonitoringAspectType } from "./aspect-types";
 import { MonitoringFacade } from "./MonitoringFacade";
 
@@ -122,9 +121,9 @@ export class MonitoringAspect implements IAspect {
 
   private monitorAppSync(node: IConstruct) {
     const [isEnabled, props] = this.getMonitoringDetails(this.props.appSync);
-    if (isEnabled && node instanceof appsync.GraphqlApi) {
+    if (isEnabled && (node as unknown as GraphqlApi).graphqlUrl) {
       this.monitoringFacade.monitorAppSyncApi({
-        api: node,
+        api: node as unknown as GraphqlApi,
         alarmFriendlyName: node.node.path,
         ...props,
       });

--- a/lib/monitoring/aws-appsync/AppSyncMetricFactory.ts
+++ b/lib/monitoring/aws-appsync/AppSyncMetricFactory.ts
@@ -1,4 +1,3 @@
-import { GraphqlApi } from "@aws-cdk/aws-appsync-alpha";
 import { DimensionsMap } from "aws-cdk-lib/aws-cloudwatch";
 
 import {
@@ -8,6 +7,26 @@ import {
 } from "../../common";
 
 const Namespace = "AWS/AppSync";
+
+/**
+ * Partial copy of [GraphqlApi] from "@aws-cdk/aws-appsync-alpha"
+ *
+ * @experimental Subject to change to match the alpha module.
+ */
+export interface GraphqlApi {
+  /**
+   * an unique AWS AppSync GraphQL API identifier
+   * i.e. 'lxz775lwdrgcndgz3nurvac7oa'
+   */
+  readonly apiId: string;
+
+  /**
+   * the URL of the endpoint created by AppSync
+   *
+   * @attribute GraphQlUrl
+   */
+  readonly graphqlUrl?: string;
+}
 
 export interface AppSyncMetricFactoryProps {
   /**

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
   },
   "peerDependencies": {
     "@aws-cdk/aws-apigatewayv2-alpha": "^2.18.0-alpha.0",
-    "@aws-cdk/aws-appsync-alpha": "^2.18.0-alpha.0",
     "@aws-cdk/aws-redshift-alpha": "^2.18.0-alpha.0",
     "@aws-cdk/aws-synthetics-alpha": "^2.18.0-alpha.0",
     "aws-cdk-lib": "^2.18.0",

--- a/test/monitoring/aws-appsync/AppSyncMonitoring.test.ts
+++ b/test/monitoring/aws-appsync/AppSyncMonitoring.test.ts
@@ -6,17 +6,15 @@ import { AlarmWithAnnotation, AppSyncMonitoring } from "../../../lib";
 import { addMonitoringDashboardsToStack } from "../../utils/SnapshotUtil";
 import { TestMonitoringScope } from "../TestMonitoringScope";
 
-test("snapshot test: no alarms", () => {
+test("snapshot test: basic object with no alarms", () => {
   const stack = new Stack();
 
   const scope = new TestMonitoringScope(stack, "Scope");
 
-  const dummyApi = new GraphqlApi(stack, "testHttpApi", {
-    name: "DummyApi",
-  });
-
   const monitoring = new AppSyncMonitoring(scope, {
-    api: dummyApi,
+    api: {
+      apiId: "API",
+    },
     humanReadableName: "Dummy API for testing",
     alarmFriendlyName: "DummyApi",
   });
@@ -25,7 +23,7 @@ test("snapshot test: no alarms", () => {
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });
 
-test("snapshot test: all alarms", () => {
+test("snapshot test: alpha construct with all alarms", () => {
   const stack = new Stack();
 
   const scope = new TestMonitoringScope(stack, "Scope");

--- a/test/monitoring/aws-appsync/__snapshots__/AppSyncMonitoring.test.ts.snap
+++ b/test/monitoring/aws-appsync/__snapshots__/AppSyncMonitoring.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`snapshot test: all alarms 1`] = `
+exports[`snapshot test: alpha construct with all alarms 1`] = `
 Object {
   "Parameters": Object {
     "BootstrapVersion": Object {
@@ -699,7 +699,7 @@ Object {
 }
 `;
 
-exports[`snapshot test: no alarms 1`] = `
+exports[`snapshot test: basic object with no alarms 1`] = `
 Object {
   "Parameters": Object {
     "BootstrapVersion": Object {
@@ -725,75 +725,19 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[{\\"label\\":\\"TPS (min: \${MIN}, max: \${MAX}, avg: \${AVG})\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\"}],[\\"AWS/AppSync\\",\\"Latency\\",\\"GraphQLAPIId\\",\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "testHttpApiC57B300F",
-                  "ApiId",
-                ],
-              },
-              "\\",{\\"label\\":\\"Requests\\",\\"stat\\":\\"SampleCount\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[{\\"label\\":\\"TPS (min: \${MIN}, max: \${MAX}, avg: \${AVG})\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\"}],[\\"AWS/AppSync\\",\\"Latency\\",\\"GraphQLAPIId\\",\\"API\\",{\\"label\\":\\"Requests\\",\\"stat\\":\\"SampleCount\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/AppSync\\",\\"Latency\\",\\"GraphQLAPIId\\",\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "testHttpApiC57B300F",
-                  "ApiId",
-                ],
-              },
-              "\\",{\\"label\\":\\"P50\\",\\"stat\\":\\"p50\\"}],[\\"AWS/AppSync\\",\\"Latency\\",\\"GraphQLAPIId\\",\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "testHttpApiC57B300F",
-                  "ApiId",
-                ],
-              },
-              "\\",{\\"label\\":\\"P90\\",\\"stat\\":\\"p90\\"}],[\\"AWS/AppSync\\",\\"Latency\\",\\"GraphQLAPIId\\",\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "testHttpApiC57B300F",
-                  "ApiId",
-                ],
-              },
-              "\\",{\\"label\\":\\"P99\\",\\"stat\\":\\"p99\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[\\"AWS/AppSync\\",\\"Latency\\",\\"GraphQLAPIId\\",\\"API\\",{\\"label\\":\\"P50\\",\\"stat\\":\\"p50\\"}],[\\"AWS/AppSync\\",\\"Latency\\",\\"GraphQLAPIId\\",\\"API\\",{\\"label\\":\\"P90\\",\\"stat\\":\\"p90\\"}],[\\"AWS/AppSync\\",\\"Latency\\",\\"GraphQLAPIId\\",\\"API\\",{\\"label\\":\\"P99\\",\\"stat\\":\\"p99\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/AppSync\\",\\"4XXError\\",\\"GraphQLAPIId\\",\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "testHttpApiC57B300F",
-                  "ApiId",
-                ],
-              },
-              "\\",{\\"label\\":\\"4XX Error\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/AppSync\\",\\"5XXError\\",\\"GraphQLAPIId\\",\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "testHttpApiC57B300F",
-                  "ApiId",
-                ],
-              },
-              "\\",{\\"label\\":\\"5XX Fault\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[\\"AWS/AppSync\\",\\"4XXError\\",\\"GraphQLAPIId\\",\\"API\\",{\\"label\\":\\"4XX Error\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/AppSync\\",\\"5XXError\\",\\"GraphQLAPIId\\",\\"API\\",{\\"label\\":\\"5XX Fault\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/AppSync\\",\\"4XXError\\",\\"GraphQLAPIId\\",\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "testHttpApiC57B300F",
-                  "ApiId",
-                ],
-              },
-              "\\",{\\"label\\":\\"4XX Error (avg)\\"}],[\\"AWS/AppSync\\",\\"5XXError\\",\\"GraphQLAPIId\\",\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "testHttpApiC57B300F",
-                  "ApiId",
-                ],
-              },
-              "\\",{\\"label\\":\\"5XX Fault (avg)\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
+              "\\",\\"metrics\\":[[\\"AWS/AppSync\\",\\"4XXError\\",\\"GraphQLAPIId\\",\\"API\\",{\\"label\\":\\"4XX Error (avg)\\"}],[\\"AWS/AppSync\\",\\"5XXError\\",\\"GraphQLAPIId\\",\\"API\\",{\\"label\\":\\"5XX Fault (avg)\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
             ],
           ],
         },
@@ -810,95 +754,20 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[{\\"label\\":\\"TPS (min: \${MIN}, max: \${MAX}, avg: \${AVG})\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\"}],[\\"AWS/AppSync\\",\\"Latency\\",\\"GraphQLAPIId\\",\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "testHttpApiC57B300F",
-                  "ApiId",
-                ],
-              },
-              "\\",{\\"label\\":\\"Requests\\",\\"stat\\":\\"SampleCount\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[{\\"label\\":\\"TPS (min: \${MIN}, max: \${MAX}, avg: \${AVG})\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\"}],[\\"AWS/AppSync\\",\\"Latency\\",\\"GraphQLAPIId\\",\\"API\\",{\\"label\\":\\"Requests\\",\\"stat\\":\\"SampleCount\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/AppSync\\",\\"Latency\\",\\"GraphQLAPIId\\",\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "testHttpApiC57B300F",
-                  "ApiId",
-                ],
-              },
-              "\\",{\\"label\\":\\"P50\\",\\"stat\\":\\"p50\\"}],[\\"AWS/AppSync\\",\\"Latency\\",\\"GraphQLAPIId\\",\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "testHttpApiC57B300F",
-                  "ApiId",
-                ],
-              },
-              "\\",{\\"label\\":\\"P90\\",\\"stat\\":\\"p90\\"}],[\\"AWS/AppSync\\",\\"Latency\\",\\"GraphQLAPIId\\",\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "testHttpApiC57B300F",
-                  "ApiId",
-                ],
-              },
-              "\\",{\\"label\\":\\"P99\\",\\"stat\\":\\"p99\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[\\"AWS/AppSync\\",\\"Latency\\",\\"GraphQLAPIId\\",\\"API\\",{\\"label\\":\\"P50\\",\\"stat\\":\\"p50\\"}],[\\"AWS/AppSync\\",\\"Latency\\",\\"GraphQLAPIId\\",\\"API\\",{\\"label\\":\\"P90\\",\\"stat\\":\\"p90\\"}],[\\"AWS/AppSync\\",\\"Latency\\",\\"GraphQLAPIId\\",\\"API\\",{\\"label\\":\\"P99\\",\\"stat\\":\\"p99\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/AppSync\\",\\"4XXError\\",\\"GraphQLAPIId\\",\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "testHttpApiC57B300F",
-                  "ApiId",
-                ],
-              },
-              "\\",{\\"label\\":\\"4XX Error (avg)\\"}],[\\"AWS/AppSync\\",\\"5XXError\\",\\"GraphQLAPIId\\",\\"",
-              Object {
-                "Fn::GetAtt": Array [
-                  "testHttpApiC57B300F",
-                  "ApiId",
-                ],
-              },
-              "\\",{\\"label\\":\\"5XX Fault (avg)\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
+              "\\",\\"metrics\\":[[\\"AWS/AppSync\\",\\"4XXError\\",\\"GraphQLAPIId\\",\\"API\\",{\\"label\\":\\"4XX Error (avg)\\"}],[\\"AWS/AppSync\\",\\"5XXError\\",\\"GraphQLAPIId\\",\\"API\\",{\\"label\\":\\"5XX Fault (avg)\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
             ],
           ],
         },
       },
       "Type": "AWS::CloudWatch::Dashboard",
-    },
-    "testHttpApiC57B300F": Object {
-      "Properties": Object {
-        "AuthenticationType": "API_KEY",
-        "Name": "DummyApi",
-      },
-      "Type": "AWS::AppSync::GraphQLApi",
-    },
-    "testHttpApiDefaultApiKey3EF156CA": Object {
-      "DependsOn": Array [
-        "testHttpApiSchemaDBC6E366",
-      ],
-      "Properties": Object {
-        "ApiId": Object {
-          "Fn::GetAtt": Array [
-            "testHttpApiC57B300F",
-            "ApiId",
-          ],
-        },
-      },
-      "Type": "AWS::AppSync::ApiKey",
-    },
-    "testHttpApiSchemaDBC6E366": Object {
-      "Properties": Object {
-        "ApiId": Object {
-          "Fn::GetAtt": Array [
-            "testHttpApiC57B300F",
-            "ApiId",
-          ],
-        },
-        "Definition": "",
-      },
-      "Type": "AWS::AppSync::GraphQLSchema",
     },
   },
   "Rules": Object {


### PR DESCRIPTION
Related to #212

This is a bit of a POC that we can remove direct peer dependencies on an alpha module at the cost of some manual interface duplication.

At a high level, we partially copy the interface for the relevant construct with whatever we need for the dimensions. Users can still pass in the alpha L2 constructs since they match up with the partial interfaces.

This allows us some flexibility in updating them, albeit not strongly coupled with actual versioning on the AWS-CDK side. 

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_