### PR TITLE
chore: add VSCode launch task for debugging Jest tests [skip ci]

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  "version": "1.0.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest: current file",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": [
+        "${fileBasenameNoExtension}"
+      ],
+      "console": "integratedTerminal"
+    }
+  ]
+}


### PR DESCRIPTION
I was asked how to debug the unit tests. This adds a task for use in VSCode so that you can use the debugger with test files (i.e. set breakpoints, stepping through, looking at call stacks and variable states, etc.).

Based on the task from https://mattmazzola.medium.com/how-to-debug-jest-tests-with-vscode-48f003c7cb41

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_