### PR TITLE
fix(dynamo): divide GSI consumed RCU/WCU metrics by period

### DIFF
--- a/lib/monitoring/aws-dynamo/DynamoTableGlobalSecondaryIndexMetricFactory.ts
+++ b/lib/monitoring/aws-dynamo/DynamoTableGlobalSecondaryIndexMetricFactory.ts
@@ -12,6 +12,7 @@ export interface DynamoTableGlobalSecondaryIndexMetricFactoryProps {
 
 export class DynamoTableGlobalSecondaryIndexMetricFactory {
   protected readonly metricFactory: MetricFactory;
+  protected readonly table: ITable;
   protected readonly dimensionsMap: DimensionsMap;
 
   constructor(
@@ -19,6 +20,7 @@ export class DynamoTableGlobalSecondaryIndexMetricFactory {
     props: DynamoTableGlobalSecondaryIndexMetricFactoryProps
   ) {
     this.metricFactory = metricFactory;
+    this.table = props.table;
     this.dimensionsMap = {
       TableName: props.table.tableName,
       GlobalSecondaryIndexName: props.globalSecondaryIndexName,
@@ -48,24 +50,28 @@ export class DynamoTableGlobalSecondaryIndexMetricFactory {
   }
 
   metricConsumedReadCapacityUnits() {
-    return this.metricFactory.createMetric(
-      "ConsumedReadCapacityUnits",
-      MetricStatistic.SUM,
-      "Consumed",
-      this.dimensionsMap,
-      undefined,
-      DynamoDbNamespace
+    return this.metricFactory.createMetricMath(
+      "consumed_rcu_sum/PERIOD(consumed_rcu_sum)",
+      {
+        consumed_rcu_sum: this.table.metricConsumedReadCapacityUnits({
+          statistic: MetricStatistic.SUM,
+          dimensionsMap: this.dimensionsMap,
+        }),
+      },
+      "Consumed"
     );
   }
 
   metricConsumedWriteCapacityUnits() {
-    return this.metricFactory.createMetric(
-      "ConsumedWriteCapacityUnits",
-      MetricStatistic.SUM,
-      "Consumed",
-      this.dimensionsMap,
-      undefined,
-      DynamoDbNamespace
+    return this.metricFactory.createMetricMath(
+      "consumed_wcu_sum/PERIOD(consumed_wcu_sum)",
+      {
+        consumed_wcu_sum: this.table.metricConsumedWriteCapacityUnits({
+          statistic: MetricStatistic.SUM,
+          dimensionsMap: this.dimensionsMap,
+        }),
+      },
+      "Consumed"
     );
   }
 

--- a/test/monitoring/aws-dynamo/__snapshots__/DynamoTableGlobalSecondaryIndexMonitoring.test.ts.snap
+++ b/test/monitoring/aws-dynamo/__snapshots__/DynamoTableGlobalSecondaryIndexMonitoring.test.ts.snap
@@ -30,11 +30,11 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/DynamoDB\\",\\"ConsumedReadCapacityUnits\\",\\"GlobalSecondaryIndexName\\",\\"non-existing-index\\",\\"TableName\\",\\"",
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Consumed\\",\\"expression\\":\\"consumed_rcu_sum/PERIOD(consumed_rcu_sum)\\"}],[\\"AWS/DynamoDB\\",\\"ConsumedReadCapacityUnits\\",\\"GlobalSecondaryIndexName\\",\\"non-existing-index\\",\\"TableName\\",\\"",
               Object {
                 "Ref": "TableCD117FA1",
               },
-              "\\",{\\"label\\":\\"Consumed\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/DynamoDB\\",\\"ProvisionedReadCapacityUnits\\",\\"GlobalSecondaryIndexName\\",\\"non-existing-index\\",\\"TableName\\",\\"",
+              "\\",{\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"consumed_rcu_sum\\"}],[\\"AWS/DynamoDB\\",\\"ProvisionedReadCapacityUnits\\",\\"GlobalSecondaryIndexName\\",\\"non-existing-index\\",\\"TableName\\",\\"",
               Object {
                 "Ref": "TableCD117FA1",
               },
@@ -42,11 +42,11 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/DynamoDB\\",\\"ConsumedWriteCapacityUnits\\",\\"GlobalSecondaryIndexName\\",\\"non-existing-index\\",\\"TableName\\",\\"",
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Consumed\\",\\"expression\\":\\"consumed_wcu_sum/PERIOD(consumed_wcu_sum)\\"}],[\\"AWS/DynamoDB\\",\\"ConsumedWriteCapacityUnits\\",\\"GlobalSecondaryIndexName\\",\\"non-existing-index\\",\\"TableName\\",\\"",
               Object {
                 "Ref": "TableCD117FA1",
               },
-              "\\",{\\"label\\":\\"Consumed\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/DynamoDB\\",\\"ProvisionedWriteCapacityUnits\\",\\"GlobalSecondaryIndexName\\",\\"non-existing-index\\",\\"TableName\\",\\"",
+              "\\",{\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"consumed_wcu_sum\\"}],[\\"AWS/DynamoDB\\",\\"ProvisionedWriteCapacityUnits\\",\\"GlobalSecondaryIndexName\\",\\"non-existing-index\\",\\"TableName\\",\\"",
               Object {
                 "Ref": "TableCD117FA1",
               },
@@ -91,11 +91,11 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/DynamoDB\\",\\"ConsumedReadCapacityUnits\\",\\"GlobalSecondaryIndexName\\",\\"non-existing-index\\",\\"TableName\\",\\"",
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Consumed\\",\\"expression\\":\\"consumed_rcu_sum/PERIOD(consumed_rcu_sum)\\"}],[\\"AWS/DynamoDB\\",\\"ConsumedReadCapacityUnits\\",\\"GlobalSecondaryIndexName\\",\\"non-existing-index\\",\\"TableName\\",\\"",
               Object {
                 "Ref": "TableCD117FA1",
               },
-              "\\",{\\"label\\":\\"Consumed\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/DynamoDB\\",\\"ProvisionedReadCapacityUnits\\",\\"GlobalSecondaryIndexName\\",\\"non-existing-index\\",\\"TableName\\",\\"",
+              "\\",{\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"consumed_rcu_sum\\"}],[\\"AWS/DynamoDB\\",\\"ProvisionedReadCapacityUnits\\",\\"GlobalSecondaryIndexName\\",\\"non-existing-index\\",\\"TableName\\",\\"",
               Object {
                 "Ref": "TableCD117FA1",
               },
@@ -103,11 +103,11 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/DynamoDB\\",\\"ConsumedWriteCapacityUnits\\",\\"GlobalSecondaryIndexName\\",\\"non-existing-index\\",\\"TableName\\",\\"",
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Consumed\\",\\"expression\\":\\"consumed_wcu_sum/PERIOD(consumed_wcu_sum)\\"}],[\\"AWS/DynamoDB\\",\\"ConsumedWriteCapacityUnits\\",\\"GlobalSecondaryIndexName\\",\\"non-existing-index\\",\\"TableName\\",\\"",
               Object {
                 "Ref": "TableCD117FA1",
               },
-              "\\",{\\"label\\":\\"Consumed\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/DynamoDB\\",\\"ProvisionedWriteCapacityUnits\\",\\"GlobalSecondaryIndexName\\",\\"non-existing-index\\",\\"TableName\\",\\"",
+              "\\",{\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"consumed_wcu_sum\\"}],[\\"AWS/DynamoDB\\",\\"ProvisionedWriteCapacityUnits\\",\\"GlobalSecondaryIndexName\\",\\"non-existing-index\\",\\"TableName\\",\\"",
               Object {
                 "Ref": "TableCD117FA1",
               },


### PR DESCRIPTION
Fixes #362

Results in a dashboard widget with a source like:

```
{
    "view": "timeSeries",
    "title": "Read Capacity",
    "region": "us-east-1",
    "metrics": [
        [ { "label": "Consumed", "expression": "consumed_rcu_sum/PERIOD(consumed_rcu_sum)", "region": "us-east-1" } ],
        [ "AWS/DynamoDB", "ConsumedReadCapacityUnits", "GlobalSecondaryIndexName", "SampleTable2-GSI", "TableName", "SampleTable2", { "stat": "Sum", "visible": false, "id": "consumed_rcu_sum", "region": "us-east-1" } ],
        [ ".", "ProvisionedReadCapacityUnits", ".", ".", ".", ".", { "label": "Provisioned", "stat": "Sum", "region": "us-east-1" } ]
    ],
    "yAxis": {
        "left": {
            "min": 0,
            "label": "Count",
            "showUnits": false
        }
    },
    "timezone": "UTC"
}
```

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_