### PR TITLE
fix(dashboards)!: handle dynamic dashboards in SingleWidgetDashboardSegment

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -233,7 +233,7 @@
       "description": "Prepare a release from \"main\" branch",
       "env": {
         "RELEASE": "true",
-        "MAJOR": "4"
+        "MAJOR": "5"
       },
       "steps": [
         {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -11,7 +11,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   keywords: ["cloudwatch", "monitoring"],
 
   defaultReleaseBranch: "main",
-  majorVersion: 4,
+  majorVersion: 5,
   stability: "experimental",
 
   cdkVersion: CDK_VERSION,

--- a/API.md
+++ b/API.md
@@ -56439,7 +56439,7 @@ new SingleWidgetDashboardSegment(widget: IWidget, dashboardsToInclude?: string[]
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.SingleWidgetDashboardSegment.Initializer.parameter.widget">widget</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IWidget</code> | widget to add. |
-| <code><a href="#cdk-monitoring-constructs.SingleWidgetDashboardSegment.Initializer.parameter.dashboardsToInclude">dashboardsToInclude</a></code> | <code>string[]</code> | list of dashboard names which will include the dashboard. |
+| <code><a href="#cdk-monitoring-constructs.SingleWidgetDashboardSegment.Initializer.parameter.dashboardsToInclude">dashboardsToInclude</a></code> | <code>string[]</code> | list of dashboard names which to show this widget on. |
 
 ---
 
@@ -56455,7 +56455,9 @@ widget to add.
 
 - *Type:* string[]
 
-list of dashboard names which will include the dashboard.
+list of dashboard names which to show this widget on.
+
+Defaults to the default dashboards.
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -56433,18 +56433,29 @@ Any warnings that are produced as a result of putting together this widget.
 ```typescript
 import { SingleWidgetDashboardSegment } from 'cdk-monitoring-constructs'
 
-new SingleWidgetDashboardSegment(widget: IWidget)
+new SingleWidgetDashboardSegment(widget: IWidget, dashboardsToInclude?: string[])
 ```
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#cdk-monitoring-constructs.SingleWidgetDashboardSegment.Initializer.parameter.widget">widget</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IWidget</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.SingleWidgetDashboardSegment.Initializer.parameter.widget">widget</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IWidget</code> | widget to add. |
+| <code><a href="#cdk-monitoring-constructs.SingleWidgetDashboardSegment.Initializer.parameter.dashboardsToInclude">dashboardsToInclude</a></code> | <code>string[]</code> | list of dashboard names which will include the dashboard. |
 
 ---
 
 ##### `widget`<sup>Required</sup> <a name="widget" id="cdk-monitoring-constructs.SingleWidgetDashboardSegment.Initializer.parameter.widget"></a>
 
 - *Type:* aws-cdk-lib.aws_cloudwatch.IWidget
+
+widget to add.
+
+---
+
+##### `dashboardsToInclude`<sup>Optional</sup> <a name="dashboardsToInclude" id="cdk-monitoring-constructs.SingleWidgetDashboardSegment.Initializer.parameter.dashboardsToInclude"></a>
+
+- *Type:* string[]
+
+list of dashboard names which will include the dashboard.
 
 ---
 
@@ -56492,12 +56503,12 @@ These should go to the detailed service dashboard.
 ##### `widgetsForDashboard` <a name="widgetsForDashboard" id="cdk-monitoring-constructs.SingleWidgetDashboardSegment.widgetsForDashboard"></a>
 
 ```typescript
-public widgetsForDashboard(_name: string): IWidget[]
+public widgetsForDashboard(name: string): IWidget[]
 ```
 
 Returns widgets for the requested dashboard type.
 
-###### `_name`<sup>Required</sup> <a name="_name" id="cdk-monitoring-constructs.SingleWidgetDashboardSegment.widgetsForDashboard.parameter._name"></a>
+###### `name`<sup>Required</sup> <a name="name" id="cdk-monitoring-constructs.SingleWidgetDashboardSegment.widgetsForDashboard.parameter.name"></a>
 
 - *Type:* string
 

--- a/API.md
+++ b/API.md
@@ -56492,12 +56492,12 @@ These should go to the detailed service dashboard.
 ##### `widgetsForDashboard` <a name="widgetsForDashboard" id="cdk-monitoring-constructs.SingleWidgetDashboardSegment.widgetsForDashboard"></a>
 
 ```typescript
-public widgetsForDashboard(name: string): IWidget[]
+public widgetsForDashboard(_name: string): IWidget[]
 ```
 
 Returns widgets for the requested dashboard type.
 
-###### `name`<sup>Required</sup> <a name="name" id="cdk-monitoring-constructs.SingleWidgetDashboardSegment.widgetsForDashboard.parameter.name"></a>
+###### `_name`<sup>Required</sup> <a name="_name" id="cdk-monitoring-constructs.SingleWidgetDashboardSegment.widgetsForDashboard.parameter._name"></a>
 
 - *Type:* string
 

--- a/API.md
+++ b/API.md
@@ -56426,39 +56426,25 @@ Any warnings that are produced as a result of putting together this widget.
 
 ### SingleWidgetDashboardSegment <a name="SingleWidgetDashboardSegment" id="cdk-monitoring-constructs.SingleWidgetDashboardSegment"></a>
 
-- *Implements:* <a href="#cdk-monitoring-constructs.IDashboardSegment">IDashboardSegment</a>
+- *Implements:* <a href="#cdk-monitoring-constructs.IDashboardSegment">IDashboardSegment</a>, <a href="#cdk-monitoring-constructs.IDynamicDashboardSegment">IDynamicDashboardSegment</a>
 
 #### Initializers <a name="Initializers" id="cdk-monitoring-constructs.SingleWidgetDashboardSegment.Initializer"></a>
 
 ```typescript
 import { SingleWidgetDashboardSegment } from 'cdk-monitoring-constructs'
 
-new SingleWidgetDashboardSegment(widget: IWidget, addToSummary?: boolean, addToAlarm?: boolean)
+new SingleWidgetDashboardSegment(widget: IWidget)
 ```
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.SingleWidgetDashboardSegment.Initializer.parameter.widget">widget</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IWidget</code> | *No description.* |
-| <code><a href="#cdk-monitoring-constructs.SingleWidgetDashboardSegment.Initializer.parameter.addToSummary">addToSummary</a></code> | <code>boolean</code> | *No description.* |
-| <code><a href="#cdk-monitoring-constructs.SingleWidgetDashboardSegment.Initializer.parameter.addToAlarm">addToAlarm</a></code> | <code>boolean</code> | *No description.* |
 
 ---
 
 ##### `widget`<sup>Required</sup> <a name="widget" id="cdk-monitoring-constructs.SingleWidgetDashboardSegment.Initializer.parameter.widget"></a>
 
 - *Type:* aws-cdk-lib.aws_cloudwatch.IWidget
-
----
-
-##### `addToSummary`<sup>Optional</sup> <a name="addToSummary" id="cdk-monitoring-constructs.SingleWidgetDashboardSegment.Initializer.parameter.addToSummary"></a>
-
-- *Type:* boolean
-
----
-
-##### `addToAlarm`<sup>Optional</sup> <a name="addToAlarm" id="cdk-monitoring-constructs.SingleWidgetDashboardSegment.Initializer.parameter.addToAlarm"></a>
-
-- *Type:* boolean
 
 ---
 
@@ -56469,6 +56455,7 @@ new SingleWidgetDashboardSegment(widget: IWidget, addToSummary?: boolean, addToA
 | <code><a href="#cdk-monitoring-constructs.SingleWidgetDashboardSegment.alarmWidgets">alarmWidgets</a></code> | Returns widgets for all alarms. |
 | <code><a href="#cdk-monitoring-constructs.SingleWidgetDashboardSegment.summaryWidgets">summaryWidgets</a></code> | Returns widgets for the summary. |
 | <code><a href="#cdk-monitoring-constructs.SingleWidgetDashboardSegment.widgets">widgets</a></code> | Returns all widgets. |
+| <code><a href="#cdk-monitoring-constructs.SingleWidgetDashboardSegment.widgetsForDashboard">widgetsForDashboard</a></code> | Returns widgets for the requested dashboard type. |
 
 ---
 
@@ -56501,6 +56488,20 @@ public widgets(): IWidget[]
 Returns all widgets.
 
 These should go to the detailed service dashboard.
+
+##### `widgetsForDashboard` <a name="widgetsForDashboard" id="cdk-monitoring-constructs.SingleWidgetDashboardSegment.widgetsForDashboard"></a>
+
+```typescript
+public widgetsForDashboard(name: string): IWidget[]
+```
+
+Returns widgets for the requested dashboard type.
+
+###### `name`<sup>Required</sup> <a name="name" id="cdk-monitoring-constructs.SingleWidgetDashboardSegment.widgetsForDashboard.parameter.name"></a>
+
+- *Type:* string
+
+---
 
 
 
@@ -57882,7 +57883,7 @@ new StaticSegmentDynamicAdapter(props: IDashboardFactoryProps)
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#cdk-monitoring-constructs.StaticSegmentDynamicAdapter.widgetsForDashboard">widgetsForDashboard</a></code> | Returns widgets for the requested dashboard type. |
+| <code><a href="#cdk-monitoring-constructs.StaticSegmentDynamicAdapter.widgetsForDashboard">widgetsForDashboard</a></code> | Adapts an IDashboardSegment to the IDynamicDashboardSegment interface by using overrideProps to determine if a segment should be shown on a specific dashboard. |
 
 ---
 
@@ -57892,7 +57893,10 @@ new StaticSegmentDynamicAdapter(props: IDashboardFactoryProps)
 public widgetsForDashboard(name: string): IWidget[]
 ```
 
-Returns widgets for the requested dashboard type.
+Adapts an IDashboardSegment to the IDynamicDashboardSegment interface by using overrideProps to determine if a segment should be shown on a specific dashboard.
+
+The default values are true, so consumers must set these to false if they would
+like to hide these items from dashboards
 
 ###### `name`<sup>Required</sup> <a name="name" id="cdk-monitoring-constructs.StaticSegmentDynamicAdapter.widgetsForDashboard.parameter.name"></a>
 
@@ -61743,7 +61747,7 @@ Gets the dashboard for the requested dashboard type.
 
 ### IDynamicDashboardSegment <a name="IDynamicDashboardSegment" id="cdk-monitoring-constructs.IDynamicDashboardSegment"></a>
 
-- *Implemented By:* <a href="#cdk-monitoring-constructs.ApiGatewayMonitoring">ApiGatewayMonitoring</a>, <a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoring">ApiGatewayV2HttpApiMonitoring</a>, <a href="#cdk-monitoring-constructs.AppSyncMonitoring">AppSyncMonitoring</a>, <a href="#cdk-monitoring-constructs.AutoScalingGroupMonitoring">AutoScalingGroupMonitoring</a>, <a href="#cdk-monitoring-constructs.BillingMonitoring">BillingMonitoring</a>, <a href="#cdk-monitoring-constructs.CertificateManagerMonitoring">CertificateManagerMonitoring</a>, <a href="#cdk-monitoring-constructs.CloudFrontDistributionMonitoring">CloudFrontDistributionMonitoring</a>, <a href="#cdk-monitoring-constructs.CodeBuildProjectMonitoring">CodeBuildProjectMonitoring</a>, <a href="#cdk-monitoring-constructs.CustomMonitoring">CustomMonitoring</a>, <a href="#cdk-monitoring-constructs.DocumentDbMonitoring">DocumentDbMonitoring</a>, <a href="#cdk-monitoring-constructs.DynamoTableGlobalSecondaryIndexMonitoring">DynamoTableGlobalSecondaryIndexMonitoring</a>, <a href="#cdk-monitoring-constructs.DynamoTableMonitoring">DynamoTableMonitoring</a>, <a href="#cdk-monitoring-constructs.EC2Monitoring">EC2Monitoring</a>, <a href="#cdk-monitoring-constructs.Ec2ServiceMonitoring">Ec2ServiceMonitoring</a>, <a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoring">ElastiCacheClusterMonitoring</a>, <a href="#cdk-monitoring-constructs.FargateServiceMonitoring">FargateServiceMonitoring</a>, <a href="#cdk-monitoring-constructs.GlueJobMonitoring">GlueJobMonitoring</a>, <a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring">KinesisDataAnalyticsMonitoring</a>, <a href="#cdk-monitoring-constructs.KinesisDataStreamMonitoring">KinesisDataStreamMonitoring</a>, <a href="#cdk-monitoring-constructs.KinesisFirehoseMonitoring">KinesisFirehoseMonitoring</a>, <a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring">LambdaFunctionMonitoring</a>, <a href="#cdk-monitoring-constructs.LogMonitoring">LogMonitoring</a>, <a href="#cdk-monitoring-constructs.Monitoring">Monitoring</a>, <a href="#cdk-monitoring-constructs.NetworkLoadBalancerMonitoring">NetworkLoadBalancerMonitoring</a>, <a href="#cdk-monitoring-constructs.OpenSearchClusterMonitoring">OpenSearchClusterMonitoring</a>, <a href="#cdk-monitoring-constructs.RdsClusterMonitoring">RdsClusterMonitoring</a>, <a href="#cdk-monitoring-constructs.RedshiftClusterMonitoring">RedshiftClusterMonitoring</a>, <a href="#cdk-monitoring-constructs.S3BucketMonitoring">S3BucketMonitoring</a>, <a href="#cdk-monitoring-constructs.SecretsManagerSecretMonitoring">SecretsManagerSecretMonitoring</a>, <a href="#cdk-monitoring-constructs.SnsTopicMonitoring">SnsTopicMonitoring</a>, <a href="#cdk-monitoring-constructs.SqsQueueMonitoring">SqsQueueMonitoring</a>, <a href="#cdk-monitoring-constructs.SqsQueueMonitoringWithDlq">SqsQueueMonitoringWithDlq</a>, <a href="#cdk-monitoring-constructs.StaticSegmentDynamicAdapter">StaticSegmentDynamicAdapter</a>, <a href="#cdk-monitoring-constructs.StepFunctionActivityMonitoring">StepFunctionActivityMonitoring</a>, <a href="#cdk-monitoring-constructs.StepFunctionLambdaIntegrationMonitoring">StepFunctionLambdaIntegrationMonitoring</a>, <a href="#cdk-monitoring-constructs.StepFunctionMonitoring">StepFunctionMonitoring</a>, <a href="#cdk-monitoring-constructs.StepFunctionServiceIntegrationMonitoring">StepFunctionServiceIntegrationMonitoring</a>, <a href="#cdk-monitoring-constructs.SyntheticsCanaryMonitoring">SyntheticsCanaryMonitoring</a>, <a href="#cdk-monitoring-constructs.WafV2Monitoring">WafV2Monitoring</a>, <a href="#cdk-monitoring-constructs.IDynamicDashboardSegment">IDynamicDashboardSegment</a>
+- *Implemented By:* <a href="#cdk-monitoring-constructs.ApiGatewayMonitoring">ApiGatewayMonitoring</a>, <a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoring">ApiGatewayV2HttpApiMonitoring</a>, <a href="#cdk-monitoring-constructs.AppSyncMonitoring">AppSyncMonitoring</a>, <a href="#cdk-monitoring-constructs.AutoScalingGroupMonitoring">AutoScalingGroupMonitoring</a>, <a href="#cdk-monitoring-constructs.BillingMonitoring">BillingMonitoring</a>, <a href="#cdk-monitoring-constructs.CertificateManagerMonitoring">CertificateManagerMonitoring</a>, <a href="#cdk-monitoring-constructs.CloudFrontDistributionMonitoring">CloudFrontDistributionMonitoring</a>, <a href="#cdk-monitoring-constructs.CodeBuildProjectMonitoring">CodeBuildProjectMonitoring</a>, <a href="#cdk-monitoring-constructs.CustomMonitoring">CustomMonitoring</a>, <a href="#cdk-monitoring-constructs.DocumentDbMonitoring">DocumentDbMonitoring</a>, <a href="#cdk-monitoring-constructs.DynamoTableGlobalSecondaryIndexMonitoring">DynamoTableGlobalSecondaryIndexMonitoring</a>, <a href="#cdk-monitoring-constructs.DynamoTableMonitoring">DynamoTableMonitoring</a>, <a href="#cdk-monitoring-constructs.EC2Monitoring">EC2Monitoring</a>, <a href="#cdk-monitoring-constructs.Ec2ServiceMonitoring">Ec2ServiceMonitoring</a>, <a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoring">ElastiCacheClusterMonitoring</a>, <a href="#cdk-monitoring-constructs.FargateServiceMonitoring">FargateServiceMonitoring</a>, <a href="#cdk-monitoring-constructs.GlueJobMonitoring">GlueJobMonitoring</a>, <a href="#cdk-monitoring-constructs.KinesisDataAnalyticsMonitoring">KinesisDataAnalyticsMonitoring</a>, <a href="#cdk-monitoring-constructs.KinesisDataStreamMonitoring">KinesisDataStreamMonitoring</a>, <a href="#cdk-monitoring-constructs.KinesisFirehoseMonitoring">KinesisFirehoseMonitoring</a>, <a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring">LambdaFunctionMonitoring</a>, <a href="#cdk-monitoring-constructs.LogMonitoring">LogMonitoring</a>, <a href="#cdk-monitoring-constructs.Monitoring">Monitoring</a>, <a href="#cdk-monitoring-constructs.NetworkLoadBalancerMonitoring">NetworkLoadBalancerMonitoring</a>, <a href="#cdk-monitoring-constructs.OpenSearchClusterMonitoring">OpenSearchClusterMonitoring</a>, <a href="#cdk-monitoring-constructs.RdsClusterMonitoring">RdsClusterMonitoring</a>, <a href="#cdk-monitoring-constructs.RedshiftClusterMonitoring">RedshiftClusterMonitoring</a>, <a href="#cdk-monitoring-constructs.S3BucketMonitoring">S3BucketMonitoring</a>, <a href="#cdk-monitoring-constructs.SecretsManagerSecretMonitoring">SecretsManagerSecretMonitoring</a>, <a href="#cdk-monitoring-constructs.SingleWidgetDashboardSegment">SingleWidgetDashboardSegment</a>, <a href="#cdk-monitoring-constructs.SnsTopicMonitoring">SnsTopicMonitoring</a>, <a href="#cdk-monitoring-constructs.SqsQueueMonitoring">SqsQueueMonitoring</a>, <a href="#cdk-monitoring-constructs.SqsQueueMonitoringWithDlq">SqsQueueMonitoringWithDlq</a>, <a href="#cdk-monitoring-constructs.StaticSegmentDynamicAdapter">StaticSegmentDynamicAdapter</a>, <a href="#cdk-monitoring-constructs.StepFunctionActivityMonitoring">StepFunctionActivityMonitoring</a>, <a href="#cdk-monitoring-constructs.StepFunctionLambdaIntegrationMonitoring">StepFunctionLambdaIntegrationMonitoring</a>, <a href="#cdk-monitoring-constructs.StepFunctionMonitoring">StepFunctionMonitoring</a>, <a href="#cdk-monitoring-constructs.StepFunctionServiceIntegrationMonitoring">StepFunctionServiceIntegrationMonitoring</a>, <a href="#cdk-monitoring-constructs.SyntheticsCanaryMonitoring">SyntheticsCanaryMonitoring</a>, <a href="#cdk-monitoring-constructs.WafV2Monitoring">WafV2Monitoring</a>, <a href="#cdk-monitoring-constructs.IDynamicDashboardSegment">IDynamicDashboardSegment</a>
 
 #### Methods <a name="Methods" id="Methods"></a>
 

--- a/lib/dashboard/DynamicDashboardSegment.ts
+++ b/lib/dashboard/DynamicDashboardSegment.ts
@@ -34,7 +34,7 @@ export class StaticSegmentDynamicAdapter implements IDynamicDashboardSegment {
     if (addToSummaryDashboard && name === DefaultDashboards.SUMMARY) {
       return this.props.segment.summaryWidgets();
     }
-    if (addToAlarmsDashboard != false && name === DefaultDashboards.ALARMS) {
+    if (addToAlarmsDashboard && name === DefaultDashboards.ALARMS) {
       return this.props.segment.alarmWidgets();
     }
     return [];

--- a/lib/dashboard/DynamicDashboardSegment.ts
+++ b/lib/dashboard/DynamicDashboardSegment.ts
@@ -31,7 +31,7 @@ export class StaticSegmentDynamicAdapter implements IDynamicDashboardSegment {
     if (addToDetailDashboard && name === DefaultDashboards.DETAIL) {
       return this.props.segment.widgets();
     }
-    if (addToSummaryDashboard != false && name === DefaultDashboards.SUMMARY) {
+    if (addToSummaryDashboard && name === DefaultDashboards.SUMMARY) {
       return this.props.segment.summaryWidgets();
     }
     if (addToAlarmsDashboard != false && name === DefaultDashboards.ALARMS) {

--- a/lib/dashboard/DynamicDashboardSegment.ts
+++ b/lib/dashboard/DynamicDashboardSegment.ts
@@ -24,15 +24,10 @@ export class StaticSegmentDynamicAdapter implements IDynamicDashboardSegment {
    * like to hide these items from dashboards
    */
   widgetsForDashboard(name: string): IWidget[] {
-    let addToDetailDashboard = true;
-    let addToSummaryDashboard = true;
-    let addToAlarmsDashboard = true;
     const overrideProps = this.props.overrideProps;
-    if (overrideProps != null) {
-      addToDetailDashboard = overrideProps.addToDetailDashboard ?? true;
-      addToSummaryDashboard = overrideProps.addToSummaryDashboard ?? true;
-      addToAlarmsDashboard = overrideProps.addToAlarmDashboard ?? true;
-    }
+    const addToDetailDashboard = overrideProps?.addToDetailDashboard ?? true;
+    const addToSummaryDashboard = overrideProps?.addToSummaryDashboard ?? true;
+    const addToAlarmsDashboard = overrideProps?.addToAlarmDashboard ?? true;
     if (addToDetailDashboard != false && name === DefaultDashboards.DETAIL) {
       return this.props.segment.widgets();
     }

--- a/lib/dashboard/DynamicDashboardSegment.ts
+++ b/lib/dashboard/DynamicDashboardSegment.ts
@@ -17,26 +17,31 @@ export class StaticSegmentDynamicAdapter implements IDynamicDashboardSegment {
     this.props = props;
   }
 
+  /**
+   * Adapts an IDashboardSegment to the IDynamicDashboardSegment interface by using
+   * overrideProps to determine if a segment should be shown on a specific dashboard.
+   * The default values are true, so consumers must set these to false if they would
+   * like to hide these items from dashboards
+   */
   widgetsForDashboard(name: string): IWidget[] {
-    if (
-      this.props.overrideProps?.addToDetailDashboard ||
-      name === DefaultDashboards.DETAIL
-    ) {
+    let addToDetailDashboard = true;
+    let addToSummaryDashboard = true;
+    let addToAlarmsDashboard = true;
+    const overrideProps = this.props.overrideProps;
+    if (overrideProps != null) {
+      addToDetailDashboard = overrideProps.addToDetailDashboard ?? true;
+      addToSummaryDashboard = overrideProps.addToSummaryDashboard ?? true;
+      addToAlarmsDashboard = overrideProps.addToAlarmDashboard ?? true;
+    }
+    if (addToDetailDashboard != false && name === DefaultDashboards.DETAIL) {
       return this.props.segment.widgets();
     }
-    if (
-      this.props.overrideProps?.addToSummaryDashboard ||
-      name === DefaultDashboards.SUMMARY
-    ) {
+    if (addToSummaryDashboard != false && name === DefaultDashboards.SUMMARY) {
       return this.props.segment.summaryWidgets();
     }
-    if (
-      this.props.overrideProps?.addToAlarmDashboard ||
-      name === DefaultDashboards.ALARMS
-    ) {
+    if (addToAlarmsDashboard != false && name === DefaultDashboards.ALARMS) {
       return this.props.segment.alarmWidgets();
     }
-
     return [];
   }
 }

--- a/lib/dashboard/DynamicDashboardSegment.ts
+++ b/lib/dashboard/DynamicDashboardSegment.ts
@@ -28,7 +28,7 @@ export class StaticSegmentDynamicAdapter implements IDynamicDashboardSegment {
     const addToDetailDashboard = overrideProps?.addToDetailDashboard ?? true;
     const addToSummaryDashboard = overrideProps?.addToSummaryDashboard ?? true;
     const addToAlarmsDashboard = overrideProps?.addToAlarmDashboard ?? true;
-    if (addToDetailDashboard != false && name === DefaultDashboards.DETAIL) {
+    if (addToDetailDashboard && name === DefaultDashboards.DETAIL) {
       return this.props.segment.widgets();
     }
     if (addToSummaryDashboard != false && name === DefaultDashboards.SUMMARY) {

--- a/lib/dashboard/SingleWidgetDashboardSegment.ts
+++ b/lib/dashboard/SingleWidgetDashboardSegment.ts
@@ -12,7 +12,7 @@ export class SingleWidgetDashboardSegment
   /**
    * Create a dashboard segment representing a single widget.
    * @param widget widget to add
-   * @param dashboardsToInclude list of dashboard names which will include the dashboard
+   * @param dashboardsToInclude list of dashboard names which to show this widget on. Defaults to the default dashboards.
    */
   constructor(widget: IWidget, dashboardsToInclude?: string[]) {
     this.widget = widget;

--- a/lib/dashboard/SingleWidgetDashboardSegment.ts
+++ b/lib/dashboard/SingleWidgetDashboardSegment.ts
@@ -1,30 +1,37 @@
 import { IWidget } from "aws-cdk-lib/aws-cloudwatch";
 
 import { IDashboardSegment } from "./DashboardSegment";
+import { DefaultDashboards } from "./DefaultDashboardFactory";
+import { IDynamicDashboardSegment } from "./DynamicDashboardSegment";
 
-export class SingleWidgetDashboardSegment implements IDashboardSegment {
+export class SingleWidgetDashboardSegment
+  implements IDashboardSegment, IDynamicDashboardSegment
+{
   protected readonly widget: IWidget;
-  protected readonly addToSummary: boolean;
-  protected readonly addToAlarm: boolean;
 
-  constructor(widget: IWidget, addToSummary?: boolean, addToAlarm?: boolean) {
+  constructor(widget: IWidget) {
     this.widget = widget;
-    this.addToSummary = addToSummary ?? true;
-    this.addToAlarm = addToAlarm ?? true;
+  }
+
+  widgetsForDashboard(name: string): IWidget[] {
+    switch (name) {
+      case DefaultDashboards.SUMMARY:
+        return [this.widget];
+      case DefaultDashboards.DETAIL:
+        return [this.widget];
+      case DefaultDashboards.ALARMS:
+        return [this.widget];
+      default:
+        return [];
+    }
   }
 
   alarmWidgets(): IWidget[] {
-    if (this.addToAlarm) {
-      return [this.widget];
-    }
-    return [];
+    return [this.widget];
   }
 
   summaryWidgets(): IWidget[] {
-    if (this.addToSummary) {
-      return [this.widget];
-    }
-    return [];
+    return [this.widget];
   }
 
   widgets(): IWidget[] {

--- a/lib/dashboard/SingleWidgetDashboardSegment.ts
+++ b/lib/dashboard/SingleWidgetDashboardSegment.ts
@@ -1,29 +1,57 @@
 import { IWidget } from "aws-cdk-lib/aws-cloudwatch";
 import { IDashboardSegment } from "./DashboardSegment";
+import { DefaultDashboards } from "./DefaultDashboardFactory";
 import { IDynamicDashboardSegment } from "./DynamicDashboardSegment";
 
 export class SingleWidgetDashboardSegment
   implements IDashboardSegment, IDynamicDashboardSegment
 {
   protected readonly widget: IWidget;
+  protected readonly dashboardsToInclude: string[];
 
-  constructor(widget: IWidget) {
+  /**
+   * Create a dashboard segment representing a single widget.
+   * @param widget widget to add
+   * @param dashboardsToInclude list of dashboard names which will include the dashboard
+   */
+  constructor(widget: IWidget, dashboardsToInclude?: string[]) {
     this.widget = widget;
+    this.dashboardsToInclude = dashboardsToInclude ?? [
+      DefaultDashboards.ALARMS,
+      DefaultDashboards.DETAIL,
+      DefaultDashboards.SUMMARY,
+    ];
   }
 
-  widgetsForDashboard(_name: string): IWidget[] {
-    return [this.widget];
+  widgetsForDashboard(name: string): IWidget[] {
+    if (this.dashboardsToInclude.includes(name)) {
+      return [this.widget];
+    } else {
+      return [];
+    }
   }
 
   alarmWidgets(): IWidget[] {
-    return [this.widget];
+    if (this.dashboardsToInclude.includes(DefaultDashboards.ALARMS)) {
+      return [this.widget];
+    } else {
+      return [];
+    }
   }
 
   summaryWidgets(): IWidget[] {
-    return [this.widget];
+    if (this.dashboardsToInclude.includes(DefaultDashboards.SUMMARY)) {
+      return [this.widget];
+    } else {
+      return [];
+    }
   }
 
   widgets(): IWidget[] {
-    return [this.widget];
+    if (this.dashboardsToInclude.includes(DefaultDashboards.DETAIL)) {
+      return [this.widget];
+    } else {
+      return [];
+    }
   }
 }

--- a/lib/dashboard/SingleWidgetDashboardSegment.ts
+++ b/lib/dashboard/SingleWidgetDashboardSegment.ts
@@ -1,7 +1,5 @@
 import { IWidget } from "aws-cdk-lib/aws-cloudwatch";
-
 import { IDashboardSegment } from "./DashboardSegment";
-import { DefaultDashboards } from "./DefaultDashboardFactory";
 import { IDynamicDashboardSegment } from "./DynamicDashboardSegment";
 
 export class SingleWidgetDashboardSegment
@@ -13,17 +11,8 @@ export class SingleWidgetDashboardSegment
     this.widget = widget;
   }
 
-  widgetsForDashboard(name: string): IWidget[] {
-    switch (name) {
-      case DefaultDashboards.SUMMARY:
-        return [this.widget];
-      case DefaultDashboards.DETAIL:
-        return [this.widget];
-      case DefaultDashboards.ALARMS:
-        return [this.widget];
-      default:
-        return [];
-    }
+  widgetsForDashboard(_name: string): IWidget[] {
+    return [this.widget];
   }
 
   alarmWidgets(): IWidget[] {

--- a/lib/facade/MonitoringFacade.ts
+++ b/lib/facade/MonitoringFacade.ts
@@ -371,9 +371,11 @@ export class MonitoringFacade extends MonitoringScope {
   }
 
   addWidget(widget: IWidget, addToSummary?: boolean, addToAlarm?: boolean) {
-    this.addSegment(
-      new SingleWidgetDashboardSegment(widget, addToSummary, addToAlarm)
-    );
+    this.addSegment(new SingleWidgetDashboardSegment(widget), {
+      addToAlarmDashboard: addToAlarm ?? true,
+      addToSummaryDashboard: addToSummary ?? true,
+      addToDetailDashboard: true,
+    });
     return this;
   }
 

--- a/test/facade/MonitoringFacade.test.ts
+++ b/test/facade/MonitoringFacade.test.ts
@@ -1,6 +1,12 @@
 import { Stack } from "aws-cdk-lib";
-import { Template } from "aws-cdk-lib/assertions";
-import { DynamicDashboardFactory, MonitoringFacade } from "../../lib";
+import { Capture, Template } from "aws-cdk-lib/assertions";
+import { TextWidget } from "aws-cdk-lib/aws-cloudwatch";
+import {
+  DefaultDashboardFactory,
+  DynamicDashboardFactory,
+  MonitoringFacade,
+  SingleWidgetDashboardSegment,
+} from "../../lib";
 
 describe("test of defaults", () => {
   test("only default dashboard gets created by default", () => {
@@ -56,5 +62,49 @@ describe("test of defaults", () => {
     result.hasResourceProperties("AWS::CloudWatch::Dashboard", {
       DashboardName: "testPrefix-Dynamic2",
     });
+  });
+
+  test("SingleWidgetDashboardSegment is not displayed if addSegment overrides set to false", () => {
+    // configure monitoring facade with dashboard factory which populates all three default dashboards
+    const stack = new Stack();
+    const dashboardFactory = new DefaultDashboardFactory(
+      stack,
+      "TestDashboardFactory",
+      {
+        dashboardNamePrefix: "testPrefix",
+        createDashboard: true,
+        createAlarmDashboard: true,
+        createSummaryDashboard: true,
+      }
+    );
+    const facade = new MonitoringFacade(stack, "Test", {
+      dashboardFactory: dashboardFactory,
+    });
+
+    // add SingleWidgetDashboardSegment with default ctor args but use overrides to
+    // direct exclusion from default dashboards
+    facade.addSegment(
+      new SingleWidgetDashboardSegment(
+        new TextWidget({ markdown: "Simple Dashboard Segment" })
+      ),
+      {
+        addToAlarmDashboard: false,
+        addToDetailDashboard: false,
+        addToSummaryDashboard: false,
+      }
+    );
+
+    // verify that the generated dashboards do not include the SingleWidgetDashboardSegment
+    // due to override exclusion directives
+    const result = Template.fromStack(stack);
+    const dashboardCapture = new Capture();
+    result.hasResourceProperties("AWS::CloudWatch::Dashboard", {
+      DashboardBody: dashboardCapture,
+    });
+    for (var i = 0; i < 3; i++) {
+      const dashboardBody = JSON.parse(dashboardCapture.asString());
+      expect(dashboardBody.widgets).toHaveLength(0);
+      dashboardCapture.next();
+    }
   });
 });

--- a/test/facade/MonitoringFacade.test.ts
+++ b/test/facade/MonitoringFacade.test.ts
@@ -101,10 +101,10 @@ describe("test of defaults", () => {
     result.hasResourceProperties("AWS::CloudWatch::Dashboard", {
       DashboardBody: dashboardCapture,
     });
-    for (var i = 0; i < 3; i++) {
+
+    do {
       const dashboardBody = JSON.parse(dashboardCapture.asString());
       expect(dashboardBody.widgets).toHaveLength(0);
-      dashboardCapture.next();
-    }
+    } while (dashboardCapture.next());
   });
 });


### PR DESCRIPTION
This change fixes a couple things with the dynamic dashboard functionality that was introduced in https://github.com/cdklabs/cdk-monitoring-constructs/commit/d118a6e0f5c788e9d986d12277a5a3ca541b8cca

1. `SingleWidgetDashboardSegment` was accepting ctor params to control dashboard visibility which conflicted with the overrideProps uses elsewhere to control the same. This change removes those params in favor of having consumers control this using overrideProps.
2. Fixes some issues in the `StaticSegmentDynamicAdapter` logic which were impacting backwards compatibility.
3. Introduces a new test to provide better coverage for the above two issues.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_