### PR TITLE
fix(glue): fix incorrect duplicate metric ID

### DIFF
--- a/lib/monitoring/aws-glue/GlueJobMetricFactory.ts
+++ b/lib/monitoring/aws-glue/GlueJobMetricFactory.ts
@@ -134,7 +134,7 @@ export class GlueJobMetricFactory {
       this.metricFailedTasksSum(),
       this.rateComputationMethod,
       true,
-      "killed",
+      "failed",
       false
     );
   }


### PR DESCRIPTION
Fixes the following error:

```
Error: Resolution error: Resolution error: Resolution error: Cannot have two different metrics share the same id ('killed') in one Alarm or Graph. Rename one of them..
```

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_