### PR TITLE
fix: correct typo in README.md [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ export class MonitoringStack extends DeploymentStack {
 
 ### Customize actions
 
-Alarms should have an action setup, otherwise they are not very useful. Currently, we support notifying an SNS queue.
+Alarms should have an action setup, otherwise they are not very useful. Currently, we support notifying an SNS Topic.
 
 ```ts
 const onAlarmTopic = new Topic(this, "AlarmTopic");

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ export class MonitoringStack extends DeploymentStack {
 
 ### Customize actions
 
-Alarms should have an action setup, otherwise they are not very useful. Currently, we support notifying an SNS Topic.
+Alarms should have an action setup, otherwise they are not very useful. Currently, we support notifying an SNS topic.
 
 ```ts
 const onAlarmTopic = new Topic(this, "AlarmTopic");


### PR DESCRIPTION
Fixes typo in documentation in README.md

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_