### PR TITLE
fix(UsageAlarmFactory) adding support to add multiple alarms from sam…

### DIFF
--- a/API.md
+++ b/API.md
@@ -59241,7 +59241,7 @@ new UsageAlarmFactory(alarmFactory: AlarmFactory)
 ##### `addMaxCpuUsagePercentAlarm` <a name="addMaxCpuUsagePercentAlarm" id="cdk-monitoring-constructs.UsageAlarmFactory.addMaxCpuUsagePercentAlarm"></a>
 
 ```typescript
-public addMaxCpuUsagePercentAlarm(percentMetric: Metric | MathExpression, props: UsageThreshold, disambiguator?: string): AlarmWithAnnotation
+public addMaxCpuUsagePercentAlarm(percentMetric: Metric | MathExpression, props: UsageThreshold, disambiguator?: string, usageType?: UsageType): AlarmWithAnnotation
 ```
 
 ###### `percentMetric`<sup>Required</sup> <a name="percentMetric" id="cdk-monitoring-constructs.UsageAlarmFactory.addMaxCpuUsagePercentAlarm.parameter.percentMetric"></a>
@@ -59259,6 +59259,12 @@ public addMaxCpuUsagePercentAlarm(percentMetric: Metric | MathExpression, props:
 ###### `disambiguator`<sup>Optional</sup> <a name="disambiguator" id="cdk-monitoring-constructs.UsageAlarmFactory.addMaxCpuUsagePercentAlarm.parameter.disambiguator"></a>
 
 - *Type:* string
+
+---
+
+###### `usageType`<sup>Optional</sup> <a name="usageType" id="cdk-monitoring-constructs.UsageAlarmFactory.addMaxCpuUsagePercentAlarm.parameter.usageType"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.UsageType">UsageType</a>
 
 ---
 

--- a/lib/common/monitoring/alarms/UsageAlarmFactory.ts
+++ b/lib/common/monitoring/alarms/UsageAlarmFactory.ts
@@ -59,8 +59,11 @@ export class UsageAlarmFactory {
   addMaxCpuUsagePercentAlarm(
     percentMetric: MetricWithAlarmSupport,
     props: UsageThreshold,
-    disambiguator?: string
+    disambiguator?: string,
+    usageType?: UsageType
   ) {
+    const alarmNameSuffix: string =
+      usageType === undefined ? "CPU-Usage" : `${usageType}-CPU-Usage`;
     return this.alarmFactory.addAlarm(percentMetric, {
       treatMissingData:
         props.treatMissingDataOverride ?? TreatMissingData.MISSING,
@@ -70,7 +73,7 @@ export class UsageAlarmFactory {
       ...props,
       disambiguator,
       threshold: props.maxUsagePercent,
-      alarmNameSuffix: "CPU-Usage",
+      alarmNameSuffix,
       alarmDescription: "The CPU usage is too high.",
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -800,7 +800,7 @@
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"
 
-"@types/babel__traverse@*", "@types/babel__traverse@^7.0.4", "@types/babel__traverse@^7.0.6":
+"@types/babel__traverse@*", "@types/babel__traverse@7.18.2", "@types/babel__traverse@^7.0.4", "@types/babel__traverse@^7.0.6":
   version "7.18.2"
   resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.18.2.tgz#235bf339d17185bdec25e024ca19cce257cc7309"
   integrity sha512-FcFaxOr2V5KZCviw1TnutEMVUVsGt4D2hP1TAfXZAMKuHYW3xQhe3jTxNPWutgCJ3/X1c5yX8ZoGVEItxKbwBg==


### PR DESCRIPTION
…e class

Fixes #
UsageAlarmFactory is creating same AlarmSuffix for every alarm that is being added in a class which leads to creation of duplicate alarms, as they have same name. This fix appends the UsageType to the alarm name thus allowing users to create alarm on avg, p50,p90... all metrics from the same class.
---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_