### PR TITLE
feat(alarm): Make AlarmNamingStrategy customizable

### DIFF
--- a/API.md
+++ b/API.md
@@ -2957,6 +2957,7 @@ const alarmFactoryDefaults: AlarmFactoryDefaults = { ... }
 | <code><a href="#cdk-monitoring-constructs.AlarmFactoryDefaults.property.actionsEnabled">actionsEnabled</a></code> | <code>boolean \| {[ key: string ]: boolean}</code> | Enables the configured CloudWatch alarm ticketing actions for either all severities, or per severity. |
 | <code><a href="#cdk-monitoring-constructs.AlarmFactoryDefaults.property.alarmNamePrefix">alarmNamePrefix</a></code> | <code>string</code> | Global prefix for all alarm names. |
 | <code><a href="#cdk-monitoring-constructs.AlarmFactoryDefaults.property.action">action</a></code> | <code><a href="#cdk-monitoring-constructs.IAlarmActionStrategy">IAlarmActionStrategy</a></code> | Default alarm action used for each alarm, unless it is overridden. |
+| <code><a href="#cdk-monitoring-constructs.AlarmFactoryDefaults.property.alarmNamingStrategy">alarmNamingStrategy</a></code> | <code><a href="#cdk-monitoring-constructs.IAlarmNamingStrategy">IAlarmNamingStrategy</a></code> | Custom strategy to name alarms. |
 | <code><a href="#cdk-monitoring-constructs.AlarmFactoryDefaults.property.annotationStrategy">annotationStrategy</a></code> | <code><a href="#cdk-monitoring-constructs.IAlarmAnnotationStrategy">IAlarmAnnotationStrategy</a></code> | Custom strategy to create annotations for alarms. |
 | <code><a href="#cdk-monitoring-constructs.AlarmFactoryDefaults.property.datapointsToAlarm">datapointsToAlarm</a></code> | <code>number</code> | Number of breaches required to transition into an ALARM state. |
 | <code><a href="#cdk-monitoring-constructs.AlarmFactoryDefaults.property.dedupeStringProcessor">dedupeStringProcessor</a></code> | <code><a href="#cdk-monitoring-constructs.IAlarmDedupeStringProcessor">IAlarmDedupeStringProcessor</a></code> | Custom strategy to process dedupe strings of the alarms. |
@@ -3006,6 +3007,19 @@ public readonly action: IAlarmActionStrategy;
 - *Default:* no action.
 
 Default alarm action used for each alarm, unless it is overridden.
+
+---
+
+##### `alarmNamingStrategy`<sup>Optional</sup> <a name="alarmNamingStrategy" id="cdk-monitoring-constructs.AlarmFactoryDefaults.property.alarmNamingStrategy"></a>
+
+```typescript
+public readonly alarmNamingStrategy: IAlarmNamingStrategy;
+```
+
+- *Type:* <a href="#cdk-monitoring-constructs.IAlarmNamingStrategy">IAlarmNamingStrategy</a>
+- *Default:* default behaviour (no change)
+
+Custom strategy to name alarms.
 
 ---
 
@@ -38055,6 +38069,8 @@ Any warnings that are produced as a result of putting together this widget.
 
 ### AlarmNamingStrategy <a name="AlarmNamingStrategy" id="cdk-monitoring-constructs.AlarmNamingStrategy"></a>
 
+- *Implements:* <a href="#cdk-monitoring-constructs.IAlarmNamingStrategy">IAlarmNamingStrategy</a>
+
 #### Initializers <a name="Initializers" id="cdk-monitoring-constructs.AlarmNamingStrategy.Initializer"></a>
 
 ```typescript
@@ -38095,7 +38111,7 @@ new AlarmNamingStrategy(globalPrefix: string, localPrefix: string, dedupeStringS
 | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.AlarmNamingStrategy.getDedupeString">getDedupeString</a></code> | Dedupe string resolved like this: - If "dedupeStringOverride" is defined for an alarm, it will be used as a dedupe string. |
 | <code><a href="#cdk-monitoring-constructs.AlarmNamingStrategy.getName">getName</a></code> | Alarm name is resolved like this: - If "alarmNameOverride" is defined for an alarm, it will be used as alarm name. |
-| <code><a href="#cdk-monitoring-constructs.AlarmNamingStrategy.getWidgetLabel">getWidgetLabel</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.AlarmNamingStrategy.getWidgetLabel">getWidgetLabel</a></code> | How to generate the label for the alarm displayed on a widget. |
 
 ---
 
@@ -38142,6 +38158,8 @@ properties.
 ```typescript
 public getWidgetLabel(props: AlarmNamingInput): string
 ```
+
+How to generate the label for the alarm displayed on a widget.
 
 ###### `props`<sup>Required</sup> <a name="props" id="cdk-monitoring-constructs.AlarmNamingStrategy.getWidgetLabel.parameter.props"></a>
 
@@ -60237,6 +60255,69 @@ Process the dedupe string which was specified by the user as an override.
 ###### `dedupeString`<sup>Required</sup> <a name="dedupeString" id="cdk-monitoring-constructs.IAlarmDedupeStringProcessor.processDedupeStringOverride.parameter.dedupeString"></a>
 
 - *Type:* string
+
+---
+
+
+### IAlarmNamingStrategy <a name="IAlarmNamingStrategy" id="cdk-monitoring-constructs.IAlarmNamingStrategy"></a>
+
+- *Implemented By:* <a href="#cdk-monitoring-constructs.AlarmNamingStrategy">AlarmNamingStrategy</a>, <a href="#cdk-monitoring-constructs.IAlarmNamingStrategy">IAlarmNamingStrategy</a>
+
+Strategy used to name alarms, their widgets, and their dedupe strings.
+
+#### Methods <a name="Methods" id="Methods"></a>
+
+| **Name** | **Description** |
+| --- | --- |
+| <code><a href="#cdk-monitoring-constructs.IAlarmNamingStrategy.getDedupeString">getDedupeString</a></code> | How to generate the deduplication string for an alarm. |
+| <code><a href="#cdk-monitoring-constructs.IAlarmNamingStrategy.getName">getName</a></code> | How to generate the name of an alarm. |
+| <code><a href="#cdk-monitoring-constructs.IAlarmNamingStrategy.getWidgetLabel">getWidgetLabel</a></code> | How to generate the label for the alarm displayed on a widget. |
+
+---
+
+##### `getDedupeString` <a name="getDedupeString" id="cdk-monitoring-constructs.IAlarmNamingStrategy.getDedupeString"></a>
+
+```typescript
+public getDedupeString(props: AlarmNamingInput): string
+```
+
+How to generate the deduplication string for an alarm.
+
+###### `props`<sup>Required</sup> <a name="props" id="cdk-monitoring-constructs.IAlarmNamingStrategy.getDedupeString.parameter.props"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.AlarmNamingInput">AlarmNamingInput</a>
+
+---
+
+##### `getName` <a name="getName" id="cdk-monitoring-constructs.IAlarmNamingStrategy.getName"></a>
+
+```typescript
+public getName(props: AlarmNamingInput): string
+```
+
+How to generate the name of an alarm.
+
+###### `props`<sup>Required</sup> <a name="props" id="cdk-monitoring-constructs.IAlarmNamingStrategy.getName.parameter.props"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.AlarmNamingInput">AlarmNamingInput</a>
+
+AlarmNamingInput.
+
+---
+
+##### `getWidgetLabel` <a name="getWidgetLabel" id="cdk-monitoring-constructs.IAlarmNamingStrategy.getWidgetLabel"></a>
+
+```typescript
+public getWidgetLabel(props: AlarmNamingInput): string
+```
+
+How to generate the label for the alarm displayed on a widget.
+
+###### `props`<sup>Required</sup> <a name="props" id="cdk-monitoring-constructs.IAlarmNamingStrategy.getWidgetLabel.parameter.props"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.AlarmNamingInput">AlarmNamingInput</a>
+
+AlarmNamingInput.
 
 ---
 

--- a/lib/common/alarm/AlarmFactory.ts
+++ b/lib/common/alarm/AlarmFactory.ts
@@ -19,6 +19,7 @@ import {
   IAlarmAnnotationStrategy,
 } from "./IAlarmAnnotationStrategy";
 import { IAlarmDedupeStringProcessor } from "./IAlarmDedupeStringProcessor";
+import { IAlarmNamingStrategy } from "./IAlarmNamingStrategy";
 import { noopAction } from "./NoopAlarmActionStrategy";
 import {
   MetricFactoryDefaults,
@@ -404,6 +405,13 @@ export interface AlarmFactoryDefaults {
   readonly dedupeStringProcessor?: IAlarmDedupeStringProcessor;
 
   /**
+   * Custom strategy to name alarms
+   *
+   * @default - default behaviour (no change)
+   */
+  readonly alarmNamingStrategy?: IAlarmNamingStrategy;
+
+  /**
    * Number of breaches required to transition into an ALARM state.
    *
    * @default - 3
@@ -460,17 +468,19 @@ export class AlarmFactory {
   protected readonly alarmScope: Construct;
   protected readonly globalAlarmDefaults: AlarmFactoryDefaults;
   protected readonly globalMetricDefaults: MetricFactoryDefaults;
-  protected readonly alarmNamingStrategy: AlarmNamingStrategy;
+  protected readonly alarmNamingStrategy: IAlarmNamingStrategy;
 
   constructor(alarmScope: Construct, props: AlarmFactoryProps) {
     this.alarmScope = alarmScope;
     this.globalAlarmDefaults = props.globalAlarmDefaults;
     this.globalMetricDefaults = props.globalMetricDefaults;
-    this.alarmNamingStrategy = new AlarmNamingStrategy(
-      props.globalAlarmDefaults.alarmNamePrefix,
-      props.localAlarmNamePrefix,
-      props.globalAlarmDefaults.dedupeStringProcessor
-    );
+    this.alarmNamingStrategy =
+      props.globalAlarmDefaults.alarmNamingStrategy ??
+      new AlarmNamingStrategy(
+        props.globalAlarmDefaults.alarmNamePrefix,
+        props.localAlarmNamePrefix,
+        props.globalAlarmDefaults.dedupeStringProcessor
+      );
   }
 
   addAlarm(

--- a/lib/common/alarm/AlarmNamingStrategy.ts
+++ b/lib/common/alarm/AlarmNamingStrategy.ts
@@ -2,19 +2,12 @@ import {
   DoNotModifyDedupeString,
   IAlarmDedupeStringProcessor,
 } from "./IAlarmDedupeStringProcessor";
+import { AlarmNamingInput, IAlarmNamingStrategy } from "./IAlarmNamingStrategy";
 
 const AlarmNamePartSeparator = "-";
 const AlarmLabelPartSeparator = " ";
 
-export interface AlarmNamingInput {
-  readonly alarmNameSuffix: string;
-  readonly alarmNameOverride?: string;
-  readonly alarmDedupeStringSuffix?: string;
-  readonly dedupeStringOverride?: string;
-  readonly disambiguator?: string;
-}
-
-export class AlarmNamingStrategy {
+export class AlarmNamingStrategy implements IAlarmNamingStrategy {
   protected readonly globalPrefix: string;
   protected readonly localPrefix: string;
   protected readonly dedupeStringStrategy: IAlarmDedupeStringProcessor;

--- a/lib/common/alarm/IAlarmNamingStrategy.ts
+++ b/lib/common/alarm/IAlarmNamingStrategy.ts
@@ -1,0 +1,31 @@
+export interface AlarmNamingInput {
+  readonly alarmNameSuffix: string;
+  readonly alarmNameOverride?: string;
+  readonly alarmDedupeStringSuffix?: string;
+  readonly dedupeStringOverride?: string;
+  readonly disambiguator?: string;
+}
+
+/**
+ * Strategy used to name alarms, their widgets, and their dedupe strings.
+ */
+export interface IAlarmNamingStrategy {
+  /**
+   * How to generate the name of an alarm.
+   *
+   * @param props AlarmNamingInput
+   */
+  getName(props: AlarmNamingInput): string;
+
+  /**
+   * How to generate the label for the alarm displayed on a widget.
+   *
+   * @param props AlarmNamingInput
+   */
+  getWidgetLabel(props: AlarmNamingInput): string;
+
+  /**
+   * How to generate the deduplication string for an alarm.
+   */
+  getDedupeString(props: AlarmNamingInput): string | undefined;
+}

--- a/lib/common/alarm/index.ts
+++ b/lib/common/alarm/index.ts
@@ -4,6 +4,7 @@ export * from "./CustomAlarmThreshold";
 export * from "./IAlarmActionStrategy";
 export * from "./IAlarmAnnotationStrategy";
 export * from "./IAlarmDedupeStringProcessor";
+export * from "./IAlarmNamingStrategy";
 export * from "./MultipleAlarmActionStrategy";
 export * from "./NoopAlarmActionStrategy";
 export * from "./OpsItemAlarmActionStrategy";


### PR DESCRIPTION
Making the AlarmNamingStrategy configurable. My team wants  to add the disambiguator to the alarm dedupe string. This requires custom logic for generating the deduplication string, which is why we want to be able to override this class's functionality.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_