### PR TITLE
feat(dynamo): add GSI throttling alarms

### DIFF
--- a/API.md
+++ b/API.md
@@ -13087,6 +13087,8 @@ const dynamoTableGlobalSecondaryIndexMonitoringProps: DynamoTableGlobalSecondary
 | <code><a href="#cdk-monitoring-constructs.DynamoTableGlobalSecondaryIndexMonitoringProps.property.addToDetailDashboard">addToDetailDashboard</a></code> | <code>boolean</code> | Flag indicating if the widgets should be added to detailed dashboard. |
 | <code><a href="#cdk-monitoring-constructs.DynamoTableGlobalSecondaryIndexMonitoringProps.property.addToSummaryDashboard">addToSummaryDashboard</a></code> | <code>boolean</code> | Flag indicating if the widgets should be added to summary dashboard. |
 | <code><a href="#cdk-monitoring-constructs.DynamoTableGlobalSecondaryIndexMonitoringProps.property.useCreatedAlarms">useCreatedAlarms</a></code> | <code><a href="#cdk-monitoring-constructs.IAlarmConsumer">IAlarmConsumer</a></code> | Calls provided function to process all alarms created. |
+| <code><a href="#cdk-monitoring-constructs.DynamoTableGlobalSecondaryIndexMonitoringProps.property.addReadThrottledEventsCountAlarm">addReadThrottledEventsCountAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ThrottledEventsThreshold">ThrottledEventsThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.DynamoTableGlobalSecondaryIndexMonitoringProps.property.addWriteThrottledEventsCountAlarm">addWriteThrottledEventsCountAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ThrottledEventsThreshold">ThrottledEventsThreshold</a>}</code> | *No description.* |
 
 ---
 
@@ -13205,6 +13207,26 @@ public readonly useCreatedAlarms: IAlarmConsumer;
 - *Type:* <a href="#cdk-monitoring-constructs.IAlarmConsumer">IAlarmConsumer</a>
 
 Calls provided function to process all alarms created.
+
+---
+
+##### `addReadThrottledEventsCountAlarm`<sup>Optional</sup> <a name="addReadThrottledEventsCountAlarm" id="cdk-monitoring-constructs.DynamoTableGlobalSecondaryIndexMonitoringProps.property.addReadThrottledEventsCountAlarm"></a>
+
+```typescript
+public readonly addReadThrottledEventsCountAlarm: {[ key: string ]: ThrottledEventsThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.ThrottledEventsThreshold">ThrottledEventsThreshold</a>}
+
+---
+
+##### `addWriteThrottledEventsCountAlarm`<sup>Optional</sup> <a name="addWriteThrottledEventsCountAlarm" id="cdk-monitoring-constructs.DynamoTableGlobalSecondaryIndexMonitoringProps.property.addWriteThrottledEventsCountAlarm"></a>
+
+```typescript
+public readonly addWriteThrottledEventsCountAlarm: {[ key: string ]: ThrottledEventsThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.ThrottledEventsThreshold">ThrottledEventsThreshold</a>}
 
 ---
 

--- a/test/monitoring/aws-dynamo/DynamoTableGlobalSecondaryIndexMonitoring.test.ts
+++ b/test/monitoring/aws-dynamo/DynamoTableGlobalSecondaryIndexMonitoring.test.ts
@@ -22,6 +22,16 @@ test("snapshot test: no alarms", () => {
   const monitoring = new DynamoTableGlobalSecondaryIndexMonitoring(scope, {
     table,
     globalSecondaryIndexName: "non-existing-index",
+    addReadThrottledEventsCountAlarm: {
+      Warning: {
+        maxThrottledEventsThreshold: 5,
+      },
+    },
+    addWriteThrottledEventsCountAlarm: {
+      Warning: {
+        maxThrottledEventsThreshold: 5,
+      },
+    },
   });
 
   addMonitoringDashboardsToStack(stack, monitoring);

--- a/test/monitoring/aws-dynamo/__snapshots__/DynamoTableGlobalSecondaryIndexMonitoring.test.ts.snap
+++ b/test/monitoring/aws-dynamo/__snapshots__/DynamoTableGlobalSecondaryIndexMonitoring.test.ts.snap
@@ -12,7 +12,36 @@ Object {
   "Resources": Object {
     "Alarm7103F465": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"widgets\\":[]}",
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestnonexistingindexReadThrottledEventsWarning572114F6",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":6,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestnonexistingindexWriteThrottledEventsWarning2D1BA7C7",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}}]}",
+            ],
+          ],
+        },
       },
       "Type": "AWS::CloudWatch::Dashboard",
     },
@@ -70,12 +99,100 @@ Object {
               Object {
                 "Ref": "TableCD117FA1",
               },
-              "\\",{\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"indexThrottles\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}}]}",
+              "\\",{\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"indexThrottles\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Read > 5 for 3 datapoints within 15 minutes\\",\\"value\\":5,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Write > 5 for 3 datapoints within 15 minutes\\",\\"value\\":5,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}}]}",
             ],
           ],
         },
       },
       "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "ScopeTestnonexistingindexReadThrottledEventsWarning572114F6": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Read throttled events above threshold.",
+        "AlarmName": "Test-non-existing-index-Read-Throttled-Events-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(readThrottles,0)",
+            "Id": "expr_1",
+            "Label": "Read",
+          },
+          Object {
+            "Id": "readThrottles",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "GlobalSecondaryIndexName",
+                    "Value": "non-existing-index",
+                  },
+                  Object {
+                    "Name": "TableName",
+                    "Value": Object {
+                      "Ref": "TableCD117FA1",
+                    },
+                  },
+                ],
+                "MetricName": "ReadThrottleEvents",
+                "Namespace": "AWS/DynamoDB",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 5,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestnonexistingindexWriteThrottledEventsWarning2D1BA7C7": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Write throttled events above threshold.",
+        "AlarmName": "Test-non-existing-index-Write-Throttled-Events-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(writeThrottles,0)",
+            "Id": "expr_1",
+            "Label": "Write",
+          },
+          Object {
+            "Id": "writeThrottles",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "GlobalSecondaryIndexName",
+                    "Value": "non-existing-index",
+                  },
+                  Object {
+                    "Name": "TableName",
+                    "Value": Object {
+                      "Ref": "TableCD117FA1",
+                    },
+                  },
+                ],
+                "MetricName": "WriteThrottleEvents",
+                "Namespace": "AWS/DynamoDB",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 5,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
     },
     "Summary68521F81": Object {
       "Properties": Object {
@@ -131,7 +248,7 @@ Object {
               Object {
                 "Ref": "TableCD117FA1",
               },
-              "\\",{\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"indexThrottles\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}}]}",
+              "\\",{\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"indexThrottles\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Read > 5 for 3 datapoints within 15 minutes\\",\\"value\\":5,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Write > 5 for 3 datapoints within 15 minutes\\",\\"value\\":5,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}}]}",
             ],
           ],
         },


### PR DESCRIPTION
  # Change Info
  GSI throttles can occur at times when the underlying table is not throttled. To notify GSI throttles, I added throttle alarms, adapting the pattern in `DynamoTableMonitoring`.

  # Testing Done
  Besides the package build, I deployed a variation of this change on an AWS stack.
 
  # Backwards Compatibility
  New `DynamoTableGlobalSecondaryIndexMonitoringProps` members are optional, so the change is backward-compatible.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_