### PR TITLE
fix(appsync): allow imported `IGraphqlApi` resources

### DIFF
--- a/API.md
+++ b/API.md
@@ -6178,7 +6178,7 @@ const appSyncMetricFactoryProps: AppSyncMetricFactoryProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#cdk-monitoring-constructs.AppSyncMetricFactoryProps.property.api">api</a></code> | <code>@aws-cdk/aws-appsync-alpha.GraphqlApi</code> | the GraphQL API to monitor. |
+| <code><a href="#cdk-monitoring-constructs.AppSyncMetricFactoryProps.property.api">api</a></code> | <code>@aws-cdk/aws-appsync-alpha.IGraphqlApi</code> | the GraphQL API to monitor. |
 | <code><a href="#cdk-monitoring-constructs.AppSyncMetricFactoryProps.property.fillTpsWithZeroes">fillTpsWithZeroes</a></code> | <code>boolean</code> | whether the TPS should be filled with zeroes. |
 | <code><a href="#cdk-monitoring-constructs.AppSyncMetricFactoryProps.property.rateComputationMethod">rateComputationMethod</a></code> | <code><a href="#cdk-monitoring-constructs.RateComputationMethod">RateComputationMethod</a></code> | method to compute TPS. |
 
@@ -6187,10 +6187,10 @@ const appSyncMetricFactoryProps: AppSyncMetricFactoryProps = { ... }
 ##### `api`<sup>Required</sup> <a name="api" id="cdk-monitoring-constructs.AppSyncMetricFactoryProps.property.api"></a>
 
 ```typescript
-public readonly api: GraphqlApi;
+public readonly api: IGraphqlApi;
 ```
 
-- *Type:* @aws-cdk/aws-appsync-alpha.GraphqlApi
+- *Type:* @aws-cdk/aws-appsync-alpha.IGraphqlApi
 
 the GraphQL API to monitor.
 
@@ -6473,7 +6473,7 @@ const appSyncMonitoringProps: AppSyncMonitoringProps = { ... }
 | <code><a href="#cdk-monitoring-constructs.AppSyncMonitoringProps.property.addLatencyP90Alarm">addLatencyP90Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.AppSyncMonitoringProps.property.addLatencyP99Alarm">addLatencyP99Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.AppSyncMonitoringProps.property.addLowTpsAlarm">addLowTpsAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LowTpsThreshold">LowTpsThreshold</a>}</code> | *No description.* |
-| <code><a href="#cdk-monitoring-constructs.AppSyncMonitoringProps.property.api">api</a></code> | <code>@aws-cdk/aws-appsync-alpha.GraphqlApi</code> | the GraphQL API to monitor. |
+| <code><a href="#cdk-monitoring-constructs.AppSyncMonitoringProps.property.api">api</a></code> | <code>@aws-cdk/aws-appsync-alpha.IGraphqlApi</code> | the GraphQL API to monitor. |
 | <code><a href="#cdk-monitoring-constructs.AppSyncMonitoringProps.property.fillTpsWithZeroes">fillTpsWithZeroes</a></code> | <code>boolean</code> | whether the TPS should be filled with zeroes. |
 | <code><a href="#cdk-monitoring-constructs.AppSyncMonitoringProps.property.rateComputationMethod">rateComputationMethod</a></code> | <code><a href="#cdk-monitoring-constructs.RateComputationMethod">RateComputationMethod</a></code> | method to compute TPS. |
 
@@ -6670,10 +6670,10 @@ public readonly addLowTpsAlarm: {[ key: string ]: LowTpsThreshold};
 ##### `api`<sup>Required</sup> <a name="api" id="cdk-monitoring-constructs.AppSyncMonitoringProps.property.api"></a>
 
 ```typescript
-public readonly api: GraphqlApi;
+public readonly api: IGraphqlApi;
 ```
 
-- *Type:* @aws-cdk/aws-appsync-alpha.GraphqlApi
+- *Type:* @aws-cdk/aws-appsync-alpha.IGraphqlApi
 
 the GraphQL API to monitor.
 

--- a/lib/monitoring/aws-appsync/AppSyncMetricFactory.ts
+++ b/lib/monitoring/aws-appsync/AppSyncMetricFactory.ts
@@ -1,4 +1,4 @@
-import { GraphqlApi } from "@aws-cdk/aws-appsync-alpha";
+import { IGraphqlApi } from "@aws-cdk/aws-appsync-alpha";
 import { DimensionsMap } from "aws-cdk-lib/aws-cloudwatch";
 
 import {
@@ -13,7 +13,7 @@ export interface AppSyncMetricFactoryProps {
   /**
    * the GraphQL API to monitor
    */
-  readonly api: GraphqlApi;
+  readonly api: IGraphqlApi;
   /**
    * whether the TPS should be filled with zeroes
    * @default - true

--- a/test/monitoring/aws-appsync/AppSyncMonitoring.test.ts
+++ b/test/monitoring/aws-appsync/AppSyncMonitoring.test.ts
@@ -1,4 +1,4 @@
-import { GraphqlApi } from "@aws-cdk/aws-appsync-alpha";
+import { GraphqlApi, IGraphqlApi } from "@aws-cdk/aws-appsync-alpha";
 import { Duration, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
 
@@ -14,6 +14,29 @@ test("snapshot test: no alarms", () => {
   const dummyApi = new GraphqlApi(stack, "testHttpApi", {
     name: "DummyApi",
   });
+
+  const monitoring = new AppSyncMonitoring(scope, {
+    api: dummyApi,
+    humanReadableName: "Dummy API for testing",
+    alarmFriendlyName: "DummyApi",
+  });
+
+  addMonitoringDashboardsToStack(stack, monitoring);
+  expect(Template.fromStack(stack)).toMatchSnapshot();
+});
+
+test("snapshot test: no alarms with imported IGraphqlApi", () => {
+  const stack = new Stack();
+
+  const scope = new TestMonitoringScope(stack, "Scope");
+
+  const dummyApi: IGraphqlApi = GraphqlApi.fromGraphqlApiAttributes(
+    scope,
+    "ImportedGraphQlApi",
+    {
+      graphqlApiId: "DummyApiFromElsewhere",
+    }
+  );
 
   const monitoring = new AppSyncMonitoring(scope, {
     api: dummyApi,

--- a/test/monitoring/aws-appsync/__snapshots__/AppSyncMonitoring.test.ts.snap
+++ b/test/monitoring/aws-appsync/__snapshots__/AppSyncMonitoring.test.ts.snap
@@ -930,3 +930,104 @@ Object {
   },
 }
 `;
+
+exports[`snapshot test: no alarms with imported IGraphqlApi 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "Alarm7103F465": Object {
+      "Properties": Object {
+        "DashboardBody": "{\\"widgets\\":[]}",
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "Resource": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### AppSync GraphQL API **Dummy API for testing**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"TPS (min: \${MIN}, max: \${MAX}, avg: \${AVG})\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\"}],[\\"AWS/AppSync\\",\\"Latency\\",\\"GraphQLAPIId\\",\\"DummyApiFromElsewhere\\",{\\"label\\":\\"Requests\\",\\"stat\\":\\"SampleCount\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/AppSync\\",\\"Latency\\",\\"GraphQLAPIId\\",\\"DummyApiFromElsewhere\\",{\\"label\\":\\"P50\\",\\"stat\\":\\"p50\\"}],[\\"AWS/AppSync\\",\\"Latency\\",\\"GraphQLAPIId\\",\\"DummyApiFromElsewhere\\",{\\"label\\":\\"P90\\",\\"stat\\":\\"p90\\"}],[\\"AWS/AppSync\\",\\"Latency\\",\\"GraphQLAPIId\\",\\"DummyApiFromElsewhere\\",{\\"label\\":\\"P99\\",\\"stat\\":\\"p99\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/AppSync\\",\\"4XXError\\",\\"GraphQLAPIId\\",\\"DummyApiFromElsewhere\\",{\\"label\\":\\"4XX Error\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/AppSync\\",\\"5XXError\\",\\"GraphQLAPIId\\",\\"DummyApiFromElsewhere\\",{\\"label\\":\\"5XX Fault\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/AppSync\\",\\"4XXError\\",\\"GraphQLAPIId\\",\\"DummyApiFromElsewhere\\",{\\"label\\":\\"4XX Error (avg)\\"}],[\\"AWS/AppSync\\",\\"5XXError\\",\\"GraphQLAPIId\\",\\"DummyApiFromElsewhere\\",{\\"label\\":\\"5XX Fault (avg)\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "Summary68521F81": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### AppSync GraphQL API **Dummy API for testing**\\"}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"TPS (min: \${MIN}, max: \${MAX}, avg: \${AVG})\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\"}],[\\"AWS/AppSync\\",\\"Latency\\",\\"GraphQLAPIId\\",\\"DummyApiFromElsewhere\\",{\\"label\\":\\"Requests\\",\\"stat\\":\\"SampleCount\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/AppSync\\",\\"Latency\\",\\"GraphQLAPIId\\",\\"DummyApiFromElsewhere\\",{\\"label\\":\\"P50\\",\\"stat\\":\\"p50\\"}],[\\"AWS/AppSync\\",\\"Latency\\",\\"GraphQLAPIId\\",\\"DummyApiFromElsewhere\\",{\\"label\\":\\"P90\\",\\"stat\\":\\"p90\\"}],[\\"AWS/AppSync\\",\\"Latency\\",\\"GraphQLAPIId\\",\\"DummyApiFromElsewhere\\",{\\"label\\":\\"P99\\",\\"stat\\":\\"p99\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/AppSync\\",\\"4XXError\\",\\"GraphQLAPIId\\",\\"DummyApiFromElsewhere\\",{\\"label\\":\\"4XX Error (avg)\\"}],[\\"AWS/AppSync\\",\\"5XXError\\",\\"GraphQLAPIId\\",\\"DummyApiFromElsewhere\\",{\\"label\\":\\"5XX Fault (avg)\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;


### PR DESCRIPTION
To stay consistent with other parts of the library.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_