### PR TITLE
feat: upgrade bitmap widget rendering Lambda to Node.js 18

### DIFF
--- a/lib/dashboard/widget/BitmapWidget.ts
+++ b/lib/dashboard/widget/BitmapWidget.ts
@@ -34,7 +34,7 @@ export class BitmapWidgetRenderingSupport extends Construct {
         "Custom Widget Render for Bitmap Widgets (MonitoringCDKConstructs)",
       handler: "index.handler",
       memorySize: 128,
-      runtime: Runtime.NODEJS_14_X,
+      runtime: Runtime.NODEJS_18_X,
       timeout: Duration.seconds(60),
       logRetention: RetentionDays.ONE_DAY,
     });

--- a/test/dashboard/widget/__snapshots__/BitmapWidget.test.ts.snap
+++ b/test/dashboard/widget/__snapshots__/BitmapWidget.test.ts.snap
@@ -109,7 +109,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Tags": Array [
           Object {
             "Key": "cw-custom-widget",


### PR DESCRIPTION
Addresses the first of two Lambda functions for #393.

Tested successfully in a dev account configured with bitmap dashboards (i.e. with `renderingPreference: DashboardRenderingPreference.INTERACTIVE_AND_BITMAP)`.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_