### PR TITLE
upgrade @aws-cdk/aws-synthetics-alpha peer dependency to latest.

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "peerDependencies": {
     "@aws-cdk/aws-apigatewayv2-alpha": "^2.65.0-alpha.0",
     "@aws-cdk/aws-redshift-alpha": "^2.65.0-alpha.0",
-    "@aws-cdk/aws-synthetics-alpha": "^2.65.0-alpha.0",
+    "@aws-cdk/aws-synthetics-alpha": "^2.88.0-alpha.0",
     "aws-cdk-lib": "^2.65.0",
     "constructs": "^10.0.5"
   },


### PR DESCRIPTION
Getting following error:

```
Running build command 'run-npm'
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR!
npm ERR! While resolving: cdk-monitoring-constructs@5.3.5
npm ERR! Found: @aws-cdk/aws-synthetics-alpha@2.88.0-alpha.0
npm ERR! node_modules/@aws-cdk/aws-synthetics-alpha
npm ERR!   dev @aws-cdk/aws-synthetics-alpha@"^2.88.0-alpha.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer @aws-cdk/aws-synthetics-alpha@"^2.65.0-alpha.0" from cdk-monitoring-constructs@5.3.5
npm ERR! node_modules/cdk-monitoring-constructs
npm ERR!   peer cdk-monitoring-constructs@"^5.0.0" from <package>@15.0.0
npm ERR!   node_modules/<package>
npm ERR!     dev <package>@"^15.0.0" from the root project
npm ERR!
npm ERR! Conflicting peer dependency: @aws-cdk/aws-synthetics-alpha@2.65.0-alpha.0
npm ERR! node_modules/@aws-cdk/aws-synthetics-alpha
npm ERR!   peer @aws-cdk/aws-synthetics-alpha@"^2.65.0-alpha.0" from cdk-monitoring-constructs@5.3.5
npm ERR!   node_modules/cdk-monitoring-constructs
npm ERR!     peer cdk-monitoring-constructs@"^5.0.0" from <package>@15.0.0
npm ERR!     node_modules/<package>
npm ERR!       dev <package>@"^15.0.0" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR!
npm ERR! For a full report see:
npm ERR! /Users/iainland/.npm/_logs/2023-07-28T20_29_24_009Z-eresolve-report.txt

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/iainland/.npm/_logs/2023-07-28T20_29_24_009Z-debug-0.log
'npm install' exited 1
```

I don't want to downgrade to 2.65, as it does not support newer puppeteer runtimes.
 
e.g. with `2.65` i cannot use: `synthetics.Runtime.SYNTHETICS_NODEJS_PUPPETEER_4_0`