### PR TITLE
feat: deprecate `important` property in favor of `addToSummaryDashboard` in CustomMetricGroup

### DIFF
--- a/API.md
+++ b/API.md
@@ -10223,13 +10223,14 @@ const customMetricGroup: CustomMetricGroup = { ... }
 | --- | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.CustomMetricGroup.property.metrics">metrics</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression \| <a href="#cdk-monitoring-constructs.CustomMetricWithAlarm">CustomMetricWithAlarm</a> \| <a href="#cdk-monitoring-constructs.CustomMetricWithAnomalyDetection">CustomMetricWithAnomalyDetection</a> \| <a href="#cdk-monitoring-constructs.CustomMetricSearch">CustomMetricSearch</a>[]</code> | list of metrics in the group (can be defined in different ways, see the type documentation). |
 | <code><a href="#cdk-monitoring-constructs.CustomMetricGroup.property.title">title</a></code> | <code>string</code> | title of the whole group. |
+| <code><a href="#cdk-monitoring-constructs.CustomMetricGroup.property.addToSummaryDashboard">addToSummaryDashboard</a></code> | <code>boolean</code> | Flag indicating this metric group should be included in the summary as well. |
 | <code><a href="#cdk-monitoring-constructs.CustomMetricGroup.property.graphWidgetAxis">graphWidgetAxis</a></code> | <code>aws-cdk-lib.aws_cloudwatch.YAxisProps</code> | optional axis. |
 | <code><a href="#cdk-monitoring-constructs.CustomMetricGroup.property.graphWidgetLegend">graphWidgetLegend</a></code> | <code>aws-cdk-lib.aws_cloudwatch.LegendPosition</code> | graph widget legend. |
 | <code><a href="#cdk-monitoring-constructs.CustomMetricGroup.property.graphWidgetRightAxis">graphWidgetRightAxis</a></code> | <code>aws-cdk-lib.aws_cloudwatch.YAxisProps</code> | optional right axis. |
 | <code><a href="#cdk-monitoring-constructs.CustomMetricGroup.property.graphWidgetType">graphWidgetType</a></code> | <code><a href="#cdk-monitoring-constructs.GraphWidgetType">GraphWidgetType</a></code> | type of the widget. |
 | <code><a href="#cdk-monitoring-constructs.CustomMetricGroup.property.horizontalAnnotations">horizontalAnnotations</a></code> | <code>aws-cdk-lib.aws_cloudwatch.HorizontalAnnotation[]</code> | optional custom horizontal annotations which will be displayed over the metrics on the left axis (if there are any alarms, any existing annotations will be merged together). |
 | <code><a href="#cdk-monitoring-constructs.CustomMetricGroup.property.horizontalRightAnnotations">horizontalRightAnnotations</a></code> | <code>aws-cdk-lib.aws_cloudwatch.HorizontalAnnotation[]</code> | optional custom horizontal annotations which will be displayed over the metrics on the right axis (if there are any alarms, any existing annotations will be merged together). |
-| <code><a href="#cdk-monitoring-constructs.CustomMetricGroup.property.important">important</a></code> | <code>boolean</code> | Flag indicating, whether this is an important metric group that should be included in the summary as well. |
+| <code><a href="#cdk-monitoring-constructs.CustomMetricGroup.property.important">important</a></code> | <code>boolean</code> | *No description.* |
 
 ---
 
@@ -10254,6 +10255,19 @@ public readonly title: string;
 - *Type:* string
 
 title of the whole group.
+
+---
+
+##### `addToSummaryDashboard`<sup>Optional</sup> <a name="addToSummaryDashboard" id="cdk-monitoring-constructs.CustomMetricGroup.property.addToSummaryDashboard"></a>
+
+```typescript
+public readonly addToSummaryDashboard: boolean;
+```
+
+- *Type:* boolean
+- *Default:* false
+
+Flag indicating this metric group should be included in the summary as well.
 
 ---
 
@@ -10333,7 +10347,10 @@ optional custom horizontal annotations which will be displayed over the metrics 
 
 ---
 
-##### `important`<sup>Optional</sup> <a name="important" id="cdk-monitoring-constructs.CustomMetricGroup.property.important"></a>
+##### ~~`important`~~<sup>Optional</sup> <a name="important" id="cdk-monitoring-constructs.CustomMetricGroup.property.important"></a>
+
+- *Deprecated:* use addToSummaryDashboard
+Flag indicating, whether this is an important metric group that should be included in the summary as well.
 
 ```typescript
 public readonly important: boolean;
@@ -10341,8 +10358,6 @@ public readonly important: boolean;
 
 - *Type:* boolean
 - *Default:* false
-
-Flag indicating, whether this is an important metric group that should be included in the summary as well.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -10349,7 +10349,7 @@ optional custom horizontal annotations which will be displayed over the metrics 
 
 ##### ~~`important`~~<sup>Optional</sup> <a name="important" id="cdk-monitoring-constructs.CustomMetricGroup.property.important"></a>
 
-- *Deprecated:* use addToSummaryDashboard
+- *Deprecated:* use addToSummaryDashboard. addToSummaryDashboard will take precedence over important.
 Flag indicating, whether this is an important metric group that should be included in the summary as well.
 
 ```typescript

--- a/lib/monitoring/custom/CustomMonitoring.ts
+++ b/lib/monitoring/custom/CustomMonitoring.ts
@@ -170,10 +170,16 @@ export interface CustomMetricGroup {
    */
   readonly graphWidgetLegend?: LegendPosition;
   /**
+   * @deprecated use addToSummaryDashboard
    * Flag indicating, whether this is an important metric group that should be included in the summary as well.
    * @default false
    */
   readonly important?: boolean;
+  /**
+   * Flag indicating this metric group should be included in the summary as well.
+   * @default false
+   */
+  readonly addToSummaryDashboard?: boolean;
   /**
    * list of metrics in the group (can be defined in different ways, see the type documentation)
    */
@@ -304,7 +310,10 @@ export class CustomMonitoring extends Monitoring {
   private getAllWidgets(summary: boolean): IWidget[] {
     const filteredMetricGroups = summary
       ? this.metricGroups.filter(
-          (group) => group.metricGroup.important ?? false
+          (group) =>
+            group.metricGroup.important ??
+            group.metricGroup.addToSummaryDashboard ??
+            false
         )
       : this.metricGroups;
 

--- a/lib/monitoring/custom/CustomMonitoring.ts
+++ b/lib/monitoring/custom/CustomMonitoring.ts
@@ -170,7 +170,7 @@ export interface CustomMetricGroup {
    */
   readonly graphWidgetLegend?: LegendPosition;
   /**
-   * @deprecated use addToSummaryDashboard
+   * @deprecated use addToSummaryDashboard. addToSummaryDashboard will take precedence over important.
    * Flag indicating, whether this is an important metric group that should be included in the summary as well.
    * @default false
    */
@@ -311,8 +311,8 @@ export class CustomMonitoring extends Monitoring {
     const filteredMetricGroups = summary
       ? this.metricGroups.filter(
           (group) =>
-            group.metricGroup.important ??
             group.metricGroup.addToSummaryDashboard ??
+            group.metricGroup.important ??
             false
         )
       : this.metricGroups;

--- a/test/monitoring/custom/CustomMonitoring.test.ts
+++ b/test/monitoring/custom/CustomMonitoring.test.ts
@@ -175,6 +175,34 @@ test("snapshot test", () => {
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });
 
+test("addToSummaryDashboard attribute takes precedence over important in metric group", () => {
+  const stack = new Stack();
+  const scope = new TestMonitoringScope(stack, "Scope");
+
+  const monitoring = new CustomMonitoring(scope, {
+    alarmFriendlyName: "DummyAlarmName",
+    humanReadableName: "DummyName",
+    description: "Monitoring widget that shows up in the summary dashboard",
+    descriptionWidgetHeight: 2,
+    height: 100,
+    addToSummaryDashboard: true,
+    metricGroups: [
+      {
+        title: "DummyGroup1",
+        important: false,
+        addToSummaryDashboard: true,
+        metrics: [
+          // regular metric
+          new Metric({ metricName: "DummyMetric1", namespace, dimensionsMap }),
+        ],
+      },
+    ],
+  });
+
+  addMonitoringDashboardsToStack(stack, monitoring);
+  expect(Template.fromStack(stack)).toMatchSnapshot();
+});
+
 test("anomaly detection", () => {
   const stack = new Stack();
   const metricFactory = new MetricFactory({

--- a/test/monitoring/custom/CustomMonitoring.test.ts
+++ b/test/monitoring/custom/CustomMonitoring.test.ts
@@ -37,7 +37,7 @@ test("snapshot test", () => {
     metricGroups: [
       {
         title: "DummyGroup1",
-        important: true,
+        addToSummaryDashboard: true,
         metrics: [
           // regular metric
           new Metric({ metricName: "DummyMetric1", namespace, dimensionsMap }),
@@ -403,7 +403,7 @@ test("throws error if attempting to add alarm on a search query", () => {
         metricGroups: [
           {
             title: "DummyGroup1",
-            important: true,
+            addToSummaryDashboard: true,
             metrics: [
               {
                 searchQuery: "DummyMetric4-",
@@ -442,7 +442,7 @@ test("throws error if attempting to add both a regular alarm and an anomoly dete
         metricGroups: [
           {
             title: "DummyGroup1",
-            important: true,
+            addToSummaryDashboard: true,
             metrics: [
               {
                 metric: new Metric({

--- a/test/monitoring/custom/__snapshots__/CustomMonitoring.test.ts.snap
+++ b/test/monitoring/custom/__snapshots__/CustomMonitoring.test.ts.snap
@@ -1,5 +1,86 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`addToSummaryDashboard attribute takes precedence over important in metric group 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "Alarm7103F465": Object {
+      "Properties": Object {
+        "DashboardBody": "{\\"widgets\\":[]}",
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "Resource": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### DummyName\\"}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"markdown\\":\\"Monitoring widget that shows up in the summary dashboard\\"}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":100,\\"x\\":0,\\"y\\":3,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"DummyGroup1\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"DummyCustomNamespace\\",\\"DummyMetric1\\",\\"CustomDimension\\",\\"CustomDimensionValue\\"]],\\"yAxis\\":{}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "Summary68521F81": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### DummyName\\"}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":100,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"DummyGroup1\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"DummyCustomNamespace\\",\\"DummyMetric1\\",\\"CustomDimension\\",\\"CustomDimensionValue\\"]],\\"yAxis\\":{}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`anomaly detection 1`] = `
 Object {
   "Parameters": Object {


### PR DESCRIPTION
Resolves #242 

To keep the add to summary naming consistent the new property has been added to CustomMetricGroup.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_