### PR TITLE
feat: Add region and account parameters as optional global defaults

### DIFF
--- a/API.md
+++ b/API.md
@@ -24429,8 +24429,25 @@ const metricFactoryDefaults: MetricFactoryDefaults = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#cdk-monitoring-constructs.MetricFactoryDefaults.property.account">account</a></code> | <code>string</code> | Account where the metrics exist. |
 | <code><a href="#cdk-monitoring-constructs.MetricFactoryDefaults.property.namespace">namespace</a></code> | <code>string</code> | Each metric exists in a namespace. |
 | <code><a href="#cdk-monitoring-constructs.MetricFactoryDefaults.property.period">period</a></code> | <code>aws-cdk-lib.Duration</code> | Metric period. |
+| <code><a href="#cdk-monitoring-constructs.MetricFactoryDefaults.property.region">region</a></code> | <code>string</code> | Region where the metrics exist. |
+
+---
+
+##### `account`<sup>Optional</sup> <a name="account" id="cdk-monitoring-constructs.MetricFactoryDefaults.property.account"></a>
+
+```typescript
+public readonly account: string;
+```
+
+- *Type:* string
+- *Default:* The account configured by the construct holding the Monitoring construct
+
+Account where the metrics exist.
+
+> [https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Cross-Account-Cross-Region.html](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Cross-Account-Cross-Region.html)
 
 ---
 
@@ -24460,6 +24477,21 @@ public readonly period: Duration;
 Metric period.
 
 Default value is used if not defined.
+
+---
+
+##### `region`<sup>Optional</sup> <a name="region" id="cdk-monitoring-constructs.MetricFactoryDefaults.property.region"></a>
+
+```typescript
+public readonly region: string;
+```
+
+- *Type:* string
+- *Default:* The region configured by the construct holding the Monitoring construct
+
+Region where the metrics exist.
+
+> [https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Cross-Account-Cross-Region.html](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Cross-Account-Cross-Region.html)
 
 ---
 
@@ -51164,7 +51196,7 @@ additional dimensions.
 ##### `createMetric` <a name="createMetric" id="cdk-monitoring-constructs.MetricFactory.createMetric"></a>
 
 ```typescript
-public createMetric(metricName: string, statistic: MetricStatistic, label?: string, dimensionsMap?: {[ key: string ]: string}, color?: string, namespace?: string, period?: Duration): Metric | MathExpression
+public createMetric(metricName: string, statistic: MetricStatistic, label?: string, dimensionsMap?: {[ key: string ]: string}, color?: string, namespace?: string, period?: Duration, region?: string, account?: string): Metric | MathExpression
 ```
 
 Factory method that creates a metric.
@@ -51230,6 +51262,26 @@ if undefined, uses the global default
 - *Type:* aws-cdk-lib.Duration
 
 specify a custom period;
+
+if undefined, uses the global default
+
+---
+
+###### `region`<sup>Optional</sup> <a name="region" id="cdk-monitoring-constructs.MetricFactory.createMetric.parameter.region"></a>
+
+- *Type:* string
+
+specify a custom region;
+
+if undefined, uses the global default
+
+---
+
+###### `account`<sup>Optional</sup> <a name="account" id="cdk-monitoring-constructs.MetricFactory.createMetric.parameter.account"></a>
+
+- *Type:* string
+
+specify a custom account;
 
 if undefined, uses the global default
 

--- a/lib/common/metric/MetricFactory.ts
+++ b/lib/common/metric/MetricFactory.ts
@@ -30,6 +30,21 @@ export interface MetricFactoryDefaults {
    * @default - DefaultMetricPeriod
    */
   readonly period?: Duration;
+
+  /**
+   * Region where the metrics exist.
+   *
+   * @default The region configured by the construct holding the Monitoring construct
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Cross-Account-Cross-Region.html
+   */
+  readonly region?: string;
+  /**
+   * Account where the metrics exist.
+   *
+   * @default The account configured by the construct holding the Monitoring construct
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Cross-Account-Cross-Region.html
+   */
+  readonly account?: string;
 }
 
 export interface MetricFactoryProps {
@@ -56,6 +71,8 @@ export class MetricFactory {
    * @param color metric color; if undefined, uses a CloudWatch provided color (preferred)
    * @param namespace specify a custom namespace; if undefined, uses the global default
    * @param period specify a custom period; if undefined, uses the global default
+   * @param region specify a custom region; if undefined, uses the global default
+   * @param account specify a custom account; if undefined, uses the global default
    */
   createMetric(
     metricName: string,
@@ -64,7 +81,9 @@ export class MetricFactory {
     dimensionsMap?: DimensionsMap,
     color?: string,
     namespace?: string,
-    period?: Duration
+    period?: Duration,
+    region?: string,
+    account?: string
   ): MetricWithAlarmSupport {
     return new Metric({
       statistic,
@@ -76,6 +95,8 @@ export class MetricFactory {
         : undefined,
       namespace: this.getNamespaceWithFallback(namespace),
       period: period ?? this.globalDefaults.period ?? DefaultMetricPeriod,
+      region: region ?? this.globalDefaults.region,
+      account: account ?? this.globalDefaults.account,
     });
   }
 

--- a/test/common/metric/MetricFactory.test.ts
+++ b/test/common/metric/MetricFactory.test.ts
@@ -1,7 +1,9 @@
+import { Duration } from "aws-cdk-lib";
 import { Metric } from "aws-cdk-lib/aws-cloudwatch";
 
 import {
   MetricFactory,
+  MetricFactoryDefaults,
   MetricStatistic,
   RateComputationMethod,
 } from "../../../lib";
@@ -17,6 +19,41 @@ test("createMetric without global namespace throws an error", () => {
       MetricStatistic.P90
     )
   ).toThrowError();
+});
+
+test("snapshot test: global defaults", () => {
+  function testMetric(props: MetricFactoryDefaults) {
+    const metricFactory = new MetricFactory({
+      globalDefaults: {
+        namespace: "DummyNamespace",
+        ...props,
+      },
+    });
+    const metric = metricFactory.createMetric(
+      "DummyMetricName",
+      MetricStatistic.P90
+    );
+    expect(metric).toMatchSnapshot();
+  }
+
+  testMetric({
+    namespace: "SomeNamespace",
+  });
+  testMetric({
+    period: Duration.minutes(15),
+  });
+  testMetric({
+    region: "us-west-2",
+  });
+  testMetric({
+    account: "123456789",
+  });
+  testMetric({
+    namespace: "SomeNamespace",
+    period: Duration.minutes(15),
+    region: "us-west-2",
+    account: "123456789",
+  });
 });
 
 test("snapshot test: createMetric", () => {
@@ -53,7 +90,10 @@ test("snapshot test: createMetric", () => {
       AnotherDummyDimension: undefined as unknown as string,
     },
     DummyColor,
-    "DummyNamespaceOverride"
+    "DummyNamespaceOverride",
+    Duration.minutes(15),
+    "us-west-2",
+    "123456789"
   );
 
   expect(metricWithUndefinedDimensions).toMatchSnapshot();

--- a/test/common/metric/__snapshots__/MetricFactory.test.ts.snap
+++ b/test/common/metric/__snapshots__/MetricFactory.test.ts.snap
@@ -130,21 +130,21 @@ Metric {
 
 exports[`snapshot test: createMetric 3`] = `
 Metric {
-  "account": undefined,
+  "account": "123456789",
   "color": "#abcdef",
   "dimensions": Object {},
   "label": "DummyLabel",
   "metricName": "DummyMetricName-AllOptionalParams",
   "namespace": "DummyNamespaceOverride",
   "period": Duration {
-    "amount": 5,
+    "amount": 15,
     "unit": TimeUnit {
       "inMillis": 60000,
       "isoLabel": "M",
       "label": "minutes",
     },
   },
-  "region": undefined,
+  "region": "us-west-2",
   "statistic": "p90",
   "unit": undefined,
   "warnings": undefined,
@@ -396,6 +396,121 @@ MathExpression {
   "warnings": Array [
     "Math expression 'SEARCH('{DummyNamespaceOverride}  MyMetricPrefix-', 'Sum', 300)' references unknown identifiers: ummyNamespaceOverride, yMetricPrefix, um. Please add them to the 'usingMetrics' map.",
   ],
+}
+`;
+
+exports[`snapshot test: global defaults 1`] = `
+Metric {
+  "account": undefined,
+  "color": undefined,
+  "dimensions": undefined,
+  "label": undefined,
+  "metricName": "DummyMetricName",
+  "namespace": "SomeNamespace",
+  "period": Duration {
+    "amount": 5,
+    "unit": TimeUnit {
+      "inMillis": 60000,
+      "isoLabel": "M",
+      "label": "minutes",
+    },
+  },
+  "region": undefined,
+  "statistic": "p90",
+  "unit": undefined,
+  "warnings": undefined,
+}
+`;
+
+exports[`snapshot test: global defaults 2`] = `
+Metric {
+  "account": undefined,
+  "color": undefined,
+  "dimensions": undefined,
+  "label": undefined,
+  "metricName": "DummyMetricName",
+  "namespace": "DummyNamespace",
+  "period": Duration {
+    "amount": 15,
+    "unit": TimeUnit {
+      "inMillis": 60000,
+      "isoLabel": "M",
+      "label": "minutes",
+    },
+  },
+  "region": undefined,
+  "statistic": "p90",
+  "unit": undefined,
+  "warnings": undefined,
+}
+`;
+
+exports[`snapshot test: global defaults 3`] = `
+Metric {
+  "account": undefined,
+  "color": undefined,
+  "dimensions": undefined,
+  "label": undefined,
+  "metricName": "DummyMetricName",
+  "namespace": "DummyNamespace",
+  "period": Duration {
+    "amount": 5,
+    "unit": TimeUnit {
+      "inMillis": 60000,
+      "isoLabel": "M",
+      "label": "minutes",
+    },
+  },
+  "region": "us-west-2",
+  "statistic": "p90",
+  "unit": undefined,
+  "warnings": undefined,
+}
+`;
+
+exports[`snapshot test: global defaults 4`] = `
+Metric {
+  "account": "123456789",
+  "color": undefined,
+  "dimensions": undefined,
+  "label": undefined,
+  "metricName": "DummyMetricName",
+  "namespace": "DummyNamespace",
+  "period": Duration {
+    "amount": 5,
+    "unit": TimeUnit {
+      "inMillis": 60000,
+      "isoLabel": "M",
+      "label": "minutes",
+    },
+  },
+  "region": undefined,
+  "statistic": "p90",
+  "unit": undefined,
+  "warnings": undefined,
+}
+`;
+
+exports[`snapshot test: global defaults 5`] = `
+Metric {
+  "account": "123456789",
+  "color": undefined,
+  "dimensions": undefined,
+  "label": undefined,
+  "metricName": "DummyMetricName",
+  "namespace": "SomeNamespace",
+  "period": Duration {
+    "amount": 15,
+    "unit": TimeUnit {
+      "inMillis": 60000,
+      "isoLabel": "M",
+      "label": "minutes",
+    },
+  },
+  "region": "us-west-2",
+  "statistic": "p90",
+  "unit": undefined,
+  "warnings": undefined,
 }
 `;
 


### PR DESCRIPTION
This lets me create cross-account and cross-region monitoring. Currently only the current account is supported.

My PR adds these parameters at the *global level* because I didn't want to go through every resource and add these extra parameters. This creates a limitation where an instance of `MonitoringFacade` would refer only to those specific region/accounts.

This is good enough for me though, so please advise if it's not desired.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_