### PR TITLE
fix(UsageAlarmFactory): allowing addition of multiple alarms from the same class

### DIFF
--- a/API.md
+++ b/API.md
@@ -59230,7 +59230,7 @@ new UsageAlarmFactory(alarmFactory: AlarmFactory)
 ##### `addMaxCpuUsagePercentAlarm` <a name="addMaxCpuUsagePercentAlarm" id="cdk-monitoring-constructs.UsageAlarmFactory.addMaxCpuUsagePercentAlarm"></a>
 
 ```typescript
-public addMaxCpuUsagePercentAlarm(percentMetric: Metric | MathExpression, props: UsageThreshold, disambiguator?: string): AlarmWithAnnotation
+public addMaxCpuUsagePercentAlarm(percentMetric: Metric | MathExpression, props: UsageThreshold, disambiguator?: string, usageType?: UsageType): AlarmWithAnnotation
 ```
 
 ###### `percentMetric`<sup>Required</sup> <a name="percentMetric" id="cdk-monitoring-constructs.UsageAlarmFactory.addMaxCpuUsagePercentAlarm.parameter.percentMetric"></a>
@@ -59248,6 +59248,12 @@ public addMaxCpuUsagePercentAlarm(percentMetric: Metric | MathExpression, props:
 ###### `disambiguator`<sup>Optional</sup> <a name="disambiguator" id="cdk-monitoring-constructs.UsageAlarmFactory.addMaxCpuUsagePercentAlarm.parameter.disambiguator"></a>
 
 - *Type:* string
+
+---
+
+###### `usageType`<sup>Optional</sup> <a name="usageType" id="cdk-monitoring-constructs.UsageAlarmFactory.addMaxCpuUsagePercentAlarm.parameter.usageType"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.UsageType">UsageType</a>
 
 ---
 

--- a/lib/common/monitoring/alarms/UsageAlarmFactory.ts
+++ b/lib/common/monitoring/alarms/UsageAlarmFactory.ts
@@ -56,6 +56,13 @@ export class UsageAlarmFactory {
     });
   }
 
+  /**
+   * @deprecated Did not allow support of adding multiple metrics from the same class.
+   * @param percentMetric 
+   * @param props 
+   * @param disambiguator 
+   * @returns 
+   */
   addMaxCpuUsagePercentAlarm(
     percentMetric: MetricWithAlarmSupport,
     props: UsageThreshold,
@@ -71,6 +78,31 @@ export class UsageAlarmFactory {
       disambiguator,
       threshold: props.maxUsagePercent,
       alarmNameSuffix: "CPU-Usage",
+      alarmDescription: "The CPU usage is too high.",
+    });
+  }
+
+  /**
+   * Allows addition of multiple metrics from the same class.
+   * @param percentMetric 
+   * @param usageType Will be added to Alarm name
+   * @param props 
+   * @param disambiguator 
+   * @returns 
+   */
+  addMaxCpuUsagePercentAlarms(
+    percentMetric: MetricWithAlarmSupport,
+    usageType: UsageType,
+    props: UsageThreshold,
+    disambiguator?: string
+  ) {
+    return this.alarmFactory.addAlarm(percentMetric, {
+      treatMissingData: props.treatMissingDataOverride ?? TreatMissingData.MISSING,
+      comparisonOperator: props.comparisonOperatorOverride ?? ComparisonOperator.GREATER_THAN_THRESHOLD,
+      ...props,
+      disambiguator,
+      threshold: props.maxUsagePercent,
+      alarmNameSuffix: `CPU-Usage-${usageType}`,
       alarmDescription: "The CPU usage is too high.",
     });
   }

--- a/lib/common/monitoring/alarms/UsageAlarmFactory.ts
+++ b/lib/common/monitoring/alarms/UsageAlarmFactory.ts
@@ -56,18 +56,14 @@ export class UsageAlarmFactory {
     });
   }
 
-  /**
-   * @deprecated Did not allow support of adding multiple metrics from the same class.
-   * @param percentMetric 
-   * @param props 
-   * @param disambiguator 
-   * @returns 
-   */
   addMaxCpuUsagePercentAlarm(
     percentMetric: MetricWithAlarmSupport,
     props: UsageThreshold,
-    disambiguator?: string
+    disambiguator?: string,
+    usageType?: UsageType
   ) {
+    const alarmNameSuffix: string =
+      usageType === undefined ? "CPU-Usage" : `${usageType}-CPU-Usage`;
     return this.alarmFactory.addAlarm(percentMetric, {
       treatMissingData:
         props.treatMissingDataOverride ?? TreatMissingData.MISSING,
@@ -77,32 +73,7 @@ export class UsageAlarmFactory {
       ...props,
       disambiguator,
       threshold: props.maxUsagePercent,
-      alarmNameSuffix: "CPU-Usage",
-      alarmDescription: "The CPU usage is too high.",
-    });
-  }
-
-  /**
-   * Allows addition of multiple metrics from the same class.
-   * @param percentMetric 
-   * @param usageType Will be added to Alarm name
-   * @param props 
-   * @param disambiguator 
-   * @returns 
-   */
-  addMaxCpuUsagePercentAlarms(
-    percentMetric: MetricWithAlarmSupport,
-    usageType: UsageType,
-    props: UsageThreshold,
-    disambiguator?: string
-  ) {
-    return this.alarmFactory.addAlarm(percentMetric, {
-      treatMissingData: props.treatMissingDataOverride ?? TreatMissingData.MISSING,
-      comparisonOperator: props.comparisonOperatorOverride ?? ComparisonOperator.GREATER_THAN_THRESHOLD,
-      ...props,
-      disambiguator,
-      threshold: props.maxUsagePercent,
-      alarmNameSuffix: `CPU-Usage-${usageType}`,
+      alarmNameSuffix,
       alarmDescription: "The CPU usage is too high.",
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -800,7 +800,7 @@
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"
 
-"@types/babel__traverse@*", "@types/babel__traverse@^7.0.4", "@types/babel__traverse@^7.0.6":
+"@types/babel__traverse@*", "@types/babel__traverse@7.18.2", "@types/babel__traverse@^7.0.4", "@types/babel__traverse@^7.0.6":
   version "7.18.2"
   resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.18.2.tgz#235bf339d17185bdec25e024ca19cce257cc7309"
   integrity sha512-FcFaxOr2V5KZCviw1TnutEMVUVsGt4D2hP1TAfXZAMKuHYW3xQhe3jTxNPWutgCJ3/X1c5yX8ZoGVEItxKbwBg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -800,7 +800,7 @@
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"
 
-"@types/babel__traverse@*", "@types/babel__traverse@7.18.2", "@types/babel__traverse@^7.0.4", "@types/babel__traverse@^7.0.6":
+"@types/babel__traverse@*", "@types/babel__traverse@^7.0.4", "@types/babel__traverse@^7.0.6":
   version "7.18.2"
   resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.18.2.tgz#235bf339d17185bdec25e024ca19cce257cc7309"
   integrity sha512-FcFaxOr2V5KZCviw1TnutEMVUVsGt4D2hP1TAfXZAMKuHYW3xQhe3jTxNPWutgCJ3/X1c5yX8ZoGVEItxKbwBg==


### PR DESCRIPTION
Fixes # Addition of multiple alarms from the sameclass

UsageAlarmFactory is creating same AlarmSuffix  for every alarm that is being added in a class which leads to creation of duplicate alarms, as they have same name. This fix appends the UsageType to the alarm name thus allowing users to create alarm on avg, p50,p90... all metrics from the same class.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_