### PR TITLE
feat(custom): use addToSummaryDashboard from CustomMonitoringProps if not specified in metric groups

### DIFF
--- a/API.md
+++ b/API.md
@@ -10265,7 +10265,7 @@ public readonly addToSummaryDashboard: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* false
+- *Default:* addToSummaryDashboard from CustomMonitoringProps, defaulting to false
 
 Flag indicating this metric group should be included in the summary as well.
 
@@ -10350,14 +10350,14 @@ optional custom horizontal annotations which will be displayed over the metrics 
 ##### ~~`important`~~<sup>Optional</sup> <a name="important" id="cdk-monitoring-constructs.CustomMetricGroup.property.important"></a>
 
 - *Deprecated:* use addToSummaryDashboard. addToSummaryDashboard will take precedence over important.
-Flag indicating, whether this is an important metric group that should be included in the summary as well.
 
 ```typescript
 public readonly important: boolean;
 ```
 
 - *Type:* boolean
-- *Default:* false
+
+> [addToSummaryDashboard](addToSummaryDashboard)
 
 ---
 
@@ -42551,6 +42551,7 @@ Returns widgets to be placed on the main dashboard.
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#cdk-monitoring-constructs.CustomMonitoring.property.addToSummaryDashboard">addToSummaryDashboard</a></code> | <code>boolean</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.CustomMonitoring.property.anomalyDetectingAlarmFactory">anomalyDetectingAlarmFactory</a></code> | <code><a href="#cdk-monitoring-constructs.AnomalyDetectingAlarmFactory">AnomalyDetectingAlarmFactory</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.CustomMonitoring.property.customAlarmFactory">customAlarmFactory</a></code> | <code><a href="#cdk-monitoring-constructs.CustomAlarmFactory">CustomAlarmFactory</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.CustomMonitoring.property.metricGroups">metricGroups</a></code> | <code><a href="#cdk-monitoring-constructs.CustomMetricGroupWithAnnotations">CustomMetricGroupWithAnnotations</a>[]</code> | *No description.* |
@@ -42558,6 +42559,16 @@ Returns widgets to be placed on the main dashboard.
 | <code><a href="#cdk-monitoring-constructs.CustomMonitoring.property.description">description</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.CustomMonitoring.property.descriptionWidgetHeight">descriptionWidgetHeight</a></code> | <code>number</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.CustomMonitoring.property.height">height</a></code> | <code>number</code> | *No description.* |
+
+---
+
+##### `addToSummaryDashboard`<sup>Required</sup> <a name="addToSummaryDashboard" id="cdk-monitoring-constructs.CustomMonitoring.property.addToSummaryDashboard"></a>
+
+```typescript
+public readonly addToSummaryDashboard: boolean;
+```
+
+- *Type:* boolean
 
 ---
 

--- a/lib/monitoring/custom/CustomMonitoring.ts
+++ b/lib/monitoring/custom/CustomMonitoring.ts
@@ -171,13 +171,12 @@ export interface CustomMetricGroup {
   readonly graphWidgetLegend?: LegendPosition;
   /**
    * @deprecated use addToSummaryDashboard. addToSummaryDashboard will take precedence over important.
-   * Flag indicating, whether this is an important metric group that should be included in the summary as well.
-   * @default false
+   * @see addToSummaryDashboard
    */
   readonly important?: boolean;
   /**
    * Flag indicating this metric group should be included in the summary as well.
-   * @default false
+   * @default - addToSummaryDashboard from CustomMonitoringProps, defaulting to false
    */
   readonly addToSummaryDashboard?: boolean;
   /**
@@ -238,6 +237,7 @@ export class CustomMonitoring extends Monitoring {
   readonly description?: string;
   readonly descriptionWidgetHeight?: number;
   readonly height?: number;
+  readonly addToSummaryDashboard: boolean;
   readonly customAlarmFactory: CustomAlarmFactory;
   readonly anomalyDetectingAlarmFactory: AnomalyDetectingAlarmFactory;
   readonly metricGroups: CustomMetricGroupWithAnnotations[];
@@ -251,6 +251,7 @@ export class CustomMonitoring extends Monitoring {
     this.description = props.description;
     this.descriptionWidgetHeight = props.descriptionWidgetHeight;
     this.height = props.height;
+    this.addToSummaryDashboard = props.addToSummaryDashboard ?? false;
 
     const alarmFactory = this.createAlarmFactory(
       namingStrategy.resolveAlarmFriendlyName()
@@ -313,7 +314,7 @@ export class CustomMonitoring extends Monitoring {
           (group) =>
             group.metricGroup.addToSummaryDashboard ??
             group.metricGroup.important ??
-            false
+            this.addToSummaryDashboard
         )
       : this.metricGroups;
 

--- a/test/monitoring/custom/CustomMonitoring.test.ts
+++ b/test/monitoring/custom/CustomMonitoring.test.ts
@@ -189,8 +189,34 @@ test("addToSummaryDashboard attribute takes precedence over important in metric 
     metricGroups: [
       {
         title: "DummyGroup1",
-        important: false,
         addToSummaryDashboard: true,
+        important: false,
+        metrics: [
+          // regular metric
+          new Metric({ metricName: "DummyMetric1", namespace, dimensionsMap }),
+        ],
+      },
+    ],
+  });
+
+  addMonitoringDashboardsToStack(stack, monitoring);
+  expect(Template.fromStack(stack)).toMatchSnapshot();
+});
+
+test("addToSummaryDashboard attribute takes value from CustomMonitoringProps if not specified in metric group", () => {
+  const stack = new Stack();
+  const scope = new TestMonitoringScope(stack, "Scope");
+
+  const monitoring = new CustomMonitoring(scope, {
+    alarmFriendlyName: "DummyAlarmName",
+    humanReadableName: "DummyName",
+    description: "Monitoring widget that shows up in the summary dashboard",
+    descriptionWidgetHeight: 2,
+    height: 100,
+    addToSummaryDashboard: true,
+    metricGroups: [
+      {
+        title: "DummyGroup1",
         metrics: [
           // regular metric
           new Metric({ metricName: "DummyMetric1", namespace, dimensionsMap }),

--- a/test/monitoring/custom/__snapshots__/CustomMonitoring.test.ts.snap
+++ b/test/monitoring/custom/__snapshots__/CustomMonitoring.test.ts.snap
@@ -81,6 +81,87 @@ Object {
 }
 `;
 
+exports[`addToSummaryDashboard attribute takes value from CustomMonitoringProps if not specified in metric group 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "Alarm7103F465": Object {
+      "Properties": Object {
+        "DashboardBody": "{\\"widgets\\":[]}",
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "Resource": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### DummyName\\"}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":2,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"markdown\\":\\"Monitoring widget that shows up in the summary dashboard\\"}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":100,\\"x\\":0,\\"y\\":3,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"DummyGroup1\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"DummyCustomNamespace\\",\\"DummyMetric1\\",\\"CustomDimension\\",\\"CustomDimensionValue\\"]],\\"yAxis\\":{}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "Summary68521F81": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### DummyName\\"}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":100,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"DummyGroup1\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"DummyCustomNamespace\\",\\"DummyMetric1\\",\\"CustomDimension\\",\\"CustomDimensionValue\\"]],\\"yAxis\\":{}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`anomaly detection 1`] = `
 Object {
   "Parameters": Object {


### PR DESCRIPTION
It's confusing that the top-level `addToSummaryDashboard` didn't do anything. This is now the lowest-precedence way to add things to the summary dashboard. This still defaults to `false` to maintain existing behaviour.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_