### PR TITLE
feat(widget): header widget supports adding description

### DIFF
--- a/API.md
+++ b/API.md
@@ -26733,6 +26733,8 @@ const monitoringHeaderWidgetProps: MonitoringHeaderWidgetProps = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.MonitoringHeaderWidgetProps.property.title">title</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.MonitoringHeaderWidgetProps.property.description">description</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.MonitoringHeaderWidgetProps.property.descriptionHeight">descriptionHeight</a></code> | <code>number</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.MonitoringHeaderWidgetProps.property.family">family</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.MonitoringHeaderWidgetProps.property.goToLinkUrl">goToLinkUrl</a></code> | <code>string</code> | *No description.* |
 
@@ -26745,6 +26747,26 @@ public readonly title: string;
 ```
 
 - *Type:* string
+
+---
+
+##### `description`<sup>Optional</sup> <a name="description" id="cdk-monitoring-constructs.MonitoringHeaderWidgetProps.property.description"></a>
+
+```typescript
+public readonly description: string;
+```
+
+- *Type:* string
+
+---
+
+##### `descriptionHeight`<sup>Optional</sup> <a name="descriptionHeight" id="cdk-monitoring-constructs.MonitoringHeaderWidgetProps.property.descriptionHeight"></a>
+
+```typescript
+public readonly descriptionHeight: number;
+```
+
+- *Type:* number
 
 ---
 
@@ -47103,13 +47125,15 @@ public readonly title: string;
 ```typescript
 import { HeaderWidget } from 'cdk-monitoring-constructs'
 
-new HeaderWidget(text: string, level?: HeaderLevel)
+new HeaderWidget(text: string, level?: HeaderLevel, description?: string, descriptionHeight?: number)
 ```
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.HeaderWidget.Initializer.parameter.text">text</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.HeaderWidget.Initializer.parameter.level">level</a></code> | <code><a href="#cdk-monitoring-constructs.HeaderLevel">HeaderLevel</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.HeaderWidget.Initializer.parameter.description">description</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.HeaderWidget.Initializer.parameter.descriptionHeight">descriptionHeight</a></code> | <code>number</code> | *No description.* |
 
 ---
 
@@ -47122,6 +47146,18 @@ new HeaderWidget(text: string, level?: HeaderLevel)
 ##### `level`<sup>Optional</sup> <a name="level" id="cdk-monitoring-constructs.HeaderWidget.Initializer.parameter.level"></a>
 
 - *Type:* <a href="#cdk-monitoring-constructs.HeaderLevel">HeaderLevel</a>
+
+---
+
+##### `description`<sup>Optional</sup> <a name="description" id="cdk-monitoring-constructs.HeaderWidget.Initializer.parameter.description"></a>
+
+- *Type:* string
+
+---
+
+##### `descriptionHeight`<sup>Optional</sup> <a name="descriptionHeight" id="cdk-monitoring-constructs.HeaderWidget.Initializer.parameter.descriptionHeight"></a>
+
+- *Type:* number
 
 ---
 

--- a/lib/dashboard/widget/HeaderWidget.ts
+++ b/lib/dashboard/widget/HeaderWidget.ts
@@ -9,15 +9,47 @@ export enum HeaderLevel {
 }
 
 export class HeaderWidget extends TextWidget {
-  constructor(text: string, level?: HeaderLevel) {
+  constructor(
+    text: string,
+    level?: HeaderLevel,
+    description?: string,
+    descriptionHeight?: number
+  ) {
     super({
       width: FullWidth,
-      height: 1,
-      markdown: HeaderWidget.toMarkdown(text, level ?? HeaderLevel.LARGE),
+      height: HeaderWidget.calculateHeight(description, descriptionHeight),
+      markdown: HeaderWidget.toMarkdown(
+        text,
+        level ?? HeaderLevel.LARGE,
+        description
+      ),
     });
   }
 
-  private static toMarkdown(text: string, level: HeaderLevel) {
+  private static calculateHeight(
+    description?: string,
+    descriptionHeight?: number
+  ) {
+    let result = 1;
+    if (description) {
+      result += descriptionHeight ?? 1;
+    }
+    return result;
+  }
+
+  private static toMarkdown(
+    text: string,
+    level: HeaderLevel,
+    description?: string
+  ) {
+    const parts = [this.toHeaderMarkdown(text, level)];
+    if (description) {
+      parts.push(description);
+    }
+    return parts.join("\n\n");
+  }
+
+  private static toHeaderMarkdown(text: string, level: HeaderLevel) {
     return "#".repeat(level + 1) + " " + text;
   }
 }

--- a/lib/dashboard/widget/MonitoringHeaderWidget.ts
+++ b/lib/dashboard/widget/MonitoringHeaderWidget.ts
@@ -4,11 +4,18 @@ export interface MonitoringHeaderWidgetProps {
   readonly title: string;
   readonly family?: string;
   readonly goToLinkUrl?: string;
+  readonly description?: string;
+  readonly descriptionHeight?: number;
 }
 
 export class MonitoringHeaderWidget extends HeaderWidget {
   constructor(props: MonitoringHeaderWidgetProps) {
-    super(MonitoringHeaderWidget.getText(props), HeaderLevel.SMALL);
+    super(
+      MonitoringHeaderWidget.getText(props),
+      HeaderLevel.SMALL,
+      props.description,
+      props.descriptionHeight
+    );
   }
 
   private static getText(props: MonitoringHeaderWidgetProps): string {
@@ -19,7 +26,7 @@ export class MonitoringHeaderWidget extends HeaderWidget {
     }
 
     if (props.family) {
-      return `${props.family} **${title}**`;
+      title = `${props.family} **${title}**`;
     }
 
     return title;

--- a/test/dashboard/widget/HeaderWidget.test.ts
+++ b/test/dashboard/widget/HeaderWidget.test.ts
@@ -1,0 +1,24 @@
+import { HeaderLevel, HeaderWidget } from "../../../lib/dashboard/widget";
+
+test("snapshot test - title only", () => {
+  const widget = new HeaderWidget("text");
+
+  expect(widget.toJson()).toMatchSnapshot();
+});
+
+test("snapshot test - title and description, no custom height", () => {
+  const widget = new HeaderWidget("text", HeaderLevel.LARGE, "description");
+
+  expect(widget.toJson()).toMatchSnapshot();
+});
+
+test("snapshot test - title and description, with custom height", () => {
+  const widget = new HeaderWidget(
+    "text",
+    HeaderLevel.LARGE,
+    "very long description",
+    5
+  );
+
+  expect(widget.toJson()).toMatchSnapshot();
+});

--- a/test/dashboard/widget/MonitoringHeaderWidget.test.ts
+++ b/test/dashboard/widget/MonitoringHeaderWidget.test.ts
@@ -36,3 +36,26 @@ test("snapshot test: with link and custom text", () => {
 
   expect(widget.toJson()).toMatchSnapshot();
 });
+
+test("snapshot test: with link, custom text and description", () => {
+  const widget = new MonitoringHeaderWidget({
+    title: "DummyTitle",
+    family: "DummyFamily",
+    goToLinkUrl: "http://amazon.com",
+    description: "CustomDescription",
+  });
+
+  expect(widget.toJson()).toMatchSnapshot();
+});
+
+test("snapshot test: with link, custom text and description with custom height", () => {
+  const widget = new MonitoringHeaderWidget({
+    title: "DummyTitle",
+    family: "DummyFamily",
+    goToLinkUrl: "http://amazon.com",
+    description: "CustomDescription",
+    descriptionHeight: 10,
+  });
+
+  expect(widget.toJson()).toMatchSnapshot();
+});

--- a/test/dashboard/widget/__snapshots__/HeaderWidget.test.ts.snap
+++ b/test/dashboard/widget/__snapshots__/HeaderWidget.test.ts.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snapshot test - title and description, no custom height 1`] = `
+Array [
+  Object {
+    "height": 2,
+    "properties": Object {
+      "markdown": "# text
+
+description",
+    },
+    "type": "text",
+    "width": 24,
+    "x": undefined,
+    "y": undefined,
+  },
+]
+`;
+
+exports[`snapshot test - title and description, with custom height 1`] = `
+Array [
+  Object {
+    "height": 6,
+    "properties": Object {
+      "markdown": "# text
+
+very long description",
+    },
+    "type": "text",
+    "width": 24,
+    "x": undefined,
+    "y": undefined,
+  },
+]
+`;
+
+exports[`snapshot test - title only 1`] = `
+Array [
+  Object {
+    "height": 1,
+    "properties": Object {
+      "markdown": "# text",
+    },
+    "type": "text",
+    "width": 24,
+    "x": undefined,
+    "y": undefined,
+  },
+]
+`;

--- a/test/dashboard/widget/__snapshots__/MonitoringHeaderWidget.test.ts.snap
+++ b/test/dashboard/widget/__snapshots__/MonitoringHeaderWidget.test.ts.snap
@@ -59,3 +59,37 @@ Array [
   },
 ]
 `;
+
+exports[`snapshot test: with link, custom text and description 1`] = `
+Array [
+  Object {
+    "height": 2,
+    "properties": Object {
+      "markdown": "### DummyFamily **[DummyTitle](http://amazon.com)**
+
+CustomDescription",
+    },
+    "type": "text",
+    "width": 24,
+    "x": undefined,
+    "y": undefined,
+  },
+]
+`;
+
+exports[`snapshot test: with link, custom text and description with custom height 1`] = `
+Array [
+  Object {
+    "height": 11,
+    "properties": Object {
+      "markdown": "### DummyFamily **[DummyTitle](http://amazon.com)**
+
+CustomDescription",
+    },
+    "type": "text",
+    "width": 24,
+    "x": undefined,
+    "y": undefined,
+  },
+]
+`;


### PR DESCRIPTION
Adding support for description. Later can be used to add generic description parameters to every monitoring props (user ask).

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_