### PR TITLE
feat(apigateway): allow using IRestApi instead of RestApiBase

### DIFF
--- a/API.md
+++ b/API.md
@@ -4257,7 +4257,7 @@ const apiGatewayMetricFactoryProps: ApiGatewayMetricFactoryProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#cdk-monitoring-constructs.ApiGatewayMetricFactoryProps.property.api">api</a></code> | <code>aws-cdk-lib.aws_apigateway.RestApiBase</code> | API to monitor (cannot use IRestApi, since it does not provide API name). |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMetricFactoryProps.property.api">api</a></code> | <code>aws-cdk-lib.aws_apigateway.IRestApi</code> | API to monitor. |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMetricFactoryProps.property.apiMethod">apiMethod</a></code> | <code>string</code> | On undefined value is not set in dimensions. |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMetricFactoryProps.property.apiResource">apiResource</a></code> | <code>string</code> | On undefined value is not set in dimensions. |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMetricFactoryProps.property.apiStage">apiStage</a></code> | <code>string</code> | *No description.* |
@@ -4269,12 +4269,12 @@ const apiGatewayMetricFactoryProps: ApiGatewayMetricFactoryProps = { ... }
 ##### `api`<sup>Required</sup> <a name="api" id="cdk-monitoring-constructs.ApiGatewayMetricFactoryProps.property.api"></a>
 
 ```typescript
-public readonly api: RestApiBase;
+public readonly api: IRestApi;
 ```
 
-- *Type:* aws-cdk-lib.aws_apigateway.RestApiBase
+- *Type:* aws-cdk-lib.aws_apigateway.IRestApi
 
-API to monitor (cannot use IRestApi, since it does not provide API name).
+API to monitor.
 
 ---
 
@@ -4733,7 +4733,7 @@ const apiGatewayMonitoringProps: ApiGatewayMonitoringProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.api">api</a></code> | <code>aws-cdk-lib.aws_apigateway.RestApiBase</code> | API to monitor (cannot use IRestApi, since it does not provide API name). |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.api">api</a></code> | <code>aws-cdk-lib.aws_apigateway.IRestApi</code> | API to monitor. |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.apiMethod">apiMethod</a></code> | <code>string</code> | On undefined value is not set in dimensions. |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.apiResource">apiResource</a></code> | <code>string</code> | On undefined value is not set in dimensions. |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.apiStage">apiStage</a></code> | <code>string</code> | *No description.* |
@@ -4775,12 +4775,12 @@ const apiGatewayMonitoringProps: ApiGatewayMonitoringProps = { ... }
 ##### `api`<sup>Required</sup> <a name="api" id="cdk-monitoring-constructs.ApiGatewayMonitoringProps.property.api"></a>
 
 ```typescript
-public readonly api: RestApiBase;
+public readonly api: IRestApi;
 ```
 
-- *Type:* aws-cdk-lib.aws_apigateway.RestApiBase
+- *Type:* aws-cdk-lib.aws_apigateway.IRestApi
 
-API to monitor (cannot use IRestApi, since it does not provide API name).
+API to monitor.
 
 ---
 

--- a/lib/monitoring/aws-apigateway/ApiGatewayMetricFactory.ts
+++ b/lib/monitoring/aws-apigateway/ApiGatewayMetricFactory.ts
@@ -1,4 +1,4 @@
-import { RestApiBase } from "aws-cdk-lib/aws-apigateway";
+import { IRestApi } from "aws-cdk-lib/aws-apigateway";
 import { DimensionsMap } from "aws-cdk-lib/aws-cloudwatch";
 
 import {
@@ -14,9 +14,9 @@ const ApiGatewayNamespace = "AWS/ApiGateway";
 
 export interface ApiGatewayMetricFactoryProps {
   /**
-   * API to monitor (cannot use IRestApi, since it does not provide API name)
+   * API to monitor
    */
-  readonly api: RestApiBase;
+  readonly api: IRestApi;
   /**
    * @default - prod
    */

--- a/test/monitoring/aws-apigateway/ApiGatewayMonitoring.test.ts
+++ b/test/monitoring/aws-apigateway/ApiGatewayMonitoring.test.ts
@@ -1,6 +1,6 @@
 import { Duration, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { RestApi } from "aws-cdk-lib/aws-apigateway";
+import { IRestApi, RestApi } from "aws-cdk-lib/aws-apigateway";
 
 import { AlarmWithAnnotation, ApiGatewayMonitoring } from "../../../lib";
 import { addMonitoringDashboardsToStack } from "../../utils/SnapshotUtil";
@@ -27,6 +27,160 @@ test("snapshot test: all alarms", () => {
   const stack = new Stack();
   const api = new RestApi(stack, "DummyApi");
   api.root.addMethod("ANY");
+
+  const scope = new TestMonitoringScope(stack, "Scope");
+
+  let numAlarmsCreated = 0;
+
+  const monitoring = new ApiGatewayMonitoring(scope, {
+    api,
+    humanReadableName: "Dummy API Gateway for testing",
+    alarmFriendlyName: "DummyApi",
+    add5XXFaultRateAlarm: {
+      Warning: {
+        maxErrorRate: 1,
+        datapointsToAlarm: 10,
+      },
+    },
+    add5XXFaultCountAlarm: {
+      Warning: {
+        maxErrorCount: 2,
+        datapointsToAlarm: 20,
+      },
+    },
+    add4XXErrorRateAlarm: {
+      Warning: {
+        maxErrorRate: 0.01,
+        datapointsToAlarm: 11,
+      },
+    },
+    add4XXErrorCountAlarm: {
+      Warning: {
+        maxErrorCount: 0.02,
+        datapointsToAlarm: 22,
+      },
+    },
+    addLatencyP50Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(150),
+        datapointsToAlarm: 150,
+      },
+    },
+    addLatencyP70Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(170),
+        datapointsToAlarm: 170,
+      },
+    },
+    addLatencyP90Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(190),
+        datapointsToAlarm: 190,
+      },
+    },
+    addLatencyP95Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(195),
+        datapointsToAlarm: 195,
+      },
+    },
+    addLatencyP99Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(199),
+        datapointsToAlarm: 199,
+      },
+    },
+    addLatencyP999Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(1999),
+        datapointsToAlarm: 1999,
+      },
+    },
+    addLatencyP9999Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(19999),
+        datapointsToAlarm: 19999,
+      },
+    },
+    addLatencyP100Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(1100),
+        datapointsToAlarm: 1100,
+      },
+    },
+    addLatencyTM50Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(250),
+        datapointsToAlarm: 250,
+      },
+    },
+    addLatencyTM70Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(270),
+        datapointsToAlarm: 270,
+      },
+    },
+    addLatencyTM90Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(290),
+        datapointsToAlarm: 290,
+      },
+    },
+    addLatencyTM95Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(295),
+        datapointsToAlarm: 295,
+      },
+    },
+    addLatencyTM99Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(299),
+        datapointsToAlarm: 299,
+      },
+    },
+    addLatencyTM999Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(2999),
+        datapointsToAlarm: 2999,
+      },
+    },
+    addLatencyTM9999Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(29999),
+        datapointsToAlarm: 29999,
+      },
+    },
+    addLatencyAverageAlarm: {
+      Warning: {
+        maxLatency: Duration.millis(20),
+        datapointsToAlarm: 20,
+      },
+    },
+    addLowTpsAlarm: {
+      Warning: { minTps: 1 },
+    },
+    addHighTpsAlarm: {
+      Warning: { maxTps: 10 },
+    },
+    useCreatedAlarms: {
+      consume(alarms: AlarmWithAnnotation[]) {
+        numAlarmsCreated = alarms.length;
+      },
+    },
+  });
+
+  addMonitoringDashboardsToStack(stack, monitoring);
+  expect(numAlarmsCreated).toStrictEqual(22);
+  expect(Template.fromStack(stack)).toMatchSnapshot();
+});
+
+test("snapshot test: all alarms using interface", () => {
+  const stack = new Stack();
+  const api: IRestApi = RestApi.fromRestApiId(
+    stack,
+    "ThisShouldBeTheApiName",
+    "thisIsNotUsed"
+  );
 
   const scope = new TestMonitoringScope(stack, "Scope");
 

--- a/test/monitoring/aws-apigateway/__snapshots__/ApiGatewayMonitoring.test.ts.snap
+++ b/test/monitoring/aws-apigateway/__snapshots__/ApiGatewayMonitoring.test.ts.snap
@@ -1325,6 +1325,1202 @@ Object {
 }
 `;
 
+exports[`snapshot test: all alarms using interface 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "Alarm7103F465": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyApiLatencyP50Warning7EEB3E57",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":6,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyApiLatencyP70Warning56ABF038",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":12,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyApiLatencyP90Warning48639A66",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":18,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyApiLatencyP95Warning450538DF",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":0,\\"y\\":4,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyApiLatencyP99Warning254DA12C",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":6,\\"y\\":4,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyApiLatencyP999Warning8CF0377D",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":12,\\"y\\":4,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyApiLatencyP9999Warning89E47C72",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":18,\\"y\\":4,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyApiLatencyP100WarningB48A5E64",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":0,\\"y\\":8,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyApiLatencyTM50Warning092E86BF",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":6,\\"y\\":8,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyApiLatencyTM70Warning8E657453",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":12,\\"y\\":8,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyApiLatencyTM90Warning0FDD3108",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":18,\\"y\\":8,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyApiLatencyTM95WarningFFD46CB8",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":0,\\"y\\":12,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyApiLatencyTM99WarningFF55C464",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":6,\\"y\\":12,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyApiLatencyTM999WarningD73972C6",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":12,\\"y\\":12,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyApiLatencyTM9999Warning4181DE97",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":18,\\"y\\":12,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyApiLatencyAverageWarning27D59767",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":0,\\"y\\":16,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyApiFaultCountWarning6270BEC0",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":6,\\"y\\":16,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyApiErrorCountWarning11BE36AF",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":12,\\"y\\":16,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyApiErrorRateWarningD181D1C6",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":18,\\"y\\":16,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyApiFaultRateWarning63CFB7F0",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":0,\\"y\\":20,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyApiMinTPSWarning4E8DB4D0",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":6,\\"y\\":20,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyApiMaxTPSWarning62732F2B",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "Resource": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### API Gateway Endpoint **Dummy API Gateway for testing**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Count/s\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\"}],[\\"AWS/ApiGateway\\",\\"Count\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"Count\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Count/s < 1 for 3 datapoints within 15 minutes\\",\\"value\\":1,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Count/s > 10 for 3 datapoints within 15 minutes\\",\\"value\\":10,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"Average\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P100 (avg: \${AVG})\\",\\"stat\\":\\"p100\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"stat\\":\\"p50\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P70 (avg: \${AVG})\\",\\"stat\\":\\"p70\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P90 (avg: \${AVG})\\",\\"stat\\":\\"p90\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P95 (avg: \${AVG})\\",\\"stat\\":\\"p95\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P99 (avg: \${AVG})\\",\\"stat\\":\\"p99\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P99.9 (avg: \${AVG})\\",\\"stat\\":\\"p99.9\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P99.99 (avg: \${AVG})\\",\\"stat\\":\\"p99.99\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"TM50 (avg: \${AVG})\\",\\"stat\\":\\"tm50\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"TM70 (avg: \${AVG})\\",\\"stat\\":\\"tm70\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"TM90 (avg: \${AVG})\\",\\"stat\\":\\"tm90\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"TM95 (avg: \${AVG})\\",\\"stat\\":\\"tm95\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"TM99 (avg: \${AVG})\\",\\"stat\\":\\"tm99\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"TM99.9 (avg: \${AVG})\\",\\"stat\\":\\"tm99.9\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"TM99.99 (avg: \${AVG})\\",\\"stat\\":\\"tm99.99\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"P50 > 150 for 150 datapoints within 750 minutes\\",\\"value\\":150,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"P70 > 170 for 170 datapoints within 850 minutes\\",\\"value\\":170,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"P90 > 190 for 190 datapoints within 950 minutes\\",\\"value\\":190,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"P95 > 195 for 195 datapoints within 975 minutes\\",\\"value\\":195,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"P99 > 199 for 199 datapoints within 995 minutes\\",\\"value\\":199,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"P99.9 > 1999 for 1999 datapoints within 9995 minutes\\",\\"value\\":1999,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"P99.99 > 19999 for 19999 datapoints within 99995 minutes\\",\\"value\\":19999,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"P100 > 1100 for 1100 datapoints within 5500 minutes\\",\\"value\\":1100,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TM50 > 250 for 250 datapoints within 1250 minutes\\",\\"value\\":250,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TM70 > 270 for 270 datapoints within 1350 minutes\\",\\"value\\":270,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TM90 > 290 for 290 datapoints within 1450 minutes\\",\\"value\\":290,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TM95 > 295 for 295 datapoints within 1475 minutes\\",\\"value\\":295,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TM99 > 299 for 299 datapoints within 1495 minutes\\",\\"value\\":299,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TM99.9 > 2999 for 2999 datapoints within 14995 minutes\\",\\"value\\":2999,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TM99.99 > 29999 for 29999 datapoints within 149995 minutes\\",\\"value\\":29999,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Average > 20 for 20 datapoints within 100 minutes\\",\\"value\\":20,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"4XXError\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"4XX Error\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/ApiGateway\\",\\"5XXError\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"5XX Fault\\",\\"stat\\":\\"Sum\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"5XX Fault > 2 for 20 datapoints within 100 minutes\\",\\"value\\":2,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"4XX Error > 0.02 for 22 datapoints within 110 minutes\\",\\"value\\":0.02,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"4XXError\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"4XX Error (avg)\\"}],[\\"AWS/ApiGateway\\",\\"5XXError\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"5XX Fault (avg)\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"4XX Error (avg) > 0.01 for 11 datapoints within 55 minutes\\",\\"value\\":0.01,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"5XX Fault (avg) > 1 for 10 datapoints within 50 minutes\\",\\"value\\":1,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "ScopeTestDummyApiErrorCountWarning11BE36AF": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Error count is too high.",
+        "AlarmName": "Test-DummyApi-Error-Count-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 22,
+        "EvaluationPeriods": 22,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "4XX Error",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ThisShouldBeTheApiName",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "4XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.02,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiErrorRateWarningD181D1C6": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Error rate is too high.",
+        "AlarmName": "Test-DummyApi-Error-Rate-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 11,
+        "EvaluationPeriods": 11,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "4XX Error (avg)",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ThisShouldBeTheApiName",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "4XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.01,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiFaultCountWarning6270BEC0": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Fault count is too high.",
+        "AlarmName": "Test-DummyApi-Fault-Count-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 20,
+        "EvaluationPeriods": 20,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "5XX Fault",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ThisShouldBeTheApiName",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 2,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiFaultRateWarning63CFB7F0": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Fault rate is too high.",
+        "AlarmName": "Test-DummyApi-Fault-Rate-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 10,
+        "EvaluationPeriods": 10,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "5XX Fault (avg)",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ThisShouldBeTheApiName",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyAverageWarning27D59767": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Average latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-Average-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 20,
+        "EvaluationPeriods": 20,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Average",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ThisShouldBeTheApiName",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 20,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyP100WarningB48A5E64": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P100 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-P100-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1100,
+        "EvaluationPeriods": 1100,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P100",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ThisShouldBeTheApiName",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p100",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 1100,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyP50Warning7EEB3E57": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P50 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-P50-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 150,
+        "EvaluationPeriods": 150,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P50",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ThisShouldBeTheApiName",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p50",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 150,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyP70Warning56ABF038": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P70 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-P70-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 170,
+        "EvaluationPeriods": 170,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P70",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ThisShouldBeTheApiName",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p70",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 170,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyP90Warning48639A66": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P90 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-P90-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 190,
+        "EvaluationPeriods": 190,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P90",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ThisShouldBeTheApiName",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p90",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 190,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyP95Warning450538DF": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P95 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-P95-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 195,
+        "EvaluationPeriods": 195,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P95",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ThisShouldBeTheApiName",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p95",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 195,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyP9999Warning89E47C72": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P9999 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-P9999-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 19999,
+        "EvaluationPeriods": 19999,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P99.99",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ThisShouldBeTheApiName",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p99.99",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 19999,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyP999Warning8CF0377D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P999 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-P999-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 1999,
+        "EvaluationPeriods": 1999,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P99.9",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ThisShouldBeTheApiName",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p99.9",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 1999,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyP99Warning254DA12C": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P99 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-P99-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 199,
+        "EvaluationPeriods": 199,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P99",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ThisShouldBeTheApiName",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p99",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 199,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyTM50Warning092E86BF": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM50 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-TM50-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 250,
+        "EvaluationPeriods": 250,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM50",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ThisShouldBeTheApiName",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm50",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 250,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyTM70Warning8E657453": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM70 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-TM70-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 270,
+        "EvaluationPeriods": 270,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM70",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ThisShouldBeTheApiName",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm70",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 270,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyTM90Warning0FDD3108": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM90 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-TM90-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 290,
+        "EvaluationPeriods": 290,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM90",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ThisShouldBeTheApiName",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm90",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 290,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyTM95WarningFFD46CB8": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM95 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-TM95-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 295,
+        "EvaluationPeriods": 295,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM95",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ThisShouldBeTheApiName",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm95",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 295,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyTM9999Warning4181DE97": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM9999 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-TM9999-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 29999,
+        "EvaluationPeriods": 29999,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM99.99",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ThisShouldBeTheApiName",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm99.99",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 29999,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyTM999WarningD73972C6": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM999 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-TM999-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 2999,
+        "EvaluationPeriods": 2999,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM99.9",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ThisShouldBeTheApiName",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm99.9",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 2999,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiLatencyTM99WarningFF55C464": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM99 latency is too high.",
+        "AlarmName": "Test-DummyApi-Latency-TM99-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 299,
+        "EvaluationPeriods": 299,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM99",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ThisShouldBeTheApiName",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "tm99",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 299,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiMaxTPSWarning62732F2B": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TPS is too high.",
+        "AlarmName": "Test-DummyApi-MaxTPS-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Count/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Count",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ThisShouldBeTheApiName",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 10,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyApiMinTPSWarning4E8DB4D0": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TPS is too low.",
+        "AlarmName": "Test-DummyApi-MinTPS-Warning",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Count/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Count",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ThisShouldBeTheApiName",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "Summary68521F81": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### API Gateway Endpoint **Dummy API Gateway for testing**\\"}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Count/s\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\"}],[\\"AWS/ApiGateway\\",\\"Count\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"Count\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Count/s < 1 for 3 datapoints within 15 minutes\\",\\"value\\":1,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Count/s > 10 for 3 datapoints within 15 minutes\\",\\"value\\":10,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"Average\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P100 (avg: \${AVG})\\",\\"stat\\":\\"p100\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"stat\\":\\"p50\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P70 (avg: \${AVG})\\",\\"stat\\":\\"p70\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P90 (avg: \${AVG})\\",\\"stat\\":\\"p90\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P95 (avg: \${AVG})\\",\\"stat\\":\\"p95\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P99 (avg: \${AVG})\\",\\"stat\\":\\"p99\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P99.9 (avg: \${AVG})\\",\\"stat\\":\\"p99.9\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P99.99 (avg: \${AVG})\\",\\"stat\\":\\"p99.99\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"TM50 (avg: \${AVG})\\",\\"stat\\":\\"tm50\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"TM70 (avg: \${AVG})\\",\\"stat\\":\\"tm70\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"TM90 (avg: \${AVG})\\",\\"stat\\":\\"tm90\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"TM95 (avg: \${AVG})\\",\\"stat\\":\\"tm95\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"TM99 (avg: \${AVG})\\",\\"stat\\":\\"tm99\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"TM99.9 (avg: \${AVG})\\",\\"stat\\":\\"tm99.9\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"TM99.99 (avg: \${AVG})\\",\\"stat\\":\\"tm99.99\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"P50 > 150 for 150 datapoints within 750 minutes\\",\\"value\\":150,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"P70 > 170 for 170 datapoints within 850 minutes\\",\\"value\\":170,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"P90 > 190 for 190 datapoints within 950 minutes\\",\\"value\\":190,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"P95 > 195 for 195 datapoints within 975 minutes\\",\\"value\\":195,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"P99 > 199 for 199 datapoints within 995 minutes\\",\\"value\\":199,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"P99.9 > 1999 for 1999 datapoints within 9995 minutes\\",\\"value\\":1999,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"P99.99 > 19999 for 19999 datapoints within 99995 minutes\\",\\"value\\":19999,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"P100 > 1100 for 1100 datapoints within 5500 minutes\\",\\"value\\":1100,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TM50 > 250 for 250 datapoints within 1250 minutes\\",\\"value\\":250,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TM70 > 270 for 270 datapoints within 1350 minutes\\",\\"value\\":270,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TM90 > 290 for 290 datapoints within 1450 minutes\\",\\"value\\":290,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TM95 > 295 for 295 datapoints within 1475 minutes\\",\\"value\\":295,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TM99 > 299 for 299 datapoints within 1495 minutes\\",\\"value\\":299,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TM99.9 > 2999 for 2999 datapoints within 14995 minutes\\",\\"value\\":2999,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TM99.99 > 29999 for 29999 datapoints within 149995 minutes\\",\\"value\\":29999,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Average > 20 for 20 datapoints within 100 minutes\\",\\"value\\":20,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"4XXError\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"4XX Error (avg)\\"}],[\\"AWS/ApiGateway\\",\\"5XXError\\",\\"ApiName\\",\\"ThisShouldBeTheApiName\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"5XX Fault (avg)\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"4XX Error (avg) > 0.01 for 11 datapoints within 55 minutes\\",\\"value\\":0.01,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"5XX Fault (avg) > 1 for 10 datapoints within 50 minutes\\",\\"value\\":1,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`snapshot test: no alarms 1`] = `
 Object {
   "Outputs": Object {


### PR DESCRIPTION
As of 2.90.0 aws-cdk now supports restApiName in the IRestApi interface. By using this interface it becomes possible for developers to monitor APIGateway without the need to reference the actual RestAPI.

Related commit: https://github.com/aws/aws-cdk/commit/3bf1361e20e2b2d497fcc2197fa45dac91e7eee3

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_