### PR TITLE
fix(step-functions): better infer name from Lambda function

### DIFF
--- a/lib/monitoring/aws-step-functions/StepFunctionLambdaIntegrationMonitoring.ts
+++ b/lib/monitoring/aws-step-functions/StepFunctionLambdaIntegrationMonitoring.ts
@@ -3,6 +3,7 @@ import {
   HorizontalAnnotation,
   IWidget,
 } from "aws-cdk-lib/aws-cloudwatch";
+import { IFunction, CfnFunction } from "aws-cdk-lib/aws-lambda";
 
 import {
   StepFunctionLambdaIntegrationMetricFactory,
@@ -71,10 +72,10 @@ export class StepFunctionLambdaIntegrationMonitoring extends Monitoring {
   ) {
     super(scope, props);
 
-    const fallbackConstructName = props.lambdaFunction.functionName;
     const namingStrategy = new MonitoringNamingStrategy({
       ...props,
-      fallbackConstructName,
+      namedConstruct: props.lambdaFunction,
+      fallbackConstructName: this.resolveFunctionName(props.lambdaFunction),
     });
     this.title = namingStrategy.resolveHumanReadableName();
     this.functionUrl = scope
@@ -259,5 +260,10 @@ export class StepFunctionLambdaIntegrationMonitoring extends Monitoring {
         leftAnnotations: this.errorRateAnnotations,
       }),
     ];
+  }
+
+  private resolveFunctionName(lambdaFunction: IFunction): string | undefined {
+    // try to take the name (if specified) instead of token
+    return (lambdaFunction.node.defaultChild as CfnFunction)?.functionName;
   }
 }

--- a/test/monitoring/aws-step-functions/__snapshots__/StepFunctionLambdaIntegrationMonitoring.test.ts.snap
+++ b/test/monitoring/aws-step-functions/__snapshots__/StepFunctionLambdaIntegrationMonitoring.test.ts.snap
@@ -146,7 +146,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### States Lambda Integration **[DummyLambdaIntegration](https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/functions/",
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### States Lambda Integration **[DummyLambda](https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/functions/",
               Object {
                 "Ref": "Function76856677",
               },
@@ -472,7 +472,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### States Lambda Integration **[DummyLambdaIntegration](https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/functions/",
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### States Lambda Integration **[DummyLambda](https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/functions/",
               Object {
                 "Ref": "Function76856677",
               },
@@ -651,7 +651,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### States Lambda Integration **[DummyLambdaIntegration](https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/functions/",
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### States Lambda Integration **[DummyLambda](https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/functions/",
               Object {
                 "Ref": "Function76856677",
               },
@@ -743,7 +743,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### States Lambda Integration **[DummyLambdaIntegration](https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/functions/",
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### States Lambda Integration **[DummyLambda](https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/functions/",
               Object {
                 "Ref": "Function76856677",
               },


### PR DESCRIPTION
Fixes #274

Use the same strategy that [we use for vanilla Lambda](https://github.com/cdklabs/cdk-monitoring-constructs/blob/cec84dba29fa60d55fcbc23ae71d13c32246182d/lib/monitoring/aws-lambda/LambdaFunctionMonitoring.ts#L169).

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_