### PR TITLE
feat!: use stable appsync module

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -2,22 +2,17 @@
   "dependencies": [
     {
       "name": "@aws-cdk/aws-apigatewayv2-alpha",
-      "version": "2.18.0-alpha.0",
-      "type": "build"
-    },
-    {
-      "name": "@aws-cdk/aws-appsync-alpha",
-      "version": "2.18.0-alpha.0",
+      "version": "2.60.0-alpha.0",
       "type": "build"
     },
     {
       "name": "@aws-cdk/aws-redshift-alpha",
-      "version": "2.18.0-alpha.0",
+      "version": "2.60.0-alpha.0",
       "type": "build"
     },
     {
       "name": "@aws-cdk/aws-synthetics-alpha",
-      "version": "2.18.0-alpha.0",
+      "version": "2.60.0-alpha.0",
       "type": "build"
     },
     {
@@ -42,7 +37,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "2.18.0",
+      "version": "2.60.0",
       "type": "build"
     },
     {
@@ -134,22 +129,17 @@
     },
     {
       "name": "@aws-cdk/aws-apigatewayv2-alpha",
-      "version": "2.18.0-alpha.0",
-      "type": "devenv"
-    },
-    {
-      "name": "@aws-cdk/aws-appsync-alpha",
-      "version": "2.18.0-alpha.0",
+      "version": "2.60.0-alpha.0",
       "type": "devenv"
     },
     {
       "name": "@aws-cdk/aws-redshift-alpha",
-      "version": "2.18.0-alpha.0",
+      "version": "2.60.0-alpha.0",
       "type": "devenv"
     },
     {
       "name": "@aws-cdk/aws-synthetics-alpha",
-      "version": "2.18.0-alpha.0",
+      "version": "2.60.0-alpha.0",
       "type": "devenv"
     },
     {
@@ -169,27 +159,22 @@
     },
     {
       "name": "@aws-cdk/aws-apigatewayv2-alpha",
-      "version": "^2.18.0-alpha.0",
-      "type": "peer"
-    },
-    {
-      "name": "@aws-cdk/aws-appsync-alpha",
-      "version": "^2.18.0-alpha.0",
+      "version": "^2.60.0-alpha.0",
       "type": "peer"
     },
     {
       "name": "@aws-cdk/aws-redshift-alpha",
-      "version": "^2.18.0-alpha.0",
+      "version": "^2.60.0-alpha.0",
       "type": "peer"
     },
     {
       "name": "@aws-cdk/aws-synthetics-alpha",
-      "version": "^2.18.0-alpha.0",
+      "version": "^2.60.0-alpha.0",
       "type": "peer"
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.18.0",
+      "version": "^2.60.0",
       "type": "peer"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -215,7 +215,7 @@
       "description": "Prepare a release from \"main\" branch",
       "env": {
         "RELEASE": "true",
-        "MAJOR": "1"
+        "MAJOR": "2"
       },
       "steps": [
         {
@@ -284,19 +284,19 @@
           "exec": "yarn upgrade npm-check-updates"
         },
         {
-          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='@aws-cdk/aws-apigatewayv2-alpha,@aws-cdk/aws-appsync-alpha,@aws-cdk/aws-redshift-alpha,@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs,@types/prettier'"
+          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='@aws-cdk/aws-apigatewayv2-alpha,@aws-cdk/aws-redshift-alpha,@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs,@types/prettier'"
         },
         {
-          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='@aws-cdk/aws-apigatewayv2-alpha,@aws-cdk/aws-appsync-alpha,@aws-cdk/aws-redshift-alpha,@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs,@types/prettier'"
+          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='@aws-cdk/aws-apigatewayv2-alpha,@aws-cdk/aws-redshift-alpha,@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs,@types/prettier'"
         },
         {
-          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='@aws-cdk/aws-apigatewayv2-alpha,@aws-cdk/aws-appsync-alpha,@aws-cdk/aws-redshift-alpha,@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs,@types/prettier'"
+          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='@aws-cdk/aws-apigatewayv2-alpha,@aws-cdk/aws-redshift-alpha,@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs,@types/prettier'"
         },
         {
-          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='@aws-cdk/aws-apigatewayv2-alpha,@aws-cdk/aws-appsync-alpha,@aws-cdk/aws-redshift-alpha,@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs,@types/prettier'"
+          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='@aws-cdk/aws-apigatewayv2-alpha,@aws-cdk/aws-redshift-alpha,@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs,@types/prettier'"
         },
         {
-          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='@aws-cdk/aws-apigatewayv2-alpha,@aws-cdk/aws-appsync-alpha,@aws-cdk/aws-redshift-alpha,@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs,@types/prettier'"
+          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='@aws-cdk/aws-apigatewayv2-alpha,@aws-cdk/aws-redshift-alpha,@aws-cdk/aws-synthetics-alpha,aws-cdk-lib,constructs,@types/prettier'"
         },
         {
           "exec": "yarn install --check-files"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -1,7 +1,7 @@
 const { awscdk, javascript, DependencyType } = require("projen");
 const { workflows } = require("projen/lib/github");
 
-const CDK_VERSION = "2.18.0";
+const CDK_VERSION = "2.60.0";
 
 const project = new awscdk.AwsCdkConstructLibrary({
   name: "cdk-monitoring-constructs",
@@ -11,7 +11,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   keywords: ["cloudwatch", "monitoring"],
 
   defaultReleaseBranch: "main",
-  majorVersion: 1,
+  majorVersion: 2,
   stability: "experimental",
 
   cdkVersion: CDK_VERSION,
@@ -79,7 +79,6 @@ _By submitting this pull request, I confirm that my contribution is made under t
 // Experimental modules
 [
   "@aws-cdk/aws-apigatewayv2-alpha",
-  "@aws-cdk/aws-appsync-alpha",
   "@aws-cdk/aws-redshift-alpha",
   "@aws-cdk/aws-synthetics-alpha",
 ].forEach((dep) => {

--- a/API.md
+++ b/API.md
@@ -105,6 +105,7 @@ to each other.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.BitmapDashboard.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#cdk-monitoring-constructs.BitmapDashboard.isOwnedResource">isOwnedResource</a></code> | Returns true if the construct was created by CDK, and false otherwise. |
 | <code><a href="#cdk-monitoring-constructs.BitmapDashboard.isResource">isResource</a></code> | Check whether the given construct is a Resource. |
 
 ---
@@ -124,6 +125,22 @@ Checks if `x` is a construct.
 - *Type:* any
 
 Any object.
+
+---
+
+##### `isOwnedResource` <a name="isOwnedResource" id="cdk-monitoring-constructs.BitmapDashboard.isOwnedResource"></a>
+
+```typescript
+import { BitmapDashboard } from 'cdk-monitoring-constructs'
+
+BitmapDashboard.isOwnedResource(construct: IConstruct)
+```
+
+Returns true if the construct was created by CDK, and false otherwise.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="cdk-monitoring-constructs.BitmapDashboard.isOwnedResource.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
 
 ---
 
@@ -150,6 +167,8 @@ Check whether the given construct is a Resource.
 | <code><a href="#cdk-monitoring-constructs.BitmapDashboard.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#cdk-monitoring-constructs.BitmapDashboard.property.env">env</a></code> | <code>aws-cdk-lib.ResourceEnvironment</code> | The environment this resource belongs to. |
 | <code><a href="#cdk-monitoring-constructs.BitmapDashboard.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this resource is defined. |
+| <code><a href="#cdk-monitoring-constructs.BitmapDashboard.property.dashboardArn">dashboardArn</a></code> | <code>string</code> | ARN of this dashboard. |
+| <code><a href="#cdk-monitoring-constructs.BitmapDashboard.property.dashboardName">dashboardName</a></code> | <code>string</code> | The name of this dashboard. |
 
 ---
 
@@ -193,6 +212,30 @@ public readonly stack: Stack;
 - *Type:* aws-cdk-lib.Stack
 
 The stack in which this resource is defined.
+
+---
+
+##### `dashboardArn`<sup>Required</sup> <a name="dashboardArn" id="cdk-monitoring-constructs.BitmapDashboard.property.dashboardArn"></a>
+
+```typescript
+public readonly dashboardArn: string;
+```
+
+- *Type:* string
+
+ARN of this dashboard.
+
+---
+
+##### `dashboardName`<sup>Required</sup> <a name="dashboardName" id="cdk-monitoring-constructs.BitmapDashboard.property.dashboardName"></a>
+
+```typescript
+public readonly dashboardName: string;
+```
+
+- *Type:* string
+
+The name of this dashboard.
 
 ---
 
@@ -422,6 +465,7 @@ to each other.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.DashboardWithBitmapCopy.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
+| <code><a href="#cdk-monitoring-constructs.DashboardWithBitmapCopy.isOwnedResource">isOwnedResource</a></code> | Returns true if the construct was created by CDK, and false otherwise. |
 | <code><a href="#cdk-monitoring-constructs.DashboardWithBitmapCopy.isResource">isResource</a></code> | Check whether the given construct is a Resource. |
 
 ---
@@ -441,6 +485,22 @@ Checks if `x` is a construct.
 - *Type:* any
 
 Any object.
+
+---
+
+##### `isOwnedResource` <a name="isOwnedResource" id="cdk-monitoring-constructs.DashboardWithBitmapCopy.isOwnedResource"></a>
+
+```typescript
+import { DashboardWithBitmapCopy } from 'cdk-monitoring-constructs'
+
+DashboardWithBitmapCopy.isOwnedResource(construct: IConstruct)
+```
+
+Returns true if the construct was created by CDK, and false otherwise.
+
+###### `construct`<sup>Required</sup> <a name="construct" id="cdk-monitoring-constructs.DashboardWithBitmapCopy.isOwnedResource.parameter.construct"></a>
+
+- *Type:* constructs.IConstruct
 
 ---
 
@@ -467,6 +527,8 @@ Check whether the given construct is a Resource.
 | <code><a href="#cdk-monitoring-constructs.DashboardWithBitmapCopy.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
 | <code><a href="#cdk-monitoring-constructs.DashboardWithBitmapCopy.property.env">env</a></code> | <code>aws-cdk-lib.ResourceEnvironment</code> | The environment this resource belongs to. |
 | <code><a href="#cdk-monitoring-constructs.DashboardWithBitmapCopy.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this resource is defined. |
+| <code><a href="#cdk-monitoring-constructs.DashboardWithBitmapCopy.property.dashboardArn">dashboardArn</a></code> | <code>string</code> | ARN of this dashboard. |
+| <code><a href="#cdk-monitoring-constructs.DashboardWithBitmapCopy.property.dashboardName">dashboardName</a></code> | <code>string</code> | The name of this dashboard. |
 
 ---
 
@@ -510,6 +572,30 @@ public readonly stack: Stack;
 - *Type:* aws-cdk-lib.Stack
 
 The stack in which this resource is defined.
+
+---
+
+##### `dashboardArn`<sup>Required</sup> <a name="dashboardArn" id="cdk-monitoring-constructs.DashboardWithBitmapCopy.property.dashboardArn"></a>
+
+```typescript
+public readonly dashboardArn: string;
+```
+
+- *Type:* string
+
+ARN of this dashboard.
+
+---
+
+##### `dashboardName`<sup>Required</sup> <a name="dashboardName" id="cdk-monitoring-constructs.DashboardWithBitmapCopy.property.dashboardName"></a>
+
+```typescript
+public readonly dashboardName: string;
+```
+
+- *Type:* string
+
+The name of this dashboard.
 
 ---
 
@@ -6178,7 +6264,7 @@ const appSyncMetricFactoryProps: AppSyncMetricFactoryProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#cdk-monitoring-constructs.AppSyncMetricFactoryProps.property.api">api</a></code> | <code>@aws-cdk/aws-appsync-alpha.IGraphqlApi</code> | the GraphQL API to monitor. |
+| <code><a href="#cdk-monitoring-constructs.AppSyncMetricFactoryProps.property.api">api</a></code> | <code>aws-cdk-lib.aws_appsync.IGraphqlApi</code> | the GraphQL API to monitor. |
 | <code><a href="#cdk-monitoring-constructs.AppSyncMetricFactoryProps.property.fillTpsWithZeroes">fillTpsWithZeroes</a></code> | <code>boolean</code> | whether the TPS should be filled with zeroes. |
 | <code><a href="#cdk-monitoring-constructs.AppSyncMetricFactoryProps.property.rateComputationMethod">rateComputationMethod</a></code> | <code><a href="#cdk-monitoring-constructs.RateComputationMethod">RateComputationMethod</a></code> | method to compute TPS. |
 
@@ -6190,7 +6276,7 @@ const appSyncMetricFactoryProps: AppSyncMetricFactoryProps = { ... }
 public readonly api: IGraphqlApi;
 ```
 
-- *Type:* @aws-cdk/aws-appsync-alpha.IGraphqlApi
+- *Type:* aws-cdk-lib.aws_appsync.IGraphqlApi
 
 the GraphQL API to monitor.
 
@@ -6473,7 +6559,7 @@ const appSyncMonitoringProps: AppSyncMonitoringProps = { ... }
 | <code><a href="#cdk-monitoring-constructs.AppSyncMonitoringProps.property.addLatencyP90Alarm">addLatencyP90Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.AppSyncMonitoringProps.property.addLatencyP99Alarm">addLatencyP99Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.AppSyncMonitoringProps.property.addLowTpsAlarm">addLowTpsAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LowTpsThreshold">LowTpsThreshold</a>}</code> | *No description.* |
-| <code><a href="#cdk-monitoring-constructs.AppSyncMonitoringProps.property.api">api</a></code> | <code>@aws-cdk/aws-appsync-alpha.IGraphqlApi</code> | the GraphQL API to monitor. |
+| <code><a href="#cdk-monitoring-constructs.AppSyncMonitoringProps.property.api">api</a></code> | <code>aws-cdk-lib.aws_appsync.IGraphqlApi</code> | the GraphQL API to monitor. |
 | <code><a href="#cdk-monitoring-constructs.AppSyncMonitoringProps.property.fillTpsWithZeroes">fillTpsWithZeroes</a></code> | <code>boolean</code> | whether the TPS should be filled with zeroes. |
 | <code><a href="#cdk-monitoring-constructs.AppSyncMonitoringProps.property.rateComputationMethod">rateComputationMethod</a></code> | <code><a href="#cdk-monitoring-constructs.RateComputationMethod">RateComputationMethod</a></code> | method to compute TPS. |
 
@@ -6673,7 +6759,7 @@ public readonly addLowTpsAlarm: {[ key: string ]: LowTpsThreshold};
 public readonly api: IGraphqlApi;
 ```
 
-- *Type:* @aws-cdk/aws-appsync-alpha.IGraphqlApi
+- *Type:* aws-cdk-lib.aws_appsync.IGraphqlApi
 
 the GraphQL API to monitor.
 
@@ -37479,7 +37565,7 @@ const xaxrMathExpressionProps: XaxrMathExpressionProps = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.XaxrMathExpressionProps.property.color">color</a></code> | <code>string</code> | Color for this metric when added to a Graph in a Dashboard. |
-| <code><a href="#cdk-monitoring-constructs.XaxrMathExpressionProps.property.label">label</a></code> | <code>string</code> | Label for this metric when added to a Graph in a Dashboard. |
+| <code><a href="#cdk-monitoring-constructs.XaxrMathExpressionProps.property.label">label</a></code> | <code>string</code> | Label for this expression when added to a Graph in a Dashboard. |
 | <code><a href="#cdk-monitoring-constructs.XaxrMathExpressionProps.property.period">period</a></code> | <code>aws-cdk-lib.Duration</code> | The period over which the expression's statistics are applied. |
 | <code><a href="#cdk-monitoring-constructs.XaxrMathExpressionProps.property.searchAccount">searchAccount</a></code> | <code>string</code> | Account to evaluate search expressions within. |
 | <code><a href="#cdk-monitoring-constructs.XaxrMathExpressionProps.property.searchRegion">searchRegion</a></code> | <code>string</code> | Region to evaluate search expressions within. |
@@ -37512,7 +37598,28 @@ public readonly label: string;
 - *Type:* string
 - *Default:* Expression value is used as label
 
-Label for this metric when added to a Graph in a Dashboard.
+Label for this expression when added to a Graph in a Dashboard.
+
+If this expression evaluates to more than one time series (for
+example, through the use of `METRICS()` or `SEARCH()` expressions),
+each time series will appear in the graph using a combination of the
+expression label and the individual metric label. Specify the empty
+string (`''`) to suppress the expression label and only keep the
+metric label.
+
+You can use [dynamic labels](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/graph-dynamic-labels.html)
+to show summary information about the displayed time series
+in the legend. For example, if you use:
+
+```
+[max: ${MAX}] MyMetric
+```
+
+As the metric label, the maximum value in the visible range will
+be shown next to the time series name in the graph's legend. If the
+math expression produces more than one time series, the maximum
+will be shown for each individual time series produce by this
+math expression.
 
 ---
 
@@ -37905,6 +38012,7 @@ Return the widget JSON for use in the dashboard.
 | --- | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.AlarmMatrixWidget.property.height">height</a></code> | <code>number</code> | The amount of vertical grid units the widget will take up. |
 | <code><a href="#cdk-monitoring-constructs.AlarmMatrixWidget.property.width">width</a></code> | <code>number</code> | The amount of horizontal grid units the widget will take up. |
+| <code><a href="#cdk-monitoring-constructs.AlarmMatrixWidget.property.warnings">warnings</a></code> | <code>string[]</code> | Any warnings that are produced as a result of putting together this widget. |
 
 ---
 
@@ -37929,6 +38037,18 @@ public readonly width: number;
 - *Type:* number
 
 The amount of horizontal grid units the widget will take up.
+
+---
+
+##### `warnings`<sup>Optional</sup> <a name="warnings" id="cdk-monitoring-constructs.AlarmMatrixWidget.property.warnings"></a>
+
+```typescript
+public readonly warnings: string[];
+```
+
+- *Type:* string[]
+
+Any warnings that are produced as a result of putting together this widget.
 
 ---
 
@@ -38098,6 +38218,7 @@ Return the widget JSON for use in the dashboard.
 | --- | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.AlarmSummaryMatrixWidget.property.height">height</a></code> | <code>number</code> | The amount of vertical grid units the widget will take up. |
 | <code><a href="#cdk-monitoring-constructs.AlarmSummaryMatrixWidget.property.width">width</a></code> | <code>number</code> | The amount of horizontal grid units the widget will take up. |
+| <code><a href="#cdk-monitoring-constructs.AlarmSummaryMatrixWidget.property.warnings">warnings</a></code> | <code>string[]</code> | Any warnings that are produced as a result of putting together this widget. |
 
 ---
 
@@ -38122,6 +38243,18 @@ public readonly width: number;
 - *Type:* number
 
 The amount of horizontal grid units the widget will take up.
+
+---
+
+##### `warnings`<sup>Optional</sup> <a name="warnings" id="cdk-monitoring-constructs.AlarmSummaryMatrixWidget.property.warnings"></a>
+
+```typescript
+public readonly warnings: string[];
+```
+
+- *Type:* string[]
+
+Any warnings that are produced as a result of putting together this widget.
 
 ---
 
@@ -38301,6 +38434,7 @@ All properties except namespace and metricName can be changed.
 | <code><a href="#cdk-monitoring-constructs.AnomalyDetectionMathExpression.property.label">label</a></code> | <code>string</code> | Label for this metric when added to a Graph. |
 | <code><a href="#cdk-monitoring-constructs.AnomalyDetectionMathExpression.property.searchAccount">searchAccount</a></code> | <code>string</code> | Account to evaluate search expressions within. |
 | <code><a href="#cdk-monitoring-constructs.AnomalyDetectionMathExpression.property.searchRegion">searchRegion</a></code> | <code>string</code> | Region to evaluate search expressions within. |
+| <code><a href="#cdk-monitoring-constructs.AnomalyDetectionMathExpression.property.warnings">warnings</a></code> | <code>string[]</code> | Warnings generated by this math expression. |
 
 ---
 
@@ -38385,6 +38519,18 @@ public readonly searchRegion: string;
 - *Type:* string
 
 Region to evaluate search expressions within.
+
+---
+
+##### `warnings`<sup>Optional</sup> <a name="warnings" id="cdk-monitoring-constructs.AnomalyDetectionMathExpression.property.warnings"></a>
+
+```typescript
+public readonly warnings: string[];
+```
+
+- *Type:* string[]
+
+Warnings generated by this math expression.
 
 ---
 
@@ -42711,6 +42857,7 @@ Return the widget JSON for use in the dashboard.
 | --- | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.CustomWidget.property.height">height</a></code> | <code>number</code> | The amount of vertical grid units the widget will take up. |
 | <code><a href="#cdk-monitoring-constructs.CustomWidget.property.width">width</a></code> | <code>number</code> | The amount of horizontal grid units the widget will take up. |
+| <code><a href="#cdk-monitoring-constructs.CustomWidget.property.warnings">warnings</a></code> | <code>string[]</code> | Any warnings that are produced as a result of putting together this widget. |
 
 ---
 
@@ -42735,6 +42882,18 @@ public readonly width: number;
 - *Type:* number
 
 The amount of horizontal grid units the widget will take up.
+
+---
+
+##### `warnings`<sup>Optional</sup> <a name="warnings" id="cdk-monitoring-constructs.CustomWidget.property.warnings"></a>
+
+```typescript
+public readonly warnings: string[];
+```
+
+- *Type:* string[]
+
+Any warnings that are produced as a result of putting together this widget.
 
 ---
 
@@ -43457,6 +43616,7 @@ the metric to add.
 | --- | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.DoubleAxisGraphWidget.property.height">height</a></code> | <code>number</code> | The amount of vertical grid units the widget will take up. |
 | <code><a href="#cdk-monitoring-constructs.DoubleAxisGraphWidget.property.width">width</a></code> | <code>number</code> | The amount of horizontal grid units the widget will take up. |
+| <code><a href="#cdk-monitoring-constructs.DoubleAxisGraphWidget.property.warnings">warnings</a></code> | <code>string[]</code> | Any warnings that are produced as a result of putting together this widget. |
 
 ---
 
@@ -43481,6 +43641,18 @@ public readonly width: number;
 - *Type:* number
 
 The amount of horizontal grid units the widget will take up.
+
+---
+
+##### `warnings`<sup>Optional</sup> <a name="warnings" id="cdk-monitoring-constructs.DoubleAxisGraphWidget.property.warnings"></a>
+
+```typescript
+public readonly warnings: string[];
+```
+
+- *Type:* string[]
+
+Any warnings that are produced as a result of putting together this widget.
 
 ---
 
@@ -47216,6 +47388,7 @@ Return the widget JSON for use in the dashboard.
 | --- | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.HeaderWidget.property.height">height</a></code> | <code>number</code> | The amount of vertical grid units the widget will take up. |
 | <code><a href="#cdk-monitoring-constructs.HeaderWidget.property.width">width</a></code> | <code>number</code> | The amount of horizontal grid units the widget will take up. |
+| <code><a href="#cdk-monitoring-constructs.HeaderWidget.property.warnings">warnings</a></code> | <code>string[]</code> | Any warnings that are produced as a result of putting together this widget. |
 
 ---
 
@@ -47240,6 +47413,18 @@ public readonly width: number;
 - *Type:* number
 
 The amount of horizontal grid units the widget will take up.
+
+---
+
+##### `warnings`<sup>Optional</sup> <a name="warnings" id="cdk-monitoring-constructs.HeaderWidget.property.warnings"></a>
+
+```typescript
+public readonly warnings: string[];
+```
+
+- *Type:* string[]
+
+Any warnings that are produced as a result of putting together this widget.
 
 ---
 
@@ -47310,6 +47495,7 @@ Return the widget JSON for use in the dashboard.
 | --- | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.KeyValueTableWidget.property.height">height</a></code> | <code>number</code> | The amount of vertical grid units the widget will take up. |
 | <code><a href="#cdk-monitoring-constructs.KeyValueTableWidget.property.width">width</a></code> | <code>number</code> | The amount of horizontal grid units the widget will take up. |
+| <code><a href="#cdk-monitoring-constructs.KeyValueTableWidget.property.warnings">warnings</a></code> | <code>string[]</code> | Any warnings that are produced as a result of putting together this widget. |
 
 ---
 
@@ -47334,6 +47520,18 @@ public readonly width: number;
 - *Type:* number
 
 The amount of horizontal grid units the widget will take up.
+
+---
+
+##### `warnings`<sup>Optional</sup> <a name="warnings" id="cdk-monitoring-constructs.KeyValueTableWidget.property.warnings"></a>
+
+```typescript
+public readonly warnings: string[];
+```
+
+- *Type:* string[]
+
+Any warnings that are produced as a result of putting together this widget.
 
 ---
 
@@ -51646,6 +51844,7 @@ Return the widget JSON for use in the dashboard.
 | --- | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.MonitoringHeaderWidget.property.height">height</a></code> | <code>number</code> | The amount of vertical grid units the widget will take up. |
 | <code><a href="#cdk-monitoring-constructs.MonitoringHeaderWidget.property.width">width</a></code> | <code>number</code> | The amount of horizontal grid units the widget will take up. |
+| <code><a href="#cdk-monitoring-constructs.MonitoringHeaderWidget.property.warnings">warnings</a></code> | <code>string[]</code> | Any warnings that are produced as a result of putting together this widget. |
 
 ---
 
@@ -51670,6 +51869,18 @@ public readonly width: number;
 - *Type:* number
 
 The amount of horizontal grid units the widget will take up.
+
+---
+
+##### `warnings`<sup>Optional</sup> <a name="warnings" id="cdk-monitoring-constructs.MonitoringHeaderWidget.property.warnings"></a>
+
+```typescript
+public readonly warnings: string[];
+```
+
+- *Type:* string[]
+
+Any warnings that are produced as a result of putting together this widget.
 
 ---
 
@@ -55115,6 +55326,7 @@ the metric to add.
 | --- | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.SingleAxisGraphWidget.property.height">height</a></code> | <code>number</code> | The amount of vertical grid units the widget will take up. |
 | <code><a href="#cdk-monitoring-constructs.SingleAxisGraphWidget.property.width">width</a></code> | <code>number</code> | The amount of horizontal grid units the widget will take up. |
+| <code><a href="#cdk-monitoring-constructs.SingleAxisGraphWidget.property.warnings">warnings</a></code> | <code>string[]</code> | Any warnings that are produced as a result of putting together this widget. |
 
 ---
 
@@ -55139,6 +55351,18 @@ public readonly width: number;
 - *Type:* number
 
 The amount of horizontal grid units the widget will take up.
+
+---
+
+##### `warnings`<sup>Optional</sup> <a name="warnings" id="cdk-monitoring-constructs.SingleAxisGraphWidget.property.warnings"></a>
+
+```typescript
+public readonly warnings: string[];
+```
+
+- *Type:* string[]
+
+Any warnings that are produced as a result of putting together this widget.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -26,14 +26,13 @@ In your `package.json`:
 ```json
 {
   "dependencies": {
-    "cdk-monitoring-constructs": "^1.0.0",
+    "cdk-monitoring-constructs": "^2.0.0",
 
     // peer dependencies of cdk-monitoring-constructs
-    "@aws-cdk/aws-apigatewayv2-alpha": "^2.18.0-alpha.0",
-    "@aws-cdk/aws-appsync-alpha": "^2.18.0-alpha.0",
-    "@aws-cdk/aws-redshift-alpha": "^2.18.0-alpha.0",
-    "@aws-cdk/aws-synthetics-alpha": "^2.18.0-alpha.0",
-    "aws-cdk-lib": "^2.18.0",
+    "@aws-cdk/aws-apigatewayv2-alpha": "^2.60.0-alpha.0",
+    "@aws-cdk/aws-redshift-alpha": "^2.60.0-alpha.0",
+    "@aws-cdk/aws-synthetics-alpha": "^2.60.0-alpha.0",
+    "aws-cdk-lib": "^2.60.0",
     "constructs": "^10.0.5"
 
     // ...your other dependencies...

--- a/lib/facade/MonitoringAspect.ts
+++ b/lib/facade/MonitoringAspect.ts
@@ -1,9 +1,9 @@
 import * as apigwv2 from "@aws-cdk/aws-apigatewayv2-alpha";
-import * as appsync from "@aws-cdk/aws-appsync-alpha";
 import * as redshift from "@aws-cdk/aws-redshift-alpha";
 import * as synthetics from "@aws-cdk/aws-synthetics-alpha";
 import { IAspect } from "aws-cdk-lib";
 import * as apigw from "aws-cdk-lib/aws-apigateway";
+import * as appsync from "aws-cdk-lib/aws-appsync";
 import * as autoscaling from "aws-cdk-lib/aws-autoscaling";
 import * as acm from "aws-cdk-lib/aws-certificatemanager";
 import * as cloudfront from "aws-cdk-lib/aws-cloudfront";

--- a/lib/monitoring/aws-appsync/AppSyncMetricFactory.ts
+++ b/lib/monitoring/aws-appsync/AppSyncMetricFactory.ts
@@ -1,4 +1,4 @@
-import { IGraphqlApi } from "@aws-cdk/aws-appsync-alpha";
+import { IGraphqlApi } from "aws-cdk-lib/aws-appsync";
 import { DimensionsMap } from "aws-cdk-lib/aws-cloudwatch";
 
 import {

--- a/package.json
+++ b/package.json
@@ -37,16 +37,15 @@
     "organization": false
   },
   "devDependencies": {
-    "@aws-cdk/aws-apigatewayv2-alpha": "2.18.0-alpha.0",
-    "@aws-cdk/aws-appsync-alpha": "2.18.0-alpha.0",
-    "@aws-cdk/aws-redshift-alpha": "2.18.0-alpha.0",
-    "@aws-cdk/aws-synthetics-alpha": "2.18.0-alpha.0",
+    "@aws-cdk/aws-apigatewayv2-alpha": "2.60.0-alpha.0",
+    "@aws-cdk/aws-redshift-alpha": "2.60.0-alpha.0",
+    "@aws-cdk/aws-synthetics-alpha": "2.60.0-alpha.0",
     "@types/jest": "^27",
     "@types/node": "^14",
     "@types/prettier": "2.6.0",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
-    "aws-cdk-lib": "2.18.0",
+    "aws-cdk-lib": "2.60.0",
     "constructs": "10.0.5",
     "eslint": "^8",
     "eslint-config-prettier": "^8.6.0",
@@ -69,11 +68,10 @@
     "typescript": "^4.9.4"
   },
   "peerDependencies": {
-    "@aws-cdk/aws-apigatewayv2-alpha": "^2.18.0-alpha.0",
-    "@aws-cdk/aws-appsync-alpha": "^2.18.0-alpha.0",
-    "@aws-cdk/aws-redshift-alpha": "^2.18.0-alpha.0",
-    "@aws-cdk/aws-synthetics-alpha": "^2.18.0-alpha.0",
-    "aws-cdk-lib": "^2.18.0",
+    "@aws-cdk/aws-apigatewayv2-alpha": "^2.60.0-alpha.0",
+    "@aws-cdk/aws-redshift-alpha": "^2.60.0-alpha.0",
+    "@aws-cdk/aws-synthetics-alpha": "^2.60.0-alpha.0",
+    "aws-cdk-lib": "^2.60.0",
     "constructs": "^10.0.5"
   },
   "keywords": [

--- a/test/assets/schema.graphql
+++ b/test/assets/schema.graphql
@@ -1,0 +1,13 @@
+type demo {
+  id: String!
+  version: String!
+}
+type Query {
+  getDemos: [ demo! ]
+}
+input DemoInput {
+  version: String!
+}
+type Mutation {
+  addDemo(input: DemoInput!): demo
+}

--- a/test/common/alarm/__snapshots__/OpsItemAlarmActionStrategy.test.ts.snap
+++ b/test/common/alarm/__snapshots__/OpsItemAlarmActionStrategy.test.ts.snap
@@ -17,7 +17,11 @@ Object {
             "Fn::Join": Array [
               "",
               Array [
-                "arn:aws:ssm:",
+                "arn:",
+                Object {
+                  "Ref": "AWS::Partition",
+                },
+                ":ssm:",
                 Object {
                   "Ref": "AWS::Region",
                 },

--- a/test/common/metric/__snapshots__/MetricFactory.test.ts.snap
+++ b/test/common/metric/__snapshots__/MetricFactory.test.ts.snap
@@ -34,6 +34,7 @@ MathExpression {
       "region": undefined,
       "statistic": "Average",
       "unit": undefined,
+      "warnings": undefined,
     },
   },
 }
@@ -73,6 +74,7 @@ MathExpression {
       "region": undefined,
       "statistic": "Average",
       "unit": undefined,
+      "warnings": undefined,
     },
   },
 }
@@ -97,6 +99,7 @@ Metric {
   "region": undefined,
   "statistic": "p90",
   "unit": undefined,
+  "warnings": undefined,
 }
 `;
 
@@ -121,6 +124,7 @@ Metric {
   "region": undefined,
   "statistic": "p90",
   "unit": undefined,
+  "warnings": undefined,
 }
 `;
 
@@ -143,6 +147,7 @@ Metric {
   "region": undefined,
   "statistic": "p90",
   "unit": undefined,
+  "warnings": undefined,
 }
 `;
 
@@ -180,6 +185,7 @@ AnomalyDetectionMathExpression {
       "region": undefined,
       "statistic": "Average",
       "unit": undefined,
+      "warnings": undefined,
     },
   },
 }
@@ -219,6 +225,7 @@ MathExpression {
       "region": undefined,
       "statistic": "Sum",
       "unit": undefined,
+      "warnings": undefined,
     },
     "b": Metric {
       "account": undefined,
@@ -238,6 +245,7 @@ MathExpression {
       "region": undefined,
       "statistic": "Sum",
       "unit": undefined,
+      "warnings": undefined,
     },
   },
 }
@@ -277,6 +285,7 @@ MathExpression {
       "region": undefined,
       "statistic": "Sum",
       "unit": undefined,
+      "warnings": undefined,
     },
     "b": Metric {
       "account": undefined,
@@ -296,6 +305,7 @@ MathExpression {
       "region": undefined,
       "statistic": "Sum",
       "unit": undefined,
+      "warnings": undefined,
     },
   },
 }
@@ -317,6 +327,9 @@ MathExpression {
   "searchAccount": undefined,
   "searchRegion": undefined,
   "usingMetrics": Object {},
+  "warnings": Array [
+    "Math expression 'SEARCH('{DummyNamespace,DummyDimension} DummyDimension=\\"DummyDimensionValue\\" MyMetricPrefix-', 'Sum', 300)' references unknown identifiers: ummyNamespace, ummyDimension, ummyDimension, ummyDimensionValue, yMetricPrefix, um. Please add them to the 'usingMetrics' map.",
+  ],
 }
 `;
 
@@ -336,6 +349,9 @@ MathExpression {
   "searchAccount": undefined,
   "searchRegion": undefined,
   "usingMetrics": Object {},
+  "warnings": Array [
+    "Math expression 'SEARCH('{DummyNamespaceOverride,DummyDimension} DummyDimension=\\"DummyDimensionValue\\" MyMetricPrefix-', 'Sum', 300)' references unknown identifiers: ummyNamespaceOverride, ummyDimension, ummyDimension, ummyDimensionValue, yMetricPrefix, um. Please add them to the 'usingMetrics' map.",
+  ],
 }
 `;
 
@@ -355,6 +371,9 @@ MathExpression {
   "searchAccount": undefined,
   "searchRegion": undefined,
   "usingMetrics": Object {},
+  "warnings": Array [
+    "Math expression 'SEARCH('{DummyNamespaceOverride,DummyUndefinedDimension,DummyDefinedDimension} DummyDefinedDimension=\\"DummyDimensionValue\\" MyMetricPrefix-', 'Sum', 300)' references unknown identifiers: ummyNamespaceOverride, ummyUndefinedDimension, ummyDefinedDimension, ummyDefinedDimension, ummyDimensionValue, yMetricPrefix, um. Please add them to the 'usingMetrics' map.",
+  ],
 }
 `;
 
@@ -374,6 +393,9 @@ MathExpression {
   "searchAccount": undefined,
   "searchRegion": undefined,
   "usingMetrics": Object {},
+  "warnings": Array [
+    "Math expression 'SEARCH('{DummyNamespaceOverride}  MyMetricPrefix-', 'Sum', 300)' references unknown identifiers: ummyNamespaceOverride, yMetricPrefix, um. Please add them to the 'usingMetrics' map.",
+  ],
 }
 `;
 
@@ -396,6 +418,7 @@ Metric {
   "region": undefined,
   "statistic": "Average",
   "unit": undefined,
+  "warnings": undefined,
 }
 `;
 
@@ -433,6 +456,7 @@ MathExpression {
       "region": undefined,
       "statistic": "Sum",
       "unit": undefined,
+      "warnings": undefined,
     },
   },
 }
@@ -472,6 +496,7 @@ MathExpression {
       "region": undefined,
       "statistic": "Sum",
       "unit": undefined,
+      "warnings": undefined,
     },
   },
 }
@@ -511,6 +536,7 @@ MathExpression {
       "region": undefined,
       "statistic": "Sum",
       "unit": undefined,
+      "warnings": undefined,
     },
   },
 }
@@ -550,6 +576,7 @@ MathExpression {
       "region": undefined,
       "statistic": "Sum",
       "unit": undefined,
+      "warnings": undefined,
     },
   },
 }
@@ -574,6 +601,7 @@ Metric {
   "region": undefined,
   "statistic": "Average",
   "unit": undefined,
+  "warnings": undefined,
 }
 `;
 
@@ -611,6 +639,7 @@ MathExpression {
       "region": undefined,
       "statistic": "Sum",
       "unit": undefined,
+      "warnings": undefined,
     },
   },
 }
@@ -650,6 +679,7 @@ MathExpression {
       "region": undefined,
       "statistic": "Sum",
       "unit": undefined,
+      "warnings": undefined,
     },
   },
 }
@@ -689,6 +719,7 @@ MathExpression {
       "region": undefined,
       "statistic": "Sum",
       "unit": undefined,
+      "warnings": undefined,
     },
   },
 }
@@ -728,6 +759,7 @@ MathExpression {
       "region": undefined,
       "statistic": "Sum",
       "unit": undefined,
+      "warnings": undefined,
     },
   },
 }

--- a/test/dashboard/widget/__snapshots__/HeaderWidget.test.ts.snap
+++ b/test/dashboard/widget/__snapshots__/HeaderWidget.test.ts.snap
@@ -5,6 +5,7 @@ Array [
   Object {
     "height": 2,
     "properties": Object {
+      "background": undefined,
       "markdown": "# text
 
 description",
@@ -22,6 +23,7 @@ Array [
   Object {
     "height": 6,
     "properties": Object {
+      "background": undefined,
       "markdown": "# text
 
 very long description",
@@ -39,6 +41,7 @@ Array [
   Object {
     "height": 1,
     "properties": Object {
+      "background": undefined,
       "markdown": "# text",
     },
     "type": "text",

--- a/test/dashboard/widget/__snapshots__/KeyValueTableWidget.test.ts.snap
+++ b/test/dashboard/widget/__snapshots__/KeyValueTableWidget.test.ts.snap
@@ -5,6 +5,7 @@ Array [
   Object {
     "height": 3,
     "properties": Object {
+      "background": undefined,
       "markdown": "| name| has
 |---|---
 | John Wick| a dog",

--- a/test/dashboard/widget/__snapshots__/MonitoringHeaderWidget.test.ts.snap
+++ b/test/dashboard/widget/__snapshots__/MonitoringHeaderWidget.test.ts.snap
@@ -5,6 +5,7 @@ Array [
   Object {
     "height": 1,
     "properties": Object {
+      "background": undefined,
       "markdown": "### DummyFamily **DummyTitle**",
     },
     "type": "text",
@@ -20,6 +21,7 @@ Array [
   Object {
     "height": 1,
     "properties": Object {
+      "background": undefined,
       "markdown": "### DummyTitle",
     },
     "type": "text",
@@ -35,6 +37,7 @@ Array [
   Object {
     "height": 1,
     "properties": Object {
+      "background": undefined,
       "markdown": "### DummyFamily **[DummyTitle](http://amazon.com)**",
     },
     "type": "text",
@@ -50,6 +53,7 @@ Array [
   Object {
     "height": 1,
     "properties": Object {
+      "background": undefined,
       "markdown": "### DummyFamily **[DummyTitle](http://amazon.com)**",
     },
     "type": "text",
@@ -65,6 +69,7 @@ Array [
   Object {
     "height": 2,
     "properties": Object {
+      "background": undefined,
       "markdown": "### DummyFamily **[DummyTitle](http://amazon.com)**
 
 CustomDescription",
@@ -82,6 +87,7 @@ Array [
   Object {
     "height": 11,
     "properties": Object {
+      "background": undefined,
       "markdown": "### DummyFamily **[DummyTitle](http://amazon.com)**
 
 CustomDescription",

--- a/test/facade/MonitoringAspect.test.ts
+++ b/test/facade/MonitoringAspect.test.ts
@@ -1,10 +1,11 @@
+import path from "path";
 import * as apigwv2 from "@aws-cdk/aws-apigatewayv2-alpha";
-import * as appsync from "@aws-cdk/aws-appsync-alpha";
 import * as redshift from "@aws-cdk/aws-redshift-alpha";
 import * as synthetics from "@aws-cdk/aws-synthetics-alpha";
 import { App, Duration, SecretValue, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
 import * as apigw from "aws-cdk-lib/aws-apigateway";
+import * as appsync from "aws-cdk-lib/aws-appsync";
 import * as autoscaling from "aws-cdk-lib/aws-autoscaling";
 import * as acm from "aws-cdk-lib/aws-certificatemanager";
 import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
@@ -118,6 +119,9 @@ describe("MonitoringAspect", () => {
 
     new appsync.GraphqlApi(stack, "DummyGraphqlApi", {
       name: "DummyGraphqlApi",
+      schema: appsync.SchemaFile.fromAsset(
+        path.join(__dirname, "..", "assets", "schema.graphql")
+      ),
     });
 
     // WHEN

--- a/test/facade/__snapshots__/MonitoringAspect.test.ts.snap
+++ b/test/facade/__snapshots__/MonitoringAspect.test.ts.snap
@@ -55,6 +55,12 @@ Object {
             "ValidationDomain": "cdk",
           },
         ],
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "Default/DummyCertificate",
+          },
+        ],
         "ValidationMethod": "EMAIL",
       },
       "Type": "AWS::CertificateManager::Certificate",
@@ -217,6 +223,7 @@ Object {
       "Type": "AWS::ApiGateway::Method",
     },
     "DummyRestApiAccount722BC8C0": Object {
+      "DeletionPolicy": "Retain",
       "DependsOn": Array [
         "DummyRestApi328A173A",
       ],
@@ -229,8 +236,10 @@ Object {
         },
       },
       "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
     },
     "DummyRestApiCloudWatchRoleA16B4AC6": Object {
+      "DeletionPolicy": "Retain",
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -260,6 +269,7 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
     },
     "DummyRestApiDeploymentE536A000827e68cce8aade0ba98340f42cbf5e9e": Object {
       "DependsOn": Array [
@@ -728,7 +738,20 @@ Object {
             "ApiId",
           ],
         },
-        "Definition": "",
+        "Definition": "type demo {
+  id: String!
+  version: String!
+}
+type Query {
+  getDemos: [ demo! ]
+}
+input DemoInput {
+  version: String!
+}
+type Mutation {
+  addDemo(input: DemoInput!): demo
+}
+",
       },
       "Type": "AWS::AppSync::GraphQLSchema",
     },
@@ -827,17 +850,7 @@ Object {
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": Object {
-                "Service": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "ec2.",
-                      Object {
-                        "Ref": "AWS::URLSuffix",
-                      },
-                    ],
-                  ],
-                },
+                "Service": "ec2.amazonaws.com",
               },
             },
           ],
@@ -1187,6 +1200,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "VpcPublicSubnet1NATGateway4D7517AA": Object {
+      "DependsOn": Array [
+        "VpcPublicSubnet1DefaultRoute3DA9E72A",
+        "VpcPublicSubnet1RouteTableAssociation97140677",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -1291,6 +1308,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "VpcPublicSubnet2NATGateway9182C01D": Object {
+      "DependsOn": Array [
+        "VpcPublicSubnet2DefaultRoute97F91067",
+        "VpcPublicSubnet2RouteTableAssociationDD5762D8",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -2763,7 +2784,9 @@ Object {
       "DeletionPolicy": "Retain",
       "DependsOn": Array [
         "DummyVpcPrivateSubnet1DefaultRouteE47453F6",
+        "DummyVpcPrivateSubnet1RouteTableAssociation88B5105F",
         "DummyVpcPrivateSubnet2DefaultRoute4E564518",
+        "DummyVpcPrivateSubnet2RouteTableAssociationC3594446",
       ],
       "Properties": Object {
         "DBClusterIdentifier": Object {
@@ -3034,6 +3057,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "DummyVpcPublicSubnet1NATGateway61554370": Object {
+      "DependsOn": Array [
+        "DummyVpcPublicSubnet1DefaultRoute166DC84B",
+        "DummyVpcPublicSubnet1RouteTableAssociation8BCD2CE1",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -3138,6 +3165,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "DummyVpcPublicSubnet2NATGateway867E77CE": Object {
+      "DependsOn": Array [
+        "DummyVpcPublicSubnet2DefaultRoute1C29EE76",
+        "DummyVpcPublicSubnet2RouteTableAssociationDCE3DC57",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -3235,7 +3266,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "558dc75fbdc793c8e2f64f85d2d7ed2cb820c727ec7e9b08666ad1af0103992e.zip",
+          "S3Key": "eb5b005c858404ea0c8f68098ed5dcdf5340e02461f149751d10f59c210d5ef8.zip",
         },
         "Handler": "index.handler",
         "Role": Object {
@@ -3863,17 +3894,7 @@ Object {
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": Object {
-                "Service": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "ec2.",
-                      Object {
-                        "Ref": "AWS::URLSuffix",
-                      },
-                    ],
-                  ],
-                },
+                "Service": "ec2.amazonaws.com",
               },
             },
           ],
@@ -4102,6 +4123,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "VpcPublicSubnet1NATGateway4D7517AA": Object {
+      "DependsOn": Array [
+        "VpcPublicSubnet1DefaultRoute3DA9E72A",
+        "VpcPublicSubnet1RouteTableAssociation97140677",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -4206,6 +4231,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "VpcPublicSubnet2NATGateway9182C01D": Object {
+      "DependsOn": Array [
+        "VpcPublicSubnet2DefaultRoute97F91067",
+        "VpcPublicSubnet2RouteTableAssociationDD5762D8",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -6389,9 +6418,6 @@ Object {
           "InstanceType": "r5.large.search",
           "ZoneAwarenessEnabled": false,
         },
-        "CognitoOptions": Object {
-          "Enabled": false,
-        },
         "DomainEndpointOptions": Object {
           "EnforceHTTPS": false,
           "TLSSecurityPolicy": "Policy-Min-TLS-1-0-2019-07",
@@ -6775,7 +6801,9 @@ Object {
       "DeletionPolicy": "Delete",
       "DependsOn": Array [
         "VpcPrivateSubnet1DefaultRouteBE02A9ED",
+        "VpcPrivateSubnet1RouteTableAssociation70C59FA6",
         "VpcPrivateSubnet2DefaultRoute060D2087",
+        "VpcPrivateSubnet2RouteTableAssociationA89CAD56",
       ],
       "Properties": Object {
         "DBClusterIdentifier": Object {
@@ -6794,7 +6822,9 @@ Object {
       "DeletionPolicy": "Delete",
       "DependsOn": Array [
         "VpcPrivateSubnet1DefaultRouteBE02A9ED",
+        "VpcPrivateSubnet1RouteTableAssociation70C59FA6",
         "VpcPrivateSubnet2DefaultRoute060D2087",
+        "VpcPrivateSubnet2RouteTableAssociationA89CAD56",
       ],
       "Properties": Object {
         "DBClusterIdentifier": Object {
@@ -7067,6 +7097,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "VpcPublicSubnet1NATGateway4D7517AA": Object {
+      "DependsOn": Array [
+        "VpcPublicSubnet1DefaultRoute3DA9E72A",
+        "VpcPublicSubnet1RouteTableAssociation97140677",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -7171,6 +7205,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "VpcPublicSubnet2NATGateway9182C01D": Object {
+      "DependsOn": Array [
+        "VpcPublicSubnet2DefaultRoute97F91067",
+        "VpcPublicSubnet2RouteTableAssociationDD5762D8",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -7702,6 +7740,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "VpcPublicSubnet1NATGateway4D7517AA": Object {
+      "DependsOn": Array [
+        "VpcPublicSubnet1DefaultRoute3DA9E72A",
+        "VpcPublicSubnet1RouteTableAssociation97140677",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -7806,6 +7848,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "VpcPublicSubnet2NATGateway9182C01D": Object {
+      "DependsOn": Array [
+        "VpcPublicSubnet2DefaultRoute97F91067",
+        "VpcPublicSubnet2RouteTableAssociationDD5762D8",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -8707,6 +8753,9 @@ Object {
       "ap-south-1": Object {
         "states": "states.ap-south-1.amazonaws.com",
       },
+      "ap-south-2": Object {
+        "states": "states.ap-south-2.amazonaws.com",
+      },
       "ap-southeast-1": Object {
         "states": "states.ap-southeast-1.amazonaws.com",
       },
@@ -8745,6 +8794,9 @@ Object {
       },
       "eu-west-3": Object {
         "states": "states.eu-west-3.amazonaws.com",
+      },
+      "me-central-1": Object {
+        "states": "states.me-central-1.amazonaws.com",
       },
       "me-south-1": Object {
         "states": "states.me-south-1.amazonaws.com",

--- a/test/monitoring/aws-acm/__snapshots__/CertificateManagerMonitoring.test.ts.snap
+++ b/test/monitoring/aws-acm/__snapshots__/CertificateManagerMonitoring.test.ts.snap
@@ -43,6 +43,12 @@ Object {
             "ValidationDomain": "cdk",
           },
         ],
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "Default/Certificate1",
+          },
+        ],
         "ValidationMethod": "EMAIL",
       },
       "Type": "AWS::CertificateManager::Certificate",
@@ -164,6 +170,12 @@ Object {
           Object {
             "DomainName": "www.monitoring.cdk",
             "ValidationDomain": "cdk",
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "Name",
+            "Value": "Default/Certificate1",
           },
         ],
         "ValidationMethod": "EMAIL",

--- a/test/monitoring/aws-apigateway/__snapshots__/ApiGatewayMonitoring.test.ts.snap
+++ b/test/monitoring/aws-apigateway/__snapshots__/ApiGatewayMonitoring.test.ts.snap
@@ -319,6 +319,7 @@ Object {
       "Type": "AWS::ApiGateway::Method",
     },
     "DummyApiAccount7A4341D1": Object {
+      "DeletionPolicy": "Retain",
       "DependsOn": Array [
         "DummyApi80F1E171",
       ],
@@ -331,8 +332,10 @@ Object {
         },
       },
       "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
     },
     "DummyApiCloudWatchRole478A67A7": Object {
+      "DeletionPolicy": "Retain",
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -362,6 +365,7 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
     },
     "DummyApiDeploymentD01F5018548e3dba60631e60c80c03977ce1f18a": Object {
       "DependsOn": Array [
@@ -1391,6 +1395,7 @@ Object {
       "Type": "AWS::ApiGateway::Method",
     },
     "DummyApiAccount7A4341D1": Object {
+      "DeletionPolicy": "Retain",
       "DependsOn": Array [
         "DummyApi80F1E171",
       ],
@@ -1403,8 +1408,10 @@ Object {
         },
       },
       "Type": "AWS::ApiGateway::Account",
+      "UpdateReplacePolicy": "Retain",
     },
     "DummyApiCloudWatchRole478A67A7": Object {
+      "DeletionPolicy": "Retain",
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -1434,6 +1441,7 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Role",
+      "UpdateReplacePolicy": "Retain",
     },
     "DummyApiDeploymentD01F5018548e3dba60631e60c80c03977ce1f18a": Object {
       "DependsOn": Array [

--- a/test/monitoring/aws-appsync/AppSyncMonitoring.test.ts
+++ b/test/monitoring/aws-appsync/AppSyncMonitoring.test.ts
@@ -1,6 +1,7 @@
-import { GraphqlApi, IGraphqlApi } from "@aws-cdk/aws-appsync-alpha";
+import path from "path";
 import { Duration, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
+import { GraphqlApi, IGraphqlApi, SchemaFile } from "aws-cdk-lib/aws-appsync";
 
 import { AlarmWithAnnotation, AppSyncMonitoring } from "../../../lib";
 import { addMonitoringDashboardsToStack } from "../../utils/SnapshotUtil";
@@ -13,6 +14,9 @@ test("snapshot test: no alarms", () => {
 
   const dummyApi = new GraphqlApi(stack, "testHttpApi", {
     name: "DummyApi",
+    schema: SchemaFile.fromAsset(
+      path.join(__dirname, "..", "..", "assets", "schema.graphql")
+    ),
   });
 
   const monitoring = new AppSyncMonitoring(scope, {
@@ -57,6 +61,9 @@ test("snapshot test: all alarms", () => {
 
   const dummyApi = new GraphqlApi(stack, "testHttpApi", {
     name: "DummyApi",
+    schema: SchemaFile.fromAsset(
+      path.join(__dirname, "..", "..", "assets", "schema.graphql")
+    ),
   });
 
   const monitoring = new AppSyncMonitoring(scope, {

--- a/test/monitoring/aws-appsync/__snapshots__/AppSyncMonitoring.test.ts.snap
+++ b/test/monitoring/aws-appsync/__snapshots__/AppSyncMonitoring.test.ts.snap
@@ -664,7 +664,20 @@ Object {
             "ApiId",
           ],
         },
-        "Definition": "",
+        "Definition": "type demo {
+  id: String!
+  version: String!
+}
+type Query {
+  getDemos: [ demo! ]
+}
+input DemoInput {
+  version: String!
+}
+type Mutation {
+  addDemo(input: DemoInput!): demo
+}
+",
       },
       "Type": "AWS::AppSync::GraphQLSchema",
     },
@@ -896,7 +909,20 @@ Object {
             "ApiId",
           ],
         },
-        "Definition": "",
+        "Definition": "type demo {
+  id: String!
+  version: String!
+}
+type Query {
+  getDemos: [ demo! ]
+}
+input DemoInput {
+  version: String!
+}
+type Mutation {
+  addDemo(input: DemoInput!): demo
+}
+",
       },
       "Type": "AWS::AppSync::GraphQLSchema",
     },

--- a/test/monitoring/aws-docdb/__snapshots__/DocumentDbMonitoring.test.ts.snap
+++ b/test/monitoring/aws-docdb/__snapshots__/DocumentDbMonitoring.test.ts.snap
@@ -81,7 +81,9 @@ Object {
       "DeletionPolicy": "Retain",
       "DependsOn": Array [
         "VpcPrivateSubnet1DefaultRouteBE02A9ED",
+        "VpcPrivateSubnet1RouteTableAssociation70C59FA6",
         "VpcPrivateSubnet2DefaultRoute060D2087",
+        "VpcPrivateSubnet2RouteTableAssociationA89CAD56",
       ],
       "Properties": Object {
         "DBClusterIdentifier": Object {
@@ -490,6 +492,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "VpcPublicSubnet1NATGateway4D7517AA": Object {
+      "DependsOn": Array [
+        "VpcPublicSubnet1DefaultRoute3DA9E72A",
+        "VpcPublicSubnet1RouteTableAssociation97140677",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -594,6 +600,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "VpcPublicSubnet2NATGateway9182C01D": Object {
+      "DependsOn": Array [
+        "VpcPublicSubnet2DefaultRoute97F91067",
+        "VpcPublicSubnet2RouteTableAssociationDD5762D8",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -775,7 +785,9 @@ Object {
       "DeletionPolicy": "Retain",
       "DependsOn": Array [
         "VpcPrivateSubnet1DefaultRouteBE02A9ED",
+        "VpcPrivateSubnet1RouteTableAssociation70C59FA6",
         "VpcPrivateSubnet2DefaultRoute060D2087",
+        "VpcPrivateSubnet2RouteTableAssociationA89CAD56",
       ],
       "Properties": Object {
         "DBClusterIdentifier": Object {
@@ -1148,6 +1160,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "VpcPublicSubnet1NATGateway4D7517AA": Object {
+      "DependsOn": Array [
+        "VpcPublicSubnet1DefaultRoute3DA9E72A",
+        "VpcPublicSubnet1RouteTableAssociation97140677",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -1252,6 +1268,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "VpcPublicSubnet2NATGateway9182C01D": Object {
+      "DependsOn": Array [
+        "VpcPublicSubnet2DefaultRoute97F91067",
+        "VpcPublicSubnet2RouteTableAssociationDD5762D8",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [

--- a/test/monitoring/aws-ec2/__snapshots__/AutoScalingGroupMonitoring.test.ts.snap
+++ b/test/monitoring/aws-ec2/__snapshots__/AutoScalingGroupMonitoring.test.ts.snap
@@ -64,17 +64,7 @@ Object {
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": Object {
-                "Service": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "ec2.",
-                      Object {
-                        "Ref": "AWS::URLSuffix",
-                      },
-                    ],
-                  ],
-                },
+                "Service": "ec2.amazonaws.com",
               },
             },
           ],
@@ -421,6 +411,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "VpcPublicSubnet1NATGateway4D7517AA": Object {
+      "DependsOn": Array [
+        "VpcPublicSubnet1DefaultRoute3DA9E72A",
+        "VpcPublicSubnet1RouteTableAssociation97140677",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -525,6 +519,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "VpcPublicSubnet2NATGateway9182C01D": Object {
+      "DependsOn": Array [
+        "VpcPublicSubnet2DefaultRoute97F91067",
+        "VpcPublicSubnet2RouteTableAssociationDD5762D8",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [

--- a/test/monitoring/aws-ecs-patterns/__snapshots__/Ec2ServiceMonitoring.test.ts.snap
+++ b/test/monitoring/aws-ecs-patterns/__snapshots__/Ec2ServiceMonitoring.test.ts.snap
@@ -325,6 +325,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet1NATGateway0693C346": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet1DefaultRoute62DA4B4B",
+        "ClusterVpcPublicSubnet1RouteTableAssociation0FBEF1F4",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -429,6 +433,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet2NATGateway00B24686": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet2DefaultRoute97446C8A",
+        "ClusterVpcPublicSubnet2RouteTableAssociation8446B27D",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -563,13 +571,13 @@ autoscaling = boto3.client('autoscaling')
 
 
 def lambda_handler(event, context):
-  print(json.dumps(event))
+  print(json.dumps(dict(event, ResponseURL='...')))
   cluster = os.environ['CLUSTER']
   snsTopicArn = event['Records'][0]['Sns']['TopicArn']
   lifecycle_event = json.loads(event['Records'][0]['Sns']['Message'])
   instance_id = lifecycle_event.get('EC2InstanceId')
   if not instance_id:
-    print('Got event without EC2InstanceId: %s', json.dumps(event))
+    print('Got event without EC2InstanceId: %s', json.dumps(dict(event, ResponseURL='...')))
     return
 
   instance_arn = container_instance_arn(cluster, instance_id)
@@ -579,7 +587,7 @@ def lambda_handler(event, context):
     return
 
   task_arns = container_instance_task_arns(cluster, instance_arn)
-  
+
   if task_arns:
     print('Instance ARN %s has task ARNs %s' % (instance_arn, ', '.join(task_arns)))
 
@@ -628,11 +636,11 @@ def has_tasks(cluster, instance_arn, task_arns):
     if tasks:
       # Consider any non-stopped tasks as running
       task_count = sum(task['lastStatus'] != 'STOPPED' for task in tasks) + instance['pendingTasksCount']
-  
+
   if not task_count:
     # Fallback to instance task counts if detailed task information is unavailable
     task_count = instance['runningTasksCount'] + instance['pendingTasksCount']
-    
+
   print('Instance %s has %s tasks' % (instance_arn, task_count))
 
   return task_count > 0
@@ -662,7 +670,7 @@ def pick(dct, *keys):
             "Arn",
           ],
         },
-        "Runtime": "python3.6",
+        "Runtime": "python3.9",
         "Tags": Array [
           Object {
             "Key": "Name",
@@ -862,17 +870,7 @@ def pick(dct, *keys):
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": Object {
-                "Service": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "ec2.",
-                      Object {
-                        "Ref": "AWS::URLSuffix",
-                      },
-                    ],
-                  ],
-                },
+                "Service": "ec2.amazonaws.com",
               },
             },
           ],
@@ -1113,11 +1111,6 @@ echo ECS_AWSVPC_BLOCK_IMDS=true >> /etc/ecs/ecs.config",
     },
     "Repository22E53BBD": Object {
       "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "ImageScanningConfiguration": Object {
-          "ScanOnPush": false,
-        },
-      },
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Retain",
     },
@@ -2573,6 +2566,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet1NATGateway0693C346": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet1DefaultRoute62DA4B4B",
+        "ClusterVpcPublicSubnet1RouteTableAssociation0FBEF1F4",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -2677,6 +2674,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet2NATGateway00B24686": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet2DefaultRoute97446C8A",
+        "ClusterVpcPublicSubnet2RouteTableAssociation8446B27D",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -2811,13 +2812,13 @@ autoscaling = boto3.client('autoscaling')
 
 
 def lambda_handler(event, context):
-  print(json.dumps(event))
+  print(json.dumps(dict(event, ResponseURL='...')))
   cluster = os.environ['CLUSTER']
   snsTopicArn = event['Records'][0]['Sns']['TopicArn']
   lifecycle_event = json.loads(event['Records'][0]['Sns']['Message'])
   instance_id = lifecycle_event.get('EC2InstanceId')
   if not instance_id:
-    print('Got event without EC2InstanceId: %s', json.dumps(event))
+    print('Got event without EC2InstanceId: %s', json.dumps(dict(event, ResponseURL='...')))
     return
 
   instance_arn = container_instance_arn(cluster, instance_id)
@@ -2827,7 +2828,7 @@ def lambda_handler(event, context):
     return
 
   task_arns = container_instance_task_arns(cluster, instance_arn)
-  
+
   if task_arns:
     print('Instance ARN %s has task ARNs %s' % (instance_arn, ', '.join(task_arns)))
 
@@ -2876,11 +2877,11 @@ def has_tasks(cluster, instance_arn, task_arns):
     if tasks:
       # Consider any non-stopped tasks as running
       task_count = sum(task['lastStatus'] != 'STOPPED' for task in tasks) + instance['pendingTasksCount']
-  
+
   if not task_count:
     # Fallback to instance task counts if detailed task information is unavailable
     task_count = instance['runningTasksCount'] + instance['pendingTasksCount']
-    
+
   print('Instance %s has %s tasks' % (instance_arn, task_count))
 
   return task_count > 0
@@ -2910,7 +2911,7 @@ def pick(dct, *keys):
             "Arn",
           ],
         },
-        "Runtime": "python3.6",
+        "Runtime": "python3.9",
         "Tags": Array [
           Object {
             "Key": "Name",
@@ -3110,17 +3111,7 @@ def pick(dct, *keys):
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": Object {
-                "Service": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "ec2.",
-                      Object {
-                        "Ref": "AWS::URLSuffix",
-                      },
-                    ],
-                  ],
-                },
+                "Service": "ec2.amazonaws.com",
               },
             },
           ],
@@ -3361,11 +3352,6 @@ echo ECS_AWSVPC_BLOCK_IMDS=true >> /etc/ecs/ecs.config",
     },
     "Repository22E53BBD": Object {
       "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "ImageScanningConfiguration": Object {
-          "ScanOnPush": false,
-        },
-      },
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Retain",
     },
@@ -4365,6 +4351,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet1NATGateway0693C346": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet1DefaultRoute62DA4B4B",
+        "ClusterVpcPublicSubnet1RouteTableAssociation0FBEF1F4",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -4469,6 +4459,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet2NATGateway00B24686": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet2DefaultRoute97446C8A",
+        "ClusterVpcPublicSubnet2RouteTableAssociation8446B27D",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -4603,13 +4597,13 @@ autoscaling = boto3.client('autoscaling')
 
 
 def lambda_handler(event, context):
-  print(json.dumps(event))
+  print(json.dumps(dict(event, ResponseURL='...')))
   cluster = os.environ['CLUSTER']
   snsTopicArn = event['Records'][0]['Sns']['TopicArn']
   lifecycle_event = json.loads(event['Records'][0]['Sns']['Message'])
   instance_id = lifecycle_event.get('EC2InstanceId')
   if not instance_id:
-    print('Got event without EC2InstanceId: %s', json.dumps(event))
+    print('Got event without EC2InstanceId: %s', json.dumps(dict(event, ResponseURL='...')))
     return
 
   instance_arn = container_instance_arn(cluster, instance_id)
@@ -4619,7 +4613,7 @@ def lambda_handler(event, context):
     return
 
   task_arns = container_instance_task_arns(cluster, instance_arn)
-  
+
   if task_arns:
     print('Instance ARN %s has task ARNs %s' % (instance_arn, ', '.join(task_arns)))
 
@@ -4668,11 +4662,11 @@ def has_tasks(cluster, instance_arn, task_arns):
     if tasks:
       # Consider any non-stopped tasks as running
       task_count = sum(task['lastStatus'] != 'STOPPED' for task in tasks) + instance['pendingTasksCount']
-  
+
   if not task_count:
     # Fallback to instance task counts if detailed task information is unavailable
     task_count = instance['runningTasksCount'] + instance['pendingTasksCount']
-    
+
   print('Instance %s has %s tasks' % (instance_arn, task_count))
 
   return task_count > 0
@@ -4702,7 +4696,7 @@ def pick(dct, *keys):
             "Arn",
           ],
         },
-        "Runtime": "python3.6",
+        "Runtime": "python3.9",
         "Tags": Array [
           Object {
             "Key": "Name",
@@ -4902,17 +4896,7 @@ def pick(dct, *keys):
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": Object {
-                "Service": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "ec2.",
-                      Object {
-                        "Ref": "AWS::URLSuffix",
-                      },
-                    ],
-                  ],
-                },
+                "Service": "ec2.amazonaws.com",
               },
             },
           ],
@@ -5132,11 +5116,6 @@ echo ECS_AWSVPC_BLOCK_IMDS=true >> /etc/ecs/ecs.config",
     },
     "Repository22E53BBD": Object {
       "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "ImageScanningConfiguration": Object {
-          "ScanOnPush": false,
-        },
-      },
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Retain",
     },
@@ -6523,6 +6502,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet1NATGateway0693C346": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet1DefaultRoute62DA4B4B",
+        "ClusterVpcPublicSubnet1RouteTableAssociation0FBEF1F4",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -6627,6 +6610,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet2NATGateway00B24686": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet2DefaultRoute97446C8A",
+        "ClusterVpcPublicSubnet2RouteTableAssociation8446B27D",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -6761,13 +6748,13 @@ autoscaling = boto3.client('autoscaling')
 
 
 def lambda_handler(event, context):
-  print(json.dumps(event))
+  print(json.dumps(dict(event, ResponseURL='...')))
   cluster = os.environ['CLUSTER']
   snsTopicArn = event['Records'][0]['Sns']['TopicArn']
   lifecycle_event = json.loads(event['Records'][0]['Sns']['Message'])
   instance_id = lifecycle_event.get('EC2InstanceId')
   if not instance_id:
-    print('Got event without EC2InstanceId: %s', json.dumps(event))
+    print('Got event without EC2InstanceId: %s', json.dumps(dict(event, ResponseURL='...')))
     return
 
   instance_arn = container_instance_arn(cluster, instance_id)
@@ -6777,7 +6764,7 @@ def lambda_handler(event, context):
     return
 
   task_arns = container_instance_task_arns(cluster, instance_arn)
-  
+
   if task_arns:
     print('Instance ARN %s has task ARNs %s' % (instance_arn, ', '.join(task_arns)))
 
@@ -6826,11 +6813,11 @@ def has_tasks(cluster, instance_arn, task_arns):
     if tasks:
       # Consider any non-stopped tasks as running
       task_count = sum(task['lastStatus'] != 'STOPPED' for task in tasks) + instance['pendingTasksCount']
-  
+
   if not task_count:
     # Fallback to instance task counts if detailed task information is unavailable
     task_count = instance['runningTasksCount'] + instance['pendingTasksCount']
-    
+
   print('Instance %s has %s tasks' % (instance_arn, task_count))
 
   return task_count > 0
@@ -6860,7 +6847,7 @@ def pick(dct, *keys):
             "Arn",
           ],
         },
-        "Runtime": "python3.6",
+        "Runtime": "python3.9",
         "Tags": Array [
           Object {
             "Key": "Name",
@@ -7060,17 +7047,7 @@ def pick(dct, *keys):
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": Object {
-                "Service": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "ec2.",
-                      Object {
-                        "Ref": "AWS::URLSuffix",
-                      },
-                    ],
-                  ],
-                },
+                "Service": "ec2.amazonaws.com",
               },
             },
           ],
@@ -7290,11 +7267,6 @@ echo ECS_AWSVPC_BLOCK_IMDS=true >> /etc/ecs/ecs.config",
     },
     "Repository22E53BBD": Object {
       "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "ImageScanningConfiguration": Object {
-          "ScanOnPush": false,
-        },
-      },
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Retain",
     },

--- a/test/monitoring/aws-ecs-patterns/__snapshots__/FargateServiceMonitoring.test.ts.snap
+++ b/test/monitoring/aws-ecs-patterns/__snapshots__/FargateServiceMonitoring.test.ts.snap
@@ -321,6 +321,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet1NATGateway0693C346": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet1DefaultRoute62DA4B4B",
+        "ClusterVpcPublicSubnet1RouteTableAssociation0FBEF1F4",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -425,6 +429,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet2NATGateway00B24686": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet2DefaultRoute97446C8A",
+        "ClusterVpcPublicSubnet2RouteTableAssociation8446B27D",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -514,11 +522,6 @@ Object {
     },
     "Repository22E53BBD": Object {
       "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "ImageScanningConfiguration": Object {
-          "ScanOnPush": false,
-        },
-      },
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Retain",
     },
@@ -2027,6 +2030,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet1NATGateway0693C346": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet1DefaultRoute62DA4B4B",
+        "ClusterVpcPublicSubnet1RouteTableAssociation0FBEF1F4",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -2131,6 +2138,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet2NATGateway00B24686": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet2DefaultRoute97446C8A",
+        "ClusterVpcPublicSubnet2RouteTableAssociation8446B27D",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -2220,11 +2231,6 @@ Object {
     },
     "Repository22E53BBD": Object {
       "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "ImageScanningConfiguration": Object {
-          "ScanOnPush": false,
-        },
-      },
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Retain",
     },
@@ -3277,6 +3283,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet1NATGateway0693C346": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet1DefaultRoute62DA4B4B",
+        "ClusterVpcPublicSubnet1RouteTableAssociation0FBEF1F4",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -3381,6 +3391,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet2NATGateway00B24686": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet2DefaultRoute97446C8A",
+        "ClusterVpcPublicSubnet2RouteTableAssociation8446B27D",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -3470,11 +3484,6 @@ Object {
     },
     "Repository22E53BBD": Object {
       "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "ImageScanningConfiguration": Object {
-          "ScanOnPush": false,
-        },
-      },
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Retain",
     },
@@ -4893,6 +4902,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet1NATGateway0693C346": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet1DefaultRoute62DA4B4B",
+        "ClusterVpcPublicSubnet1RouteTableAssociation0FBEF1F4",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -4997,6 +5010,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet2NATGateway00B24686": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet2DefaultRoute97446C8A",
+        "ClusterVpcPublicSubnet2RouteTableAssociation8446B27D",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -5086,11 +5103,6 @@ Object {
     },
     "Repository22E53BBD": Object {
       "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "ImageScanningConfiguration": Object {
-          "ScanOnPush": false,
-        },
-      },
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Retain",
     },
@@ -6048,6 +6060,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet1NATGateway0693C346": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet1DefaultRoute62DA4B4B",
+        "ClusterVpcPublicSubnet1RouteTableAssociation0FBEF1F4",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -6152,6 +6168,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet2NATGateway00B24686": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet2DefaultRoute97446C8A",
+        "ClusterVpcPublicSubnet2RouteTableAssociation8446B27D",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -6291,11 +6311,6 @@ Object {
     },
     "Repository22E53BBD": Object {
       "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "ImageScanningConfiguration": Object {
-          "ScanOnPush": false,
-        },
-      },
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Retain",
     },
@@ -7585,6 +7600,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet1NATGateway0693C346": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet1DefaultRoute62DA4B4B",
+        "ClusterVpcPublicSubnet1RouteTableAssociation0FBEF1F4",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -7689,6 +7708,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet2NATGateway00B24686": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet2DefaultRoute97446C8A",
+        "ClusterVpcPublicSubnet2RouteTableAssociation8446B27D",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -7828,11 +7851,6 @@ Object {
     },
     "Repository22E53BBD": Object {
       "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "ImageScanningConfiguration": Object {
-          "ScanOnPush": false,
-        },
-      },
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Retain",
     },
@@ -8677,6 +8695,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet1NATGateway0693C346": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet1DefaultRoute62DA4B4B",
+        "ClusterVpcPublicSubnet1RouteTableAssociation0FBEF1F4",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -8781,6 +8803,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet2NATGateway00B24686": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet2DefaultRoute97446C8A",
+        "ClusterVpcPublicSubnet2RouteTableAssociation8446B27D",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -8870,11 +8896,6 @@ Object {
     },
     "Repository22E53BBD": Object {
       "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "ImageScanningConfiguration": Object {
-          "ScanOnPush": false,
-        },
-      },
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Retain",
     },
@@ -9573,6 +9594,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet1NATGateway0693C346": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet1DefaultRoute62DA4B4B",
+        "ClusterVpcPublicSubnet1RouteTableAssociation0FBEF1F4",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -9677,6 +9702,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet2NATGateway00B24686": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet2DefaultRoute97446C8A",
+        "ClusterVpcPublicSubnet2RouteTableAssociation8446B27D",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -9766,11 +9795,6 @@ Object {
     },
     "Repository22E53BBD": Object {
       "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "ImageScanningConfiguration": Object {
-          "ScanOnPush": false,
-        },
-      },
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Retain",
     },

--- a/test/monitoring/aws-ecs-patterns/__snapshots__/misc.test.ts.snap
+++ b/test/monitoring/aws-ecs-patterns/__snapshots__/misc.test.ts.snap
@@ -243,6 +243,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet1NATGateway0693C346": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet1DefaultRoute62DA4B4B",
+        "ClusterVpcPublicSubnet1RouteTableAssociation0FBEF1F4",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -347,6 +351,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet2NATGateway00B24686": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet2DefaultRoute97446C8A",
+        "ClusterVpcPublicSubnet2RouteTableAssociation8446B27D",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -481,13 +489,13 @@ autoscaling = boto3.client('autoscaling')
 
 
 def lambda_handler(event, context):
-  print(json.dumps(event))
+  print(json.dumps(dict(event, ResponseURL='...')))
   cluster = os.environ['CLUSTER']
   snsTopicArn = event['Records'][0]['Sns']['TopicArn']
   lifecycle_event = json.loads(event['Records'][0]['Sns']['Message'])
   instance_id = lifecycle_event.get('EC2InstanceId')
   if not instance_id:
-    print('Got event without EC2InstanceId: %s', json.dumps(event))
+    print('Got event without EC2InstanceId: %s', json.dumps(dict(event, ResponseURL='...')))
     return
 
   instance_arn = container_instance_arn(cluster, instance_id)
@@ -497,7 +505,7 @@ def lambda_handler(event, context):
     return
 
   task_arns = container_instance_task_arns(cluster, instance_arn)
-  
+
   if task_arns:
     print('Instance ARN %s has task ARNs %s' % (instance_arn, ', '.join(task_arns)))
 
@@ -546,11 +554,11 @@ def has_tasks(cluster, instance_arn, task_arns):
     if tasks:
       # Consider any non-stopped tasks as running
       task_count = sum(task['lastStatus'] != 'STOPPED' for task in tasks) + instance['pendingTasksCount']
-  
+
   if not task_count:
     # Fallback to instance task counts if detailed task information is unavailable
     task_count = instance['runningTasksCount'] + instance['pendingTasksCount']
-    
+
   print('Instance %s has %s tasks' % (instance_arn, task_count))
 
   return task_count > 0
@@ -580,7 +588,7 @@ def pick(dct, *keys):
             "Arn",
           ],
         },
-        "Runtime": "python3.6",
+        "Runtime": "python3.9",
         "Tags": Array [
           Object {
             "Key": "Name",
@@ -780,17 +788,7 @@ def pick(dct, *keys):
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": Object {
-                "Service": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "ec2.",
-                      Object {
-                        "Ref": "AWS::URLSuffix",
-                      },
-                    ],
-                  ],
-                },
+                "Service": "ec2.amazonaws.com",
               },
             },
           ],
@@ -1010,11 +1008,6 @@ echo ECS_AWSVPC_BLOCK_IMDS=true >> /etc/ecs/ecs.config",
     },
     "Repository22E53BBD": Object {
       "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "ImageScanningConfiguration": Object {
-          "ScanOnPush": false,
-        },
-      },
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Retain",
     },
@@ -1716,6 +1709,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet1NATGateway0693C346": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet1DefaultRoute62DA4B4B",
+        "ClusterVpcPublicSubnet1RouteTableAssociation0FBEF1F4",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -1820,6 +1817,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet2NATGateway00B24686": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet2DefaultRoute97446C8A",
+        "ClusterVpcPublicSubnet2RouteTableAssociation8446B27D",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -1954,13 +1955,13 @@ autoscaling = boto3.client('autoscaling')
 
 
 def lambda_handler(event, context):
-  print(json.dumps(event))
+  print(json.dumps(dict(event, ResponseURL='...')))
   cluster = os.environ['CLUSTER']
   snsTopicArn = event['Records'][0]['Sns']['TopicArn']
   lifecycle_event = json.loads(event['Records'][0]['Sns']['Message'])
   instance_id = lifecycle_event.get('EC2InstanceId')
   if not instance_id:
-    print('Got event without EC2InstanceId: %s', json.dumps(event))
+    print('Got event without EC2InstanceId: %s', json.dumps(dict(event, ResponseURL='...')))
     return
 
   instance_arn = container_instance_arn(cluster, instance_id)
@@ -1970,7 +1971,7 @@ def lambda_handler(event, context):
     return
 
   task_arns = container_instance_task_arns(cluster, instance_arn)
-  
+
   if task_arns:
     print('Instance ARN %s has task ARNs %s' % (instance_arn, ', '.join(task_arns)))
 
@@ -2019,11 +2020,11 @@ def has_tasks(cluster, instance_arn, task_arns):
     if tasks:
       # Consider any non-stopped tasks as running
       task_count = sum(task['lastStatus'] != 'STOPPED' for task in tasks) + instance['pendingTasksCount']
-  
+
   if not task_count:
     # Fallback to instance task counts if detailed task information is unavailable
     task_count = instance['runningTasksCount'] + instance['pendingTasksCount']
-    
+
   print('Instance %s has %s tasks' % (instance_arn, task_count))
 
   return task_count > 0
@@ -2053,7 +2054,7 @@ def pick(dct, *keys):
             "Arn",
           ],
         },
-        "Runtime": "python3.6",
+        "Runtime": "python3.9",
         "Tags": Array [
           Object {
             "Key": "Name",
@@ -2253,17 +2254,7 @@ def pick(dct, *keys):
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": Object {
-                "Service": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "ec2.",
-                      Object {
-                        "Ref": "AWS::URLSuffix",
-                      },
-                    ],
-                  ],
-                },
+                "Service": "ec2.amazonaws.com",
               },
             },
           ],
@@ -2483,11 +2474,6 @@ echo ECS_AWSVPC_BLOCK_IMDS=true >> /etc/ecs/ecs.config",
     },
     "Repository22E53BBD": Object {
       "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "ImageScanningConfiguration": Object {
-          "ScanOnPush": false,
-        },
-      },
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Retain",
     },
@@ -3308,6 +3294,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet1NATGateway0693C346": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet1DefaultRoute62DA4B4B",
+        "ClusterVpcPublicSubnet1RouteTableAssociation0FBEF1F4",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -3412,6 +3402,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet2NATGateway00B24686": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet2DefaultRoute97446C8A",
+        "ClusterVpcPublicSubnet2RouteTableAssociation8446B27D",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -3501,11 +3495,6 @@ Object {
     },
     "Repository22E53BBD": Object {
       "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "ImageScanningConfiguration": Object {
-          "ScanOnPush": false,
-        },
-      },
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Retain",
     },
@@ -4394,6 +4383,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet1NATGateway0693C346": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet1DefaultRoute62DA4B4B",
+        "ClusterVpcPublicSubnet1RouteTableAssociation0FBEF1F4",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -4498,6 +4491,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet2NATGateway00B24686": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet2DefaultRoute97446C8A",
+        "ClusterVpcPublicSubnet2RouteTableAssociation8446B27D",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -4587,11 +4584,6 @@ Object {
     },
     "Repository22E53BBD": Object {
       "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "ImageScanningConfiguration": Object {
-          "ScanOnPush": false,
-        },
-      },
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Retain",
     },

--- a/test/monitoring/aws-loadbalancing/__snapshots__/ApplicationLoadBalancerMonitoring.test.ts.snap
+++ b/test/monitoring/aws-loadbalancing/__snapshots__/ApplicationLoadBalancerMonitoring.test.ts.snap
@@ -398,6 +398,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet1NATGateway0693C346": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet1DefaultRoute62DA4B4B",
+        "ClusterVpcPublicSubnet1RouteTableAssociation0FBEF1F4",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -502,6 +506,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet2NATGateway00B24686": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet2DefaultRoute97446C8A",
+        "ClusterVpcPublicSubnet2RouteTableAssociation8446B27D",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -591,11 +599,6 @@ Object {
     },
     "Repository22E53BBD": Object {
       "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "ImageScanningConfiguration": Object {
-          "ScanOnPush": false,
-        },
-      },
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Retain",
     },
@@ -2048,6 +2051,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet1NATGateway0693C346": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet1DefaultRoute62DA4B4B",
+        "ClusterVpcPublicSubnet1RouteTableAssociation0FBEF1F4",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -2152,6 +2159,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet2NATGateway00B24686": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet2DefaultRoute97446C8A",
+        "ClusterVpcPublicSubnet2RouteTableAssociation8446B27D",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -2241,11 +2252,6 @@ Object {
     },
     "Repository22E53BBD": Object {
       "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "ImageScanningConfiguration": Object {
-          "ScanOnPush": false,
-        },
-      },
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Retain",
     },
@@ -3262,6 +3268,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet1NATGateway0693C346": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet1DefaultRoute62DA4B4B",
+        "ClusterVpcPublicSubnet1RouteTableAssociation0FBEF1F4",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -3366,6 +3376,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet2NATGateway00B24686": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet2DefaultRoute97446C8A",
+        "ClusterVpcPublicSubnet2RouteTableAssociation8446B27D",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -3500,13 +3514,13 @@ autoscaling = boto3.client('autoscaling')
 
 
 def lambda_handler(event, context):
-  print(json.dumps(event))
+  print(json.dumps(dict(event, ResponseURL='...')))
   cluster = os.environ['CLUSTER']
   snsTopicArn = event['Records'][0]['Sns']['TopicArn']
   lifecycle_event = json.loads(event['Records'][0]['Sns']['Message'])
   instance_id = lifecycle_event.get('EC2InstanceId')
   if not instance_id:
-    print('Got event without EC2InstanceId: %s', json.dumps(event))
+    print('Got event without EC2InstanceId: %s', json.dumps(dict(event, ResponseURL='...')))
     return
 
   instance_arn = container_instance_arn(cluster, instance_id)
@@ -3516,7 +3530,7 @@ def lambda_handler(event, context):
     return
 
   task_arns = container_instance_task_arns(cluster, instance_arn)
-  
+
   if task_arns:
     print('Instance ARN %s has task ARNs %s' % (instance_arn, ', '.join(task_arns)))
 
@@ -3565,11 +3579,11 @@ def has_tasks(cluster, instance_arn, task_arns):
     if tasks:
       # Consider any non-stopped tasks as running
       task_count = sum(task['lastStatus'] != 'STOPPED' for task in tasks) + instance['pendingTasksCount']
-  
+
   if not task_count:
     # Fallback to instance task counts if detailed task information is unavailable
     task_count = instance['runningTasksCount'] + instance['pendingTasksCount']
-    
+
   print('Instance %s has %s tasks' % (instance_arn, task_count))
 
   return task_count > 0
@@ -3599,7 +3613,7 @@ def pick(dct, *keys):
             "Arn",
           ],
         },
-        "Runtime": "python3.6",
+        "Runtime": "python3.9",
         "Tags": Array [
           Object {
             "Key": "Name",
@@ -3799,17 +3813,7 @@ def pick(dct, *keys):
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": Object {
-                "Service": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "ec2.",
-                      Object {
-                        "Ref": "AWS::URLSuffix",
-                      },
-                    ],
-                  ],
-                },
+                "Service": "ec2.amazonaws.com",
               },
             },
           ],
@@ -4050,11 +4054,6 @@ echo ECS_AWSVPC_BLOCK_IMDS=true >> /etc/ecs/ecs.config",
     },
     "Repository22E53BBD": Object {
       "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "ImageScanningConfiguration": Object {
-          "ScanOnPush": false,
-        },
-      },
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Retain",
     },
@@ -5454,6 +5453,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet1NATGateway0693C346": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet1DefaultRoute62DA4B4B",
+        "ClusterVpcPublicSubnet1RouteTableAssociation0FBEF1F4",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -5558,6 +5561,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "ClusterVpcPublicSubnet2NATGateway00B24686": Object {
+      "DependsOn": Array [
+        "ClusterVpcPublicSubnet2DefaultRoute97446C8A",
+        "ClusterVpcPublicSubnet2RouteTableAssociation8446B27D",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -5692,13 +5699,13 @@ autoscaling = boto3.client('autoscaling')
 
 
 def lambda_handler(event, context):
-  print(json.dumps(event))
+  print(json.dumps(dict(event, ResponseURL='...')))
   cluster = os.environ['CLUSTER']
   snsTopicArn = event['Records'][0]['Sns']['TopicArn']
   lifecycle_event = json.loads(event['Records'][0]['Sns']['Message'])
   instance_id = lifecycle_event.get('EC2InstanceId')
   if not instance_id:
-    print('Got event without EC2InstanceId: %s', json.dumps(event))
+    print('Got event without EC2InstanceId: %s', json.dumps(dict(event, ResponseURL='...')))
     return
 
   instance_arn = container_instance_arn(cluster, instance_id)
@@ -5708,7 +5715,7 @@ def lambda_handler(event, context):
     return
 
   task_arns = container_instance_task_arns(cluster, instance_arn)
-  
+
   if task_arns:
     print('Instance ARN %s has task ARNs %s' % (instance_arn, ', '.join(task_arns)))
 
@@ -5757,11 +5764,11 @@ def has_tasks(cluster, instance_arn, task_arns):
     if tasks:
       # Consider any non-stopped tasks as running
       task_count = sum(task['lastStatus'] != 'STOPPED' for task in tasks) + instance['pendingTasksCount']
-  
+
   if not task_count:
     # Fallback to instance task counts if detailed task information is unavailable
     task_count = instance['runningTasksCount'] + instance['pendingTasksCount']
-    
+
   print('Instance %s has %s tasks' % (instance_arn, task_count))
 
   return task_count > 0
@@ -5791,7 +5798,7 @@ def pick(dct, *keys):
             "Arn",
           ],
         },
-        "Runtime": "python3.6",
+        "Runtime": "python3.9",
         "Tags": Array [
           Object {
             "Key": "Name",
@@ -5991,17 +5998,7 @@ def pick(dct, *keys):
               "Action": "sts:AssumeRole",
               "Effect": "Allow",
               "Principal": Object {
-                "Service": Object {
-                  "Fn::Join": Array [
-                    "",
-                    Array [
-                      "ec2.",
-                      Object {
-                        "Ref": "AWS::URLSuffix",
-                      },
-                    ],
-                  ],
-                },
+                "Service": "ec2.amazonaws.com",
               },
             },
           ],
@@ -6242,11 +6239,6 @@ echo ECS_AWSVPC_BLOCK_IMDS=true >> /etc/ecs/ecs.config",
     },
     "Repository22E53BBD": Object {
       "DeletionPolicy": "Retain",
-      "Properties": Object {
-        "ImageScanningConfiguration": Object {
-          "ScanOnPush": false,
-        },
-      },
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Retain",
     },

--- a/test/monitoring/aws-loadbalancing/__snapshots__/NetworkLoadBalancerMonitoring.test.ts.snap
+++ b/test/monitoring/aws-loadbalancing/__snapshots__/NetworkLoadBalancerMonitoring.test.ts.snap
@@ -977,6 +977,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "VpcPublicSubnet1NATGateway4D7517AA": Object {
+      "DependsOn": Array [
+        "VpcPublicSubnet1DefaultRoute3DA9E72A",
+        "VpcPublicSubnet1RouteTableAssociation97140677",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -1081,6 +1085,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "VpcPublicSubnet2NATGateway9182C01D": Object {
+      "DependsOn": Array [
+        "VpcPublicSubnet2DefaultRoute97F91067",
+        "VpcPublicSubnet2RouteTableAssociationDD5762D8",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -1736,6 +1744,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "VpcPublicSubnet1NATGateway4D7517AA": Object {
+      "DependsOn": Array [
+        "VpcPublicSubnet1DefaultRoute3DA9E72A",
+        "VpcPublicSubnet1RouteTableAssociation97140677",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [
@@ -1840,6 +1852,10 @@ Object {
       "Type": "AWS::EC2::EIP",
     },
     "VpcPublicSubnet2NATGateway9182C01D": Object {
+      "DependsOn": Array [
+        "VpcPublicSubnet2DefaultRoute97F91067",
+        "VpcPublicSubnet2RouteTableAssociationDD5762D8",
+      ],
       "Properties": Object {
         "AllocationId": Object {
           "Fn::GetAtt": Array [

--- a/test/monitoring/aws-opensearch/__snapshots__/OpenSearchClusterMonitoring.test.ts.snap
+++ b/test/monitoring/aws-opensearch/__snapshots__/OpenSearchClusterMonitoring.test.ts.snap
@@ -65,9 +65,6 @@ Object {
           "InstanceType": "r5.large.search",
           "ZoneAwarenessEnabled": false,
         },
-        "CognitoOptions": Object {
-          "Enabled": false,
-        },
         "DomainEndpointOptions": Object {
           "EnforceHTTPS": false,
           "TLSSecurityPolicy": "Policy-Min-TLS-1-0-2019-07",
@@ -185,9 +182,6 @@ Object {
           "InstanceCount": 1,
           "InstanceType": "r5.large.search",
           "ZoneAwarenessEnabled": false,
-        },
-        "CognitoOptions": Object {
-          "Enabled": false,
         },
         "DomainEndpointOptions": Object {
           "EnforceHTTPS": false,
@@ -307,9 +301,6 @@ Object {
           "InstanceType": "r5.large.search",
           "ZoneAwarenessEnabled": false,
         },
-        "CognitoOptions": Object {
-          "Enabled": false,
-        },
         "DomainEndpointOptions": Object {
           "EnforceHTTPS": false,
           "TLSSecurityPolicy": "Policy-Min-TLS-1-0-2019-07",
@@ -427,9 +418,6 @@ Object {
           "InstanceCount": 1,
           "InstanceType": "r5.large.search",
           "ZoneAwarenessEnabled": false,
-        },
-        "CognitoOptions": Object {
-          "Enabled": false,
         },
         "DomainEndpointOptions": Object {
           "EnforceHTTPS": false,
@@ -549,9 +537,6 @@ Object {
           "InstanceType": "r5.large.search",
           "ZoneAwarenessEnabled": false,
         },
-        "CognitoOptions": Object {
-          "Enabled": false,
-        },
         "DomainEndpointOptions": Object {
           "EnforceHTTPS": false,
           "TLSSecurityPolicy": "Policy-Min-TLS-1-0-2019-07",
@@ -669,9 +654,6 @@ Object {
           "InstanceCount": 1,
           "InstanceType": "r5.large.search",
           "ZoneAwarenessEnabled": false,
-        },
-        "CognitoOptions": Object {
-          "Enabled": false,
         },
         "DomainEndpointOptions": Object {
           "EnforceHTTPS": false,
@@ -791,9 +773,6 @@ Object {
           "InstanceType": "r5.large.search",
           "ZoneAwarenessEnabled": false,
         },
-        "CognitoOptions": Object {
-          "Enabled": false,
-        },
         "DomainEndpointOptions": Object {
           "EnforceHTTPS": false,
           "TLSSecurityPolicy": "Policy-Min-TLS-1-0-2019-07",
@@ -911,9 +890,6 @@ Object {
           "InstanceCount": 1,
           "InstanceType": "r5.large.search",
           "ZoneAwarenessEnabled": false,
-        },
-        "CognitoOptions": Object {
-          "Enabled": false,
         },
         "DomainEndpointOptions": Object {
           "EnforceHTTPS": false,

--- a/test/monitoring/aws-step-functions/__snapshots__/StepFunctionMonitoring.test.ts.snap
+++ b/test/monitoring/aws-step-functions/__snapshots__/StepFunctionMonitoring.test.ts.snap
@@ -22,6 +22,9 @@ Object {
       "ap-south-1": Object {
         "states": "states.ap-south-1.amazonaws.com",
       },
+      "ap-south-2": Object {
+        "states": "states.ap-south-2.amazonaws.com",
+      },
       "ap-southeast-1": Object {
         "states": "states.ap-southeast-1.amazonaws.com",
       },
@@ -60,6 +63,9 @@ Object {
       },
       "eu-west-3": Object {
         "states": "states.eu-west-3.amazonaws.com",
+      },
+      "me-central-1": Object {
+        "states": "states.me-central-1.amazonaws.com",
       },
       "me-south-1": Object {
         "states": "states.me-south-1.amazonaws.com",
@@ -763,6 +769,9 @@ Object {
       "ap-south-1": Object {
         "states": "states.ap-south-1.amazonaws.com",
       },
+      "ap-south-2": Object {
+        "states": "states.ap-south-2.amazonaws.com",
+      },
       "ap-southeast-1": Object {
         "states": "states.ap-southeast-1.amazonaws.com",
       },
@@ -801,6 +810,9 @@ Object {
       },
       "eu-west-3": Object {
         "states": "states.eu-west-3.amazonaws.com",
+      },
+      "me-central-1": Object {
+        "states": "states.me-central-1.amazonaws.com",
       },
       "me-south-1": Object {
         "states": "states.me-south-1.amazonaws.com",
@@ -1504,6 +1516,9 @@ Object {
       "ap-south-1": Object {
         "states": "states.ap-south-1.amazonaws.com",
       },
+      "ap-south-2": Object {
+        "states": "states.ap-south-2.amazonaws.com",
+      },
       "ap-southeast-1": Object {
         "states": "states.ap-southeast-1.amazonaws.com",
       },
@@ -1542,6 +1557,9 @@ Object {
       },
       "eu-west-3": Object {
         "states": "states.eu-west-3.amazonaws.com",
+      },
+      "me-central-1": Object {
+        "states": "states.me-central-1.amazonaws.com",
       },
       "me-south-1": Object {
         "states": "states.me-south-1.amazonaws.com",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,25 +10,35 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@aws-cdk/aws-apigatewayv2-alpha@2.18.0-alpha.0":
-  version "2.18.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigatewayv2-alpha/-/aws-apigatewayv2-alpha-2.18.0-alpha.0.tgz#fd7de4c1413a0a3eb82a9bbf805b0d31c36c6a40"
-  integrity sha512-vmcO8TJB4Li6IQ8kqu2Y+UUMqmKOtiJ0ZLwew4TXN6hN/EG4zBRC9flddcYPQzI1KTwf784G9l3jwfXdQKm1PA==
+"@aws-cdk/asset-awscli-v1@^2.2.49":
+  version "2.2.49"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.49.tgz#af7618a3a39bf103f82d7aa396efa50e6ae79092"
+  integrity sha512-Qd5bdLlC/sphWQQPNn7etKXWCh+fij7DWxtkIwvhhZ+LM6UEApGLS8sBLBQcRO2ZQdEuNb+zeClUy+3DNojfeg==
 
-"@aws-cdk/aws-appsync-alpha@2.18.0-alpha.0":
-  version "2.18.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-appsync-alpha/-/aws-appsync-alpha-2.18.0-alpha.0.tgz#39b6db31fab1fc30a04080bb34a24b8af4e924d0"
-  integrity sha512-vVbFb4uNeVzLdjTmp/r0FGb+U/v9595Coh8A0q5Q0P9X6bR+QpsMpqJx5ZCcBH04h5043PGjiGmCw9p42yaLRg==
+"@aws-cdk/asset-kubectl-v20@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.1.tgz#d01c1efb867fb7f2cfd8c8b230b8eae16447e156"
+  integrity sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw==
 
-"@aws-cdk/aws-redshift-alpha@2.18.0-alpha.0":
-  version "2.18.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-redshift-alpha/-/aws-redshift-alpha-2.18.0-alpha.0.tgz#07b19610b372ecdcf917990f0570a1c8df6fa521"
-  integrity sha512-QxpmvWE9fvXf3tLNNzfiFoYKFXc2nd535t3QsqVYUzAmmAn1wv0/4wNescnlcdBLO2ACbpgBjpYFuVlYBSNGzA==
+"@aws-cdk/asset-node-proxy-agent-v5@^2.0.38":
+  version "2.0.38"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.38.tgz#6765bef55f95220c52decb4adba8f75c1817b0f7"
+  integrity sha512-BBwAjORhuUkTGO3CxGS5Evcp5n20h9v06Sftn2R1DuSm8zIoUlPsNlI1HUk8XqYuoEI4aD7IKRQBLglv09ciJQ==
 
-"@aws-cdk/aws-synthetics-alpha@2.18.0-alpha.0":
-  version "2.18.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-synthetics-alpha/-/aws-synthetics-alpha-2.18.0-alpha.0.tgz#071dd8633ff197537685c7d85c0805c2ed6373a2"
-  integrity sha512-84WPwuO+gEfRY+EcTLrCSnUao2RCA7ad7nevLTaO1MSGI2Qqg66ryvPxwLVZbAAyJvZbgF4V8UeJzEwQVFSjxA==
+"@aws-cdk/aws-apigatewayv2-alpha@2.60.0-alpha.0":
+  version "2.60.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigatewayv2-alpha/-/aws-apigatewayv2-alpha-2.60.0-alpha.0.tgz#36303d7d84f122a9031c9f875a82031042cb0981"
+  integrity sha512-Igk5Gaj+XvP0osNcWEgIFsM7FRheZokNQQl+4FM66YRQ3qh1eWkhuzh1Zqkhc/U3prEI+sSV6YD0/ZIqLL1Tig==
+
+"@aws-cdk/aws-redshift-alpha@2.60.0-alpha.0":
+  version "2.60.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-redshift-alpha/-/aws-redshift-alpha-2.60.0-alpha.0.tgz#f9bcd66c28c696c17158068b4f30b1cc3b75ec12"
+  integrity sha512-U/xZ6P04JKEJOxcnBVPgopflIQsh1x5uwi/UJmxH56JnV/b3OwWa2SqhChQVAc0vXALwf5Q64o5glX3ggrYyYw==
+
+"@aws-cdk/aws-synthetics-alpha@2.60.0-alpha.0":
+  version "2.60.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-synthetics-alpha/-/aws-synthetics-alpha-2.60.0-alpha.0.tgz#99484c9e09020fb9973ac9538b85514286662c0a"
+  integrity sha512-C7AI/IUaLeJbN9Bep/WQyG+C9LENOuALIcBHe108lUJtgLpPKMf12P2mFYQkthY3ZVem+SvDl1uVF5lDnPhSZg==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.18.6":
   version "7.18.6"
@@ -1247,19 +1257,22 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-cdk-lib@2.18.0:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.18.0.tgz#a130edf9d90ec166d5c0f14d275ab49cbbe75261"
-  integrity sha512-4XpEqRgKSzDmcpeNGRqRlnWEltnt5+NoHWKpQDHUsAmyJ2QNQ5dYxVLIReaGiE9H8zS0rlpp3exuDEy0UgKj2Q==
+aws-cdk-lib@2.60.0:
+  version "2.60.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.60.0.tgz#e96400640aca6cf326bd01b02866a157110e6432"
+  integrity sha512-AttvwGmS1TDiOgkskrRw4lQoDwoyzjb+M0iMzHEa75xDz7hkykudNVEvWOfcbid+rzkgfLQyElwtf/oz6m+O9A==
   dependencies:
+    "@aws-cdk/asset-awscli-v1" "^2.2.49"
+    "@aws-cdk/asset-kubectl-v20" "^2.1.1"
+    "@aws-cdk/asset-node-proxy-agent-v5" "^2.0.38"
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
     fs-extra "^9.1.0"
-    ignore "^5.2.0"
-    jsonschema "^1.4.0"
+    ignore "^5.2.4"
+    jsonschema "^1.4.1"
     minimatch "^3.1.2"
     punycode "^2.1.1"
-    semver "^7.3.5"
+    semver "^7.3.8"
     yaml "1.10.2"
 
 babel-jest@^27.5.1:
@@ -3108,7 +3121,7 @@ ignore-walk@^6.0.0:
   dependencies:
     minimatch "^5.0.1"
 
-ignore@^5.2.0:
+ignore@^5.2.0, ignore@^5.2.4:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
@@ -4124,7 +4137,7 @@ jsonparse@^1.2.0, jsonparse@^1.3.1:
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==
 
-jsonschema@^1.4.0:
+jsonschema@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.1.tgz#cc4c3f0077fb4542982973d8a083b6b34f482dab"
   integrity sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==


### PR DESCRIPTION
BREAKING CHANGE: requires aws-cdk-lib@^2.60.0

The AppSync module was promoted to stable in https://github.com/aws/aws-cdk/releases/tag/v2.60.0. The peer dependency change is a breaking change, so this bumps this library up to v2.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_