### PR TITLE
fix(dashboards): use correct scope for default DashboardFactory

### DIFF
--- a/lib/facade/MonitoringFacade.ts
+++ b/lib/facade/MonitoringFacade.ts
@@ -165,7 +165,7 @@ export class MonitoringFacade extends MonitoringScope {
     };
     this.dashboardFactory =
       props?.dashboardFactory ??
-      new DefaultDashboardFactory(scope, `${id}-Dashboards`, {
+      new DefaultDashboardFactory(this, `${id}-Dashboards`, {
         dashboardNamePrefix: id,
       });
 


### PR DESCRIPTION
Fixes #357

This was unintentionally changed during [this refactoring](https://github.com/cdklabs/cdk-monitoring-constructs/commit/6e04b202de62afb056f2fe1ef89bfda10da6d726#diff-03751236dd3f86d2e1421165630d186616c9ca23c203b86ab195b36c5f1022f2) in between v3.0.4 and v3.0.5.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_