### PR TITLE
feat(cloudwatch): add addMinIncomingLogsAlarm

### DIFF
--- a/API.md
+++ b/API.md
@@ -8825,6 +8825,36 @@ public readonly addLowTpsAlarm: {[ key: string ]: LowTpsThreshold};
 
 ---
 
+### CloudWatchLogsMetricFactoryProps <a name="CloudWatchLogsMetricFactoryProps" id="cdk-monitoring-constructs.CloudWatchLogsMetricFactoryProps"></a>
+
+#### Initializer <a name="Initializer" id="cdk-monitoring-constructs.CloudWatchLogsMetricFactoryProps.Initializer"></a>
+
+```typescript
+import { CloudWatchLogsMetricFactoryProps } from 'cdk-monitoring-constructs'
+
+const cloudWatchLogsMetricFactoryProps: CloudWatchLogsMetricFactoryProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#cdk-monitoring-constructs.CloudWatchLogsMetricFactoryProps.property.logGroupName">logGroupName</a></code> | <code>string</code> | Name of the log group to monitor. |
+
+---
+
+##### `logGroupName`<sup>Required</sup> <a name="logGroupName" id="cdk-monitoring-constructs.CloudWatchLogsMetricFactoryProps.property.logGroupName"></a>
+
+```typescript
+public readonly logGroupName: string;
+```
+
+- *Type:* string
+
+Name of the log group to monitor.
+
+---
+
 ### CodeBuildProjectMetricFactoryProps <a name="CodeBuildProjectMetricFactoryProps" id="cdk-monitoring-constructs.CodeBuildProjectMetricFactoryProps"></a>
 
 #### Initializer <a name="Initializer" id="cdk-monitoring-constructs.CodeBuildProjectMetricFactoryProps.Initializer"></a>
@@ -20898,10 +20928,11 @@ const logMonitoringProps: LogMonitoringProps = { ... }
 | <code><a href="#cdk-monitoring-constructs.LogMonitoringProps.property.addToDetailDashboard">addToDetailDashboard</a></code> | <code>boolean</code> | Flag indicating if the widgets should be added to detailed dashboard. |
 | <code><a href="#cdk-monitoring-constructs.LogMonitoringProps.property.addToSummaryDashboard">addToSummaryDashboard</a></code> | <code>boolean</code> | Flag indicating if the widgets should be added to summary dashboard. |
 | <code><a href="#cdk-monitoring-constructs.LogMonitoringProps.property.useCreatedAlarms">useCreatedAlarms</a></code> | <code><a href="#cdk-monitoring-constructs.IAlarmConsumer">IAlarmConsumer</a></code> | Calls provided function to process all alarms created. |
-| <code><a href="#cdk-monitoring-constructs.LogMonitoringProps.property.logGroupName">logGroupName</a></code> | <code>string</code> | name of the log group to analyze for the given pattern. |
-| <code><a href="#cdk-monitoring-constructs.LogMonitoringProps.property.pattern">pattern</a></code> | <code>string</code> | pattern to show, e.g. "ERROR". |
-| <code><a href="#cdk-monitoring-constructs.LogMonitoringProps.property.limit">limit</a></code> | <code>number</code> | number of log messages to search for. |
-| <code><a href="#cdk-monitoring-constructs.LogMonitoringProps.property.title">title</a></code> | <code>string</code> | widget title. |
+| <code><a href="#cdk-monitoring-constructs.LogMonitoringProps.property.logGroupName">logGroupName</a></code> | <code>string</code> | Name of the log group to monitor. |
+| <code><a href="#cdk-monitoring-constructs.LogMonitoringProps.property.addMinIncomingLogsAlarm">addMinIncomingLogsAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.MinUsageCountThreshold">MinUsageCountThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LogMonitoringProps.property.limit">limit</a></code> | <code>number</code> | Maximum number of log messages to search for. |
+| <code><a href="#cdk-monitoring-constructs.LogMonitoringProps.property.pattern">pattern</a></code> | <code>string</code> | Pattern to search for, e.g. "ERROR". |
+| <code><a href="#cdk-monitoring-constructs.LogMonitoringProps.property.title">title</a></code> | <code>string</code> | Widget title. |
 
 ---
 
@@ -21011,19 +21042,17 @@ public readonly logGroupName: string;
 
 - *Type:* string
 
-name of the log group to analyze for the given pattern.
+Name of the log group to monitor.
 
 ---
 
-##### `pattern`<sup>Required</sup> <a name="pattern" id="cdk-monitoring-constructs.LogMonitoringProps.property.pattern"></a>
+##### `addMinIncomingLogsAlarm`<sup>Optional</sup> <a name="addMinIncomingLogsAlarm" id="cdk-monitoring-constructs.LogMonitoringProps.property.addMinIncomingLogsAlarm"></a>
 
 ```typescript
-public readonly pattern: string;
+public readonly addMinIncomingLogsAlarm: {[ key: string ]: MinUsageCountThreshold};
 ```
 
-- *Type:* string
-
-pattern to show, e.g. "ERROR".
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.MinUsageCountThreshold">MinUsageCountThreshold</a>}
 
 ---
 
@@ -21036,7 +21065,19 @@ public readonly limit: number;
 - *Type:* number
 - *Default:* 10
 
-number of log messages to search for.
+Maximum number of log messages to search for.
+
+---
+
+##### `pattern`<sup>Optional</sup> <a name="pattern" id="cdk-monitoring-constructs.LogMonitoringProps.property.pattern"></a>
+
+```typescript
+public readonly pattern: string;
+```
+
+- *Type:* string
+
+Pattern to search for, e.g. "ERROR".
 
 ---
 
@@ -21049,7 +21090,7 @@ public readonly title: string;
 - *Type:* string
 - *Default:* auto-generated title based on the pattern and limit
 
-widget title.
+Widget title.
 
 ---
 
@@ -42005,6 +42046,52 @@ public readonly distributionUrl: string;
 ---
 
 
+### CloudWatchLogsMetricFactory <a name="CloudWatchLogsMetricFactory" id="cdk-monitoring-constructs.CloudWatchLogsMetricFactory"></a>
+
+#### Initializers <a name="Initializers" id="cdk-monitoring-constructs.CloudWatchLogsMetricFactory.Initializer"></a>
+
+```typescript
+import { CloudWatchLogsMetricFactory } from 'cdk-monitoring-constructs'
+
+new CloudWatchLogsMetricFactory(metricFactory: MetricFactory, props: CloudWatchLogsMetricFactoryProps)
+```
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#cdk-monitoring-constructs.CloudWatchLogsMetricFactory.Initializer.parameter.metricFactory">metricFactory</a></code> | <code><a href="#cdk-monitoring-constructs.MetricFactory">MetricFactory</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.CloudWatchLogsMetricFactory.Initializer.parameter.props">props</a></code> | <code><a href="#cdk-monitoring-constructs.CloudWatchLogsMetricFactoryProps">CloudWatchLogsMetricFactoryProps</a></code> | *No description.* |
+
+---
+
+##### `metricFactory`<sup>Required</sup> <a name="metricFactory" id="cdk-monitoring-constructs.CloudWatchLogsMetricFactory.Initializer.parameter.metricFactory"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.MetricFactory">MetricFactory</a>
+
+---
+
+##### `props`<sup>Required</sup> <a name="props" id="cdk-monitoring-constructs.CloudWatchLogsMetricFactory.Initializer.parameter.props"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.CloudWatchLogsMetricFactoryProps">CloudWatchLogsMetricFactoryProps</a>
+
+---
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#cdk-monitoring-constructs.CloudWatchLogsMetricFactory.metricIncomingLogEvents">metricIncomingLogEvents</a></code> | *No description.* |
+
+---
+
+##### `metricIncomingLogEvents` <a name="metricIncomingLogEvents" id="cdk-monitoring-constructs.CloudWatchLogsMetricFactory.metricIncomingLogEvents"></a>
+
+```typescript
+public metricIncomingLogEvents(): Metric | MathExpression
+```
+
+
+
+
 ### CodeBuildProjectMetricFactory <a name="CodeBuildProjectMetricFactory" id="cdk-monitoring-constructs.CodeBuildProjectMetricFactory"></a>
 
 #### Initializers <a name="Initializers" id="cdk-monitoring-constructs.CodeBuildProjectMetricFactory.Initializer"></a>
@@ -50907,6 +50994,8 @@ new LogMonitoring(scope: MonitoringScope, props: LogMonitoringProps)
 | <code><a href="#cdk-monitoring-constructs.LogMonitoring.createWidgetFactory">createWidgetFactory</a></code> | Creates a new widget factory. |
 | <code><a href="#cdk-monitoring-constructs.LogMonitoring.summaryWidgets">summaryWidgets</a></code> | Returns widgets to be placed on the summary dashboard. |
 | <code><a href="#cdk-monitoring-constructs.LogMonitoring.widgets">widgets</a></code> | Returns widgets to be placed on the main dashboard. |
+| <code><a href="#cdk-monitoring-constructs.LogMonitoring.createIncomingLogsWidget">createIncomingLogsWidget</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LogMonitoring.createTitleWidget">createTitleWidget</a></code> | *No description.* |
 
 ---
 
@@ -50994,16 +51083,64 @@ public widgets(): IWidget[]
 
 Returns widgets to be placed on the main dashboard.
 
+##### `createIncomingLogsWidget` <a name="createIncomingLogsWidget" id="cdk-monitoring-constructs.LogMonitoring.createIncomingLogsWidget"></a>
+
+```typescript
+public createIncomingLogsWidget(width: number, height: number): GraphWidget
+```
+
+###### `width`<sup>Required</sup> <a name="width" id="cdk-monitoring-constructs.LogMonitoring.createIncomingLogsWidget.parameter.width"></a>
+
+- *Type:* number
+
+---
+
+###### `height`<sup>Required</sup> <a name="height" id="cdk-monitoring-constructs.LogMonitoring.createIncomingLogsWidget.parameter.height"></a>
+
+- *Type:* number
+
+---
+
+##### `createTitleWidget` <a name="createTitleWidget" id="cdk-monitoring-constructs.LogMonitoring.createTitleWidget"></a>
+
+```typescript
+public createTitleWidget(): MonitoringHeaderWidget
+```
+
 
 #### Properties <a name="Properties" id="Properties"></a>
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#cdk-monitoring-constructs.LogMonitoring.property.alarmFactory">alarmFactory</a></code> | <code><a href="#cdk-monitoring-constructs.AlarmFactory">AlarmFactory</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LogMonitoring.property.incomingLogEventsMetric">incomingLogEventsMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LogMonitoring.property.limit">limit</a></code> | <code>number</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LogMonitoring.property.logGroupName">logGroupName</a></code> | <code>string</code> | *No description.* |
-| <code><a href="#cdk-monitoring-constructs.LogMonitoring.property.pattern">pattern</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LogMonitoring.property.usageAlarmFactory">usageAlarmFactory</a></code> | <code><a href="#cdk-monitoring-constructs.UsageAlarmFactory">UsageAlarmFactory</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LogMonitoring.property.usageAnnotations">usageAnnotations</a></code> | <code>aws-cdk-lib.aws_cloudwatch.HorizontalAnnotation[]</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LogMonitoring.property.logGroupUrl">logGroupUrl</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LogMonitoring.property.pattern">pattern</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LogMonitoring.property.title">title</a></code> | <code>string</code> | *No description.* |
+
+---
+
+##### `alarmFactory`<sup>Required</sup> <a name="alarmFactory" id="cdk-monitoring-constructs.LogMonitoring.property.alarmFactory"></a>
+
+```typescript
+public readonly alarmFactory: AlarmFactory;
+```
+
+- *Type:* <a href="#cdk-monitoring-constructs.AlarmFactory">AlarmFactory</a>
+
+---
+
+##### `incomingLogEventsMetric`<sup>Required</sup> <a name="incomingLogEventsMetric" id="cdk-monitoring-constructs.LogMonitoring.property.incomingLogEventsMetric"></a>
+
+```typescript
+public readonly incomingLogEventsMetric: Metric | MathExpression;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.Metric | aws-cdk-lib.aws_cloudwatch.MathExpression
 
 ---
 
@@ -51027,13 +51164,23 @@ public readonly logGroupName: string;
 
 ---
 
-##### `pattern`<sup>Required</sup> <a name="pattern" id="cdk-monitoring-constructs.LogMonitoring.property.pattern"></a>
+##### `usageAlarmFactory`<sup>Required</sup> <a name="usageAlarmFactory" id="cdk-monitoring-constructs.LogMonitoring.property.usageAlarmFactory"></a>
 
 ```typescript
-public readonly pattern: string;
+public readonly usageAlarmFactory: UsageAlarmFactory;
 ```
 
-- *Type:* string
+- *Type:* <a href="#cdk-monitoring-constructs.UsageAlarmFactory">UsageAlarmFactory</a>
+
+---
+
+##### `usageAnnotations`<sup>Required</sup> <a name="usageAnnotations" id="cdk-monitoring-constructs.LogMonitoring.property.usageAnnotations"></a>
+
+```typescript
+public readonly usageAnnotations: HorizontalAnnotation[];
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.HorizontalAnnotation[]
 
 ---
 
@@ -51041,6 +51188,16 @@ public readonly pattern: string;
 
 ```typescript
 public readonly logGroupUrl: string;
+```
+
+- *Type:* string
+
+---
+
+##### `pattern`<sup>Optional</sup> <a name="pattern" id="cdk-monitoring-constructs.LogMonitoring.property.pattern"></a>
+
+```typescript
+public readonly pattern: string;
 ```
 
 - *Type:* string

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You can browse the documentation at https://constructs.dev/packages/cdk-monitori
 | AWS Billing (`.monitorBilling()`) | AWS account cost | Total cost (anomaly) | [Requires enabling](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/gs_monitor_estimated_charges_with_cloudwatch.html#gs_turning_on_billing_metrics) the **Receive Billing Alerts** option in AWS Console / Billing Preferences |
 | AWS Certificate Manager (`.monitorCertificate()`) | Certificate expiration | Days until expiration | |
 | AWS CloudFront (`.monitorCloudFrontDistribution()`) | TPS, traffic, latency, errors | Error rate, low/high TPS | |
-| AWS CloudWatch Logs (`.monitorLog()`) | Patterns present in the log group | | |
+| AWS CloudWatch Logs (`.monitorLog()`) | Patterns present in the log group | Minimum incoming logs | |
 | AWS CloudWatch Synthetics Canary (`.monitorSyntheticsCanary()`) | Latency, error count/rate | Error count/rate, latency | |
 | AWS CodeBuild (`.monitorCodeBuildProject()`) | Build counts (total, successful, failed), failed rate, duration | Failed build count/rate, duration | |
 | AWS DocumentDB (`.monitorDocumentDbCluster()`) | CPU, throttling, read/write latency, transactions, cursors | CPU | |

--- a/lib/monitoring/aws-cloudwatch/CloudWatchLogsMetricFactory.ts
+++ b/lib/monitoring/aws-cloudwatch/CloudWatchLogsMetricFactory.ts
@@ -1,0 +1,38 @@
+import { DimensionsMap } from "aws-cdk-lib/aws-cloudwatch";
+
+import { MetricFactory, MetricStatistic } from "../../common";
+
+const CloudWatchLogsNamespace = "AWS/Logs";
+
+export interface CloudWatchLogsMetricFactoryProps {
+  /**
+   * Name of the log group to monitor.
+   */
+  readonly logGroupName: string;
+}
+
+export class CloudWatchLogsMetricFactory {
+  private readonly metricFactory: MetricFactory;
+  private readonly dimensionsMap: DimensionsMap;
+
+  constructor(
+    metricFactory: MetricFactory,
+    props: CloudWatchLogsMetricFactoryProps
+  ) {
+    this.metricFactory = metricFactory;
+    this.dimensionsMap = {
+      LogGroupName: props.logGroupName,
+    };
+  }
+
+  metricIncomingLogEvents() {
+    return this.metricFactory.createMetric(
+      "IncomingLogEvents",
+      MetricStatistic.N,
+      "Logs",
+      this.dimensionsMap,
+      undefined,
+      CloudWatchLogsNamespace
+    );
+  }
+}

--- a/lib/monitoring/aws-cloudwatch/LogMonitoring.ts
+++ b/lib/monitoring/aws-cloudwatch/LogMonitoring.ts
@@ -1,88 +1,182 @@
-import { IWidget, LogQueryWidget } from "aws-cdk-lib/aws-cloudwatch";
+import {
+  GraphWidget,
+  HorizontalAnnotation,
+  IWidget,
+  LogQueryWidget,
+} from "aws-cdk-lib/aws-cloudwatch";
 
 import {
+  CloudWatchLogsMetricFactory,
+  CloudWatchLogsMetricFactoryProps,
+} from "./CloudWatchLogsMetricFactory";
+import {
+  AlarmFactory,
   BaseMonitoringProps,
+  CountAxisFromZero,
+  DefaultGraphWidgetHeight,
   DefaultLogWidgetHeight,
+  DefaultSummaryWidgetHeight,
   FullWidth,
+  MetricWithAlarmSupport,
+  MinUsageCountThreshold,
   Monitoring,
   MonitoringScope,
+  QuarterWidth,
+  ThreeQuartersWidth,
+  UsageAlarmFactory,
 } from "../../common";
-import { MonitoringHeaderWidget } from "../../dashboard";
+import {
+  MonitoringHeaderWidget,
+  MonitoringNamingStrategy,
+} from "../../dashboard";
 
 const DefaultLimit = 10;
 
-export interface LogMonitoringProps extends BaseMonitoringProps {
+export interface LogMonitoringProps
+  extends BaseMonitoringProps,
+    CloudWatchLogsMetricFactoryProps {
   /**
-   * name of the log group to analyze for the given pattern
-   */
-  readonly logGroupName: string;
-
-  /**
-   * pattern to show, e.g. "ERROR"
-   */
-  readonly pattern: string;
-
-  /**
-   * widget title
+   * Widget title
    *
    * @default - auto-generated title based on the pattern and limit
    */
   readonly title?: string;
 
   /**
-   * number of log messages to search for
+   * Pattern to search for, e.g. "ERROR"
+   */
+  readonly pattern?: string;
+
+  /**
+   * Maximum number of log messages to search for.
    *
    * @default - 10
    */
   readonly limit?: number;
+
+  readonly addMinIncomingLogsAlarm?: Record<string, MinUsageCountThreshold>;
 }
 
 /**
  * Monitors a CloudWatch log group for various patterns.
  */
 export class LogMonitoring extends Monitoring {
-  readonly pattern: string;
   readonly logGroupName: string;
   readonly logGroupUrl?: string;
+
   readonly title?: string;
+
+  readonly pattern?: string;
   readonly limit: number;
+
+  readonly alarmFactory: AlarmFactory;
+  readonly usageAlarmFactory: UsageAlarmFactory;
+  readonly incomingLogEventsMetric: MetricWithAlarmSupport;
+
+  readonly usageAnnotations: HorizontalAnnotation[];
 
   constructor(scope: MonitoringScope, props: LogMonitoringProps) {
     super(scope);
 
-    this.pattern = props.pattern;
-    this.title = props.title;
-    this.limit = props.limit ?? DefaultLimit;
     this.logGroupName = props.logGroupName;
     this.logGroupUrl = scope
       .createAwsConsoleUrlFactory()
       .getCloudWatchLogGroupUrl(props.logGroupName);
+
+    this.title = props.title;
+
+    this.pattern = props.pattern;
+    this.limit = props.limit ?? DefaultLimit;
+
+    const namingStrategy = new MonitoringNamingStrategy({
+      ...props,
+      fallbackConstructName: this.logGroupName,
+    });
+    this.alarmFactory = this.createAlarmFactory(
+      namingStrategy.resolveAlarmFriendlyName()
+    );
+    this.usageAlarmFactory = new UsageAlarmFactory(this.alarmFactory);
+
+    this.usageAnnotations = [];
+
+    const metricFactory = new CloudWatchLogsMetricFactory(
+      scope.createMetricFactory(),
+      props
+    );
+    this.incomingLogEventsMetric = metricFactory.metricIncomingLogEvents();
+
+    for (const disambiguator in props.addMinIncomingLogsAlarm) {
+      const alarmProps = props.addMinIncomingLogsAlarm[disambiguator];
+      const createdAlarm = this.usageAlarmFactory.addMinUsageCountAlarm(
+        this.incomingLogEventsMetric,
+        alarmProps,
+        disambiguator
+      );
+      this.usageAnnotations.push(createdAlarm.annotation);
+      this.addAlarm(createdAlarm);
+    }
+
+    props.useCreatedAlarms?.consume(this.createdAlarms());
+  }
+
+  summaryWidgets(): IWidget[] {
+    return [
+      this.createTitleWidget(),
+      this.createIncomingLogsWidget(FullWidth, DefaultSummaryWidgetHeight),
+    ];
   }
 
   widgets(): IWidget[] {
-    return [
-      new MonitoringHeaderWidget({
-        family: "Log Group",
-        title: this.logGroupName,
-        goToLinkUrl: this.logGroupUrl,
-      }),
-      // Log Query Results
-      new LogQueryWidget({
-        logGroupNames: [this.logGroupName],
-        height: this.resolveRecommendedHeight(this.limit),
-        width: FullWidth,
-        title: this.title ?? `Find ${this.pattern} (limit = ${this.limit})`,
-        /**
-         * https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax.html
-         */
-        queryLines: [
-          "fields @timestamp, @logStream, @message",
-          `filter @message like /${this.pattern}/`,
-          "sort @timestamp desc",
-          `limit ${this.limit}`,
-        ],
-      }),
-    ];
+    if (this.pattern) {
+      const height = this.resolveRecommendedHeight(this.limit);
+
+      return [
+        this.createTitleWidget(),
+
+        // Log Query Results
+        new LogQueryWidget({
+          logGroupNames: [this.logGroupName],
+          height,
+          width: ThreeQuartersWidth,
+          title: this.title ?? `Find ${this.pattern} (limit = ${this.limit})`,
+          /**
+           * https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax.html
+           */
+          queryLines: [
+            "fields @timestamp, @logStream, @message",
+            `filter @message like /${this.pattern}/`,
+            "sort @timestamp desc",
+            `limit ${this.limit}`,
+          ],
+        }),
+
+        this.createIncomingLogsWidget(QuarterWidth, height),
+      ];
+    } else {
+      return [
+        this.createTitleWidget(),
+        this.createIncomingLogsWidget(FullWidth, DefaultGraphWidgetHeight),
+      ];
+    }
+  }
+
+  createTitleWidget() {
+    return new MonitoringHeaderWidget({
+      family: "Log Group",
+      title: this.logGroupName,
+      goToLinkUrl: this.logGroupUrl,
+    });
+  }
+
+  createIncomingLogsWidget(width: number, height: number) {
+    return new GraphWidget({
+      width,
+      height,
+      title: "Incoming logs",
+      left: [this.incomingLogEventsMetric],
+      leftYAxis: CountAxisFromZero,
+      leftAnnotations: this.usageAnnotations,
+    });
   }
 
   protected resolveRecommendedHeight(numRows: number) {

--- a/lib/monitoring/aws-cloudwatch/index.ts
+++ b/lib/monitoring/aws-cloudwatch/index.ts
@@ -1,1 +1,2 @@
+export * from "./CloudWatchLogsMetricFactory";
 export * from "./LogMonitoring";

--- a/test/monitoring/aws-cloudwatch/LogMonitoring.test.ts
+++ b/test/monitoring/aws-cloudwatch/LogMonitoring.test.ts
@@ -1,5 +1,6 @@
 import { Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
+import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
 
 import { LogMonitoring } from "../../../lib";
 import { addMonitoringDashboardsToStack } from "../../utils/SnapshotUtil";
@@ -11,8 +12,8 @@ test("snapshot test", () => {
   const scope = new TestMonitoringScope(stack, "Scope");
 
   const monitoring = new LogMonitoring(scope, {
-    pattern: "DummyPattern",
     logGroupName: "DummyLogGroup",
+    pattern: "DummyPattern",
     title: "DummyTitle",
   });
 
@@ -26,11 +27,52 @@ test("snapshot test: custom limit", () => {
   const scope = new TestMonitoringScope(stack, "Scope");
 
   const monitoring = new LogMonitoring(scope, {
-    pattern: "DummyPattern",
     logGroupName: "DummyLogGroup",
+    pattern: "DummyPattern",
     limit: 500,
   });
 
   addMonitoringDashboardsToStack(stack, monitoring);
+  expect(Template.fromStack(stack)).toMatchSnapshot();
+});
+
+test("snapshot test: no pattern", () => {
+  const stack = new Stack();
+
+  const scope = new TestMonitoringScope(stack, "Scope");
+
+  const monitoring = new LogMonitoring(scope, {
+    logGroupName: "DummyLogGroup",
+  });
+
+  addMonitoringDashboardsToStack(stack, monitoring);
+  expect(Template.fromStack(stack)).toMatchSnapshot();
+});
+
+test("snapshot test: with alarms", () => {
+  const stack = new Stack();
+
+  const scope = new TestMonitoringScope(stack, "Scope");
+
+  let numAlarmsCreated = 0;
+
+  const monitoring = new LogMonitoring(scope, {
+    logGroupName: "DummyLogGroup",
+    pattern: "DummyPattern",
+    addMinIncomingLogsAlarm: {
+      Warning: {
+        minCount: 20,
+        treatMissingDataOverride: TreatMissingData.BREACHING,
+      },
+    },
+    useCreatedAlarms: {
+      consume(alarms) {
+        numAlarmsCreated = alarms.length;
+      },
+    },
+  });
+
+  addMonitoringDashboardsToStack(stack, monitoring);
+  expect(numAlarmsCreated).toStrictEqual(1);
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });

--- a/test/monitoring/aws-cloudwatch/__snapshots__/LogMonitoring.test.ts.snap
+++ b/test/monitoring/aws-cloudwatch/__snapshots__/LogMonitoring.test.ts.snap
@@ -22,11 +22,15 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Log Group **[DummyLogGroup](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/DummyLogGroup)**\\"}},{\\"type\\":\\"log\\",\\"width\\":24,\\"height\\":10,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"table\\",\\"title\\":\\"DummyTitle\\",\\"region\\":\\"",
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Log Group **[DummyLogGroup](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/DummyLogGroup)**\\"}},{\\"type\\":\\"log\\",\\"width\\":18,\\"height\\":10,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"table\\",\\"title\\":\\"DummyTitle\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"query\\":\\"SOURCE 'DummyLogGroup' | fields @timestamp, @logStream, @message\\\\n| filter @message like /DummyPattern/\\\\n| sort @timestamp desc\\\\n| limit 10\\"}}]}",
+              "\\",\\"query\\":\\"SOURCE 'DummyLogGroup' | fields @timestamp, @logStream, @message\\\\n| filter @message like /DummyPattern/\\\\n| sort @timestamp desc\\\\n| limit 10\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":10,\\"x\\":18,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Incoming logs\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Logs\\",\\"IncomingLogEvents\\",\\"LogGroupName\\",\\"DummyLogGroup\\",{\\"label\\":\\"Logs\\",\\"stat\\":\\"SampleCount\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}}]}",
             ],
           ],
         },
@@ -35,7 +39,18 @@ Object {
     },
     "Summary68521F81": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"widgets\\":[]}",
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Log Group **[DummyLogGroup](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/DummyLogGroup)**\\"}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Incoming logs\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Logs\\",\\"IncomingLogEvents\\",\\"LogGroupName\\",\\"DummyLogGroup\\",{\\"label\\":\\"Logs\\",\\"stat\\":\\"SampleCount\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
       },
       "Type": "AWS::CloudWatch::Dashboard",
     },
@@ -92,11 +107,15 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Log Group **[DummyLogGroup](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/DummyLogGroup)**\\"}},{\\"type\\":\\"log\\",\\"width\\":24,\\"height\\":500,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"table\\",\\"title\\":\\"Find DummyPattern (limit = 500)\\",\\"region\\":\\"",
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Log Group **[DummyLogGroup](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/DummyLogGroup)**\\"}},{\\"type\\":\\"log\\",\\"width\\":18,\\"height\\":500,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"table\\",\\"title\\":\\"Find DummyPattern (limit = 500)\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"query\\":\\"SOURCE 'DummyLogGroup' | fields @timestamp, @logStream, @message\\\\n| filter @message like /DummyPattern/\\\\n| sort @timestamp desc\\\\n| limit 500\\"}}]}",
+              "\\",\\"query\\":\\"SOURCE 'DummyLogGroup' | fields @timestamp, @logStream, @message\\\\n| filter @message like /DummyPattern/\\\\n| sort @timestamp desc\\\\n| limit 500\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":500,\\"x\\":18,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Incoming logs\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Logs\\",\\"IncomingLogEvents\\",\\"LogGroupName\\",\\"DummyLogGroup\\",{\\"label\\":\\"Logs\\",\\"stat\\":\\"SampleCount\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}}]}",
             ],
           ],
         },
@@ -105,7 +124,236 @@ Object {
     },
     "Summary68521F81": Object {
       "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Log Group **[DummyLogGroup](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/DummyLogGroup)**\\"}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Incoming logs\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Logs\\",\\"IncomingLogEvents\\",\\"LogGroupName\\",\\"DummyLogGroup\\",{\\"label\\":\\"Logs\\",\\"stat\\":\\"SampleCount\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`snapshot test: no pattern 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "Alarm7103F465": Object {
+      "Properties": Object {
         "DashboardBody": "{\\"widgets\\":[]}",
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "Resource": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Log Group **[DummyLogGroup](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/DummyLogGroup)**\\"}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Incoming logs\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Logs\\",\\"IncomingLogEvents\\",\\"LogGroupName\\",\\"DummyLogGroup\\",{\\"label\\":\\"Logs\\",\\"stat\\":\\"SampleCount\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "Summary68521F81": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Log Group **[DummyLogGroup](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/DummyLogGroup)**\\"}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Incoming logs\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Logs\\",\\"IncomingLogEvents\\",\\"LogGroupName\\",\\"DummyLogGroup\\",{\\"label\\":\\"Logs\\",\\"stat\\":\\"SampleCount\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`snapshot test: with alarms 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "Alarm7103F465": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyLogGroupUsageCountWarningAE5FF03C",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "Resource": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Log Group **[DummyLogGroup](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/DummyLogGroup)**\\"}},{\\"type\\":\\"log\\",\\"width\\":18,\\"height\\":10,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"table\\",\\"title\\":\\"Find DummyPattern (limit = 10)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"query\\":\\"SOURCE 'DummyLogGroup' | fields @timestamp, @logStream, @message\\\\n| filter @message like /DummyPattern/\\\\n| sort @timestamp desc\\\\n| limit 10\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":10,\\"x\\":18,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Incoming logs\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Logs\\",\\"IncomingLogEvents\\",\\"LogGroupName\\",\\"DummyLogGroup\\",{\\"label\\":\\"Logs\\",\\"stat\\":\\"SampleCount\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Logs undefined 20 for 3 datapoints within 15 minutes\\",\\"value\\":20,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "ScopeTestDummyLogGroupUsageCountWarningAE5FF03C": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "The count is too low.",
+        "AlarmName": "Test-DummyLogGroup-Usage-Count-Warning",
+        "ComparisonOperator": "LessThanLowerThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Logs",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "LogGroupName",
+                    "Value": "DummyLogGroup",
+                  },
+                ],
+                "MetricName": "IncomingLogEvents",
+                "Namespace": "AWS/Logs",
+              },
+              "Period": 300,
+              "Stat": "SampleCount",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 20,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "Summary68521F81": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Log Group **[DummyLogGroup](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#logsV2:log-groups/log-group/DummyLogGroup)**\\"}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Incoming logs\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Logs\\",\\"IncomingLogEvents\\",\\"LogGroupName\\",\\"DummyLogGroup\\",{\\"label\\":\\"Logs\\",\\"stat\\":\\"SampleCount\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Logs undefined 20 for 3 datapoints within 15 minutes\\",\\"value\\":20,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
       },
       "Type": "AWS::CloudWatch::Dashboard",
     },


### PR DESCRIPTION
Add ability to alarm on minimum number from `IncomingLogEvents` metric for a given CloudWatch log group. This is useful for detecting issues that would surface as missing incoming logs as a symptom (e.g., improper permissions, service outage/configuration issue, etc.).

All available metrics: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CloudWatch-Logs-Monitoring-CloudWatch-Metrics.html

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_