### PR TITLE
chore: bump slackapi/slack-github-action [skip ci]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,7 +235,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Send notification
-        uses: slackapi/slack-github-action@v1.18.0
+        uses: slackapi/slack-github-action@v1.24.0
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -140,7 +140,7 @@ project.release.addJobs({
       },
       {
         name: "Send notification",
-        uses: "slackapi/slack-github-action@v1.18.0",
+        uses: "slackapi/slack-github-action@v1.24.0",
         with: {
           payload: `{"html_url": "\${{ steps.get_release.outputs.html_url }}", "tag_name": "\${{ steps.get_release.outputs.tag_name }}"}`,
         },


### PR DESCRIPTION
Addresses the warning:

> 
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: slackapi/slack-github-action@v1.18.0. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

Example run with warning: https://github.com/cdklabs/cdk-monitoring-constructs/actions/runs/5148341475

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_