### PR TITLE
chore: add security policy doc [skip ci]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,9 +63,5 @@ For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of
 opensource-codeofconduct@amazon.com with any additional questions or comments.
 
 
-## Security issue notifications
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public GitHub issue.
-
-
 ## Licensing
 See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.

--- a/README.md
+++ b/README.md
@@ -416,9 +416,14 @@ monitoring.monitorScope(stack, {
 ```
 
 
-## Contributing/Security
+## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for more information.
+
+
+## Security policy
+
+See [SECURITY](SECURITY.md) for more information.
 
 
 ## License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Supported Versions
+
+We only provide support for the latest version of the library.
+
+## Reporting a Vulnerability
+
+If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/).
+
+Please do **not** create a public GitHub issue.


### PR DESCRIPTION
Adding doc in standardized GitHub location so it's easily discoverable in the main project view.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_