### PR TITLE
feat(elasticache): monitor Redis engine CPU utilization

### DIFF
--- a/API.md
+++ b/API.md
@@ -16083,11 +16083,12 @@ const elastiCacheClusterMonitoringOptions: ElastiCacheClusterMonitoringOptions =
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoringOptions.property.addToSummaryDashboard">addToSummaryDashboard</a></code> | <code>boolean</code> | Flag indicating if the widgets should be added to summary dashboard. |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoringOptions.property.useCreatedAlarms">useCreatedAlarms</a></code> | <code><a href="#cdk-monitoring-constructs.IAlarmConsumer">IAlarmConsumer</a></code> | Calls provided function to process all alarms created. |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoringOptions.property.clusterType">clusterType</a></code> | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterType">ElastiCacheClusterType</a></code> | Cluster type (needed, since each type has their own specific metrics). |
-| <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoringOptions.property.addCpuUsageAlarm">addCpuUsageAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.UsageThreshold">UsageThreshold</a>}</code> | Add CPU usage alarm. |
+| <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoringOptions.property.addCpuUsageAlarm">addCpuUsageAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.UsageThreshold">UsageThreshold</a>}</code> | Add CPU usage alarm (useful for all clusterTypes including Redis). |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoringOptions.property.addMaxEvictedItemsCountAlarm">addMaxEvictedItemsCountAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.MaxItemsCountThreshold">MaxItemsCountThreshold</a>}</code> | Add alarm on number of evicted items. |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoringOptions.property.addMaxItemsCountAlarm">addMaxItemsCountAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.MaxItemsCountThreshold">MaxItemsCountThreshold</a>}</code> | Add alarm on total number of items. |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoringOptions.property.addMaxUsedSwapMemoryAlarm">addMaxUsedSwapMemoryAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.MaxUsedSwapMemoryThreshold">MaxUsedSwapMemoryThreshold</a>}</code> | Add alarm on amount of used swap memory. |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoringOptions.property.addMinFreeableMemoryAlarm">addMinFreeableMemoryAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.MinFreeableMemoryThreshold">MinFreeableMemoryThreshold</a>}</code> | Add alarm on amount of freeable memory. |
+| <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoringOptions.property.addRedisEngineCpuUsageAlarm">addRedisEngineCpuUsageAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.UsageThreshold">UsageThreshold</a>}</code> | Add Redis engine CPU usage alarm. |
 
 ---
 
@@ -16209,7 +16210,7 @@ public readonly addCpuUsageAlarm: {[ key: string ]: UsageThreshold};
 
 - *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.UsageThreshold">UsageThreshold</a>}
 
-Add CPU usage alarm.
+Add CPU usage alarm (useful for all clusterTypes including Redis).
 
 ---
 
@@ -16261,6 +16262,21 @@ Add alarm on amount of freeable memory.
 
 ---
 
+##### `addRedisEngineCpuUsageAlarm`<sup>Optional</sup> <a name="addRedisEngineCpuUsageAlarm" id="cdk-monitoring-constructs.ElastiCacheClusterMonitoringOptions.property.addRedisEngineCpuUsageAlarm"></a>
+
+```typescript
+public readonly addRedisEngineCpuUsageAlarm: {[ key: string ]: UsageThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.UsageThreshold">UsageThreshold</a>}
+
+Add Redis engine CPU usage alarm.
+
+It is recommended to monitor CPU utilization with `addCpuUsageAlarm` 
+as well for hosts with two vCPUs or less.
+
+---
+
 ### ElastiCacheClusterMonitoringProps <a name="ElastiCacheClusterMonitoringProps" id="cdk-monitoring-constructs.ElastiCacheClusterMonitoringProps"></a>
 
 #### Initializer <a name="Initializer" id="cdk-monitoring-constructs.ElastiCacheClusterMonitoringProps.Initializer"></a>
@@ -16284,11 +16300,12 @@ const elastiCacheClusterMonitoringProps: ElastiCacheClusterMonitoringProps = { .
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoringProps.property.addToSummaryDashboard">addToSummaryDashboard</a></code> | <code>boolean</code> | Flag indicating if the widgets should be added to summary dashboard. |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoringProps.property.useCreatedAlarms">useCreatedAlarms</a></code> | <code><a href="#cdk-monitoring-constructs.IAlarmConsumer">IAlarmConsumer</a></code> | Calls provided function to process all alarms created. |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoringProps.property.clusterType">clusterType</a></code> | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterType">ElastiCacheClusterType</a></code> | Cluster type (needed, since each type has their own specific metrics). |
-| <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoringProps.property.addCpuUsageAlarm">addCpuUsageAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.UsageThreshold">UsageThreshold</a>}</code> | Add CPU usage alarm. |
+| <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoringProps.property.addCpuUsageAlarm">addCpuUsageAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.UsageThreshold">UsageThreshold</a>}</code> | Add CPU usage alarm (useful for all clusterTypes including Redis). |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoringProps.property.addMaxEvictedItemsCountAlarm">addMaxEvictedItemsCountAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.MaxItemsCountThreshold">MaxItemsCountThreshold</a>}</code> | Add alarm on number of evicted items. |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoringProps.property.addMaxItemsCountAlarm">addMaxItemsCountAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.MaxItemsCountThreshold">MaxItemsCountThreshold</a>}</code> | Add alarm on total number of items. |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoringProps.property.addMaxUsedSwapMemoryAlarm">addMaxUsedSwapMemoryAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.MaxUsedSwapMemoryThreshold">MaxUsedSwapMemoryThreshold</a>}</code> | Add alarm on amount of used swap memory. |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoringProps.property.addMinFreeableMemoryAlarm">addMinFreeableMemoryAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.MinFreeableMemoryThreshold">MinFreeableMemoryThreshold</a>}</code> | Add alarm on amount of freeable memory. |
+| <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoringProps.property.addRedisEngineCpuUsageAlarm">addRedisEngineCpuUsageAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.UsageThreshold">UsageThreshold</a>}</code> | Add Redis engine CPU usage alarm. |
 
 ---
 
@@ -16423,7 +16440,7 @@ public readonly addCpuUsageAlarm: {[ key: string ]: UsageThreshold};
 
 - *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.UsageThreshold">UsageThreshold</a>}
 
-Add CPU usage alarm.
+Add CPU usage alarm (useful for all clusterTypes including Redis).
 
 ---
 
@@ -16472,6 +16489,21 @@ public readonly addMinFreeableMemoryAlarm: {[ key: string ]: MinFreeableMemoryTh
 - *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.MinFreeableMemoryThreshold">MinFreeableMemoryThreshold</a>}
 
 Add alarm on amount of freeable memory.
+
+---
+
+##### `addRedisEngineCpuUsageAlarm`<sup>Optional</sup> <a name="addRedisEngineCpuUsageAlarm" id="cdk-monitoring-constructs.ElastiCacheClusterMonitoringProps.property.addRedisEngineCpuUsageAlarm"></a>
+
+```typescript
+public readonly addRedisEngineCpuUsageAlarm: {[ key: string ]: UsageThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.UsageThreshold">UsageThreshold</a>}
+
+Add Redis engine CPU usage alarm.
+
+It is recommended to monitor CPU utilization with `addCpuUsageAlarm` 
+as well for hosts with two vCPUs or less.
 
 ---
 
@@ -51570,6 +51602,7 @@ new ElastiCacheClusterMetricFactory(metricFactory: MetricFactory, props: ElastiC
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMetricFactory.metricEvictions">metricEvictions</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMetricFactory.metricMaxCpuUtilizationInPercent">metricMaxCpuUtilizationInPercent</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMetricFactory.metricMaxItemCount">metricMaxItemCount</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMetricFactory.metricMaxRedisEngineCpuUtilizationInPercent">metricMaxRedisEngineCpuUtilizationInPercent</a></code> | Because Redis is single-threaded, you can use this metric to analyze the load of the Redis process itself. |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMetricFactory.metricNetworkBytesIn">metricNetworkBytesIn</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMetricFactory.metricNetworkBytesOut">metricNetworkBytesOut</a></code> | *No description.* |
 
@@ -51622,6 +51655,20 @@ public metricMaxCpuUtilizationInPercent(): Metric | MathExpression
 ```typescript
 public metricMaxItemCount(): Metric | MathExpression
 ```
+
+##### `metricMaxRedisEngineCpuUtilizationInPercent` <a name="metricMaxRedisEngineCpuUtilizationInPercent" id="cdk-monitoring-constructs.ElastiCacheClusterMetricFactory.metricMaxRedisEngineCpuUtilizationInPercent"></a>
+
+```typescript
+public metricMaxRedisEngineCpuUtilizationInPercent(): Metric | MathExpression
+```
+
+Because Redis is single-threaded, you can use this metric to analyze the load of the Redis process itself.
+
+Note that you may want to monitor both Engine CPU Utilization as well as CPU Utilization as background
+processes can take up a significant portion of the CPU workload. This is especially important for 
+hosts with 2 vCPUs or less.
+
+> [https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheMetrics.Redis.html](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheMetrics.Redis.html)
 
 ##### `metricNetworkBytesIn` <a name="metricNetworkBytesIn" id="cdk-monitoring-constructs.ElastiCacheClusterMetricFactory.metricNetworkBytesIn"></a>
 
@@ -51684,6 +51731,7 @@ new ElastiCacheClusterMonitoring(scope: MonitoringScope, props: ElastiCacheClust
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoring.createCpuUsageWidget">createCpuUsageWidget</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoring.createItemCountWidget">createItemCountWidget</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoring.createMemoryUsageWidget">createMemoryUsageWidget</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoring.createRedisEngineCpuUsageWidget">createRedisEngineCpuUsageWidget</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoring.createTitleWidget">createTitleWidget</a></code> | *No description.* |
 
 ---
@@ -51858,6 +51906,24 @@ public createMemoryUsageWidget(width: number, height: number): GraphWidget
 
 ---
 
+##### `createRedisEngineCpuUsageWidget` <a name="createRedisEngineCpuUsageWidget" id="cdk-monitoring-constructs.ElastiCacheClusterMonitoring.createRedisEngineCpuUsageWidget"></a>
+
+```typescript
+public createRedisEngineCpuUsageWidget(width: number, height: number): GraphWidget
+```
+
+###### `width`<sup>Required</sup> <a name="width" id="cdk-monitoring-constructs.ElastiCacheClusterMonitoring.createRedisEngineCpuUsageWidget.parameter.width"></a>
+
+- *Type:* number
+
+---
+
+###### `height`<sup>Required</sup> <a name="height" id="cdk-monitoring-constructs.ElastiCacheClusterMonitoring.createRedisEngineCpuUsageWidget.parameter.height"></a>
+
+- *Type:* number
+
+---
+
 ##### `createTitleWidget` <a name="createTitleWidget" id="cdk-monitoring-constructs.ElastiCacheClusterMonitoring.createTitleWidget"></a>
 
 ```typescript
@@ -51869,6 +51935,7 @@ public createTitleWidget(): MonitoringHeaderWidget
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoring.property.clusterType">clusterType</a></code> | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterType">ElastiCacheClusterType</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoring.property.connectionsMetric">connectionsMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoring.property.cpuUsageAnnotations">cpuUsageAnnotations</a></code> | <code>aws-cdk-lib.aws_cloudwatch.HorizontalAnnotation[]</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoring.property.cpuUsageMetric">cpuUsageMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
@@ -51880,11 +51947,23 @@ public createTitleWidget(): MonitoringHeaderWidget
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoring.property.itemsEvictedMetrics">itemsEvictedMetrics</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoring.property.itemsMemoryMetric">itemsMemoryMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoring.property.memoryUsageAnnotations">memoryUsageAnnotations</a></code> | <code>aws-cdk-lib.aws_cloudwatch.HorizontalAnnotation[]</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoring.property.redisEngineCpuUsageAnnotations">redisEngineCpuUsageAnnotations</a></code> | <code>aws-cdk-lib.aws_cloudwatch.HorizontalAnnotation[]</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoring.property.redisEngineCpuUsageMetric">redisEngineCpuUsageMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoring.property.swapMemoryMetric">swapMemoryMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoring.property.title">title</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoring.property.unusedMemoryMetric">unusedMemoryMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoring.property.usageAlarmFactory">usageAlarmFactory</a></code> | <code><a href="#cdk-monitoring-constructs.UsageAlarmFactory">UsageAlarmFactory</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ElastiCacheClusterMonitoring.property.clusterUrl">clusterUrl</a></code> | <code>string</code> | *No description.* |
+
+---
+
+##### `clusterType`<sup>Required</sup> <a name="clusterType" id="cdk-monitoring-constructs.ElastiCacheClusterMonitoring.property.clusterType"></a>
+
+```typescript
+public readonly clusterType: ElastiCacheClusterType;
+```
+
+- *Type:* <a href="#cdk-monitoring-constructs.ElastiCacheClusterType">ElastiCacheClusterType</a>
 
 ---
 
@@ -51995,6 +52074,26 @@ public readonly memoryUsageAnnotations: HorizontalAnnotation[];
 ```
 
 - *Type:* aws-cdk-lib.aws_cloudwatch.HorizontalAnnotation[]
+
+---
+
+##### `redisEngineCpuUsageAnnotations`<sup>Required</sup> <a name="redisEngineCpuUsageAnnotations" id="cdk-monitoring-constructs.ElastiCacheClusterMonitoring.property.redisEngineCpuUsageAnnotations"></a>
+
+```typescript
+public readonly redisEngineCpuUsageAnnotations: HorizontalAnnotation[];
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.HorizontalAnnotation[]
+
+---
+
+##### `redisEngineCpuUsageMetric`<sup>Required</sup> <a name="redisEngineCpuUsageMetric" id="cdk-monitoring-constructs.ElastiCacheClusterMonitoring.property.redisEngineCpuUsageMetric"></a>
+
+```typescript
+public readonly redisEngineCpuUsageMetric: Metric | MathExpression;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.Metric | aws-cdk-lib.aws_cloudwatch.MathExpression
 
 ---
 
@@ -66540,7 +66639,7 @@ new UsageAlarmFactory(alarmFactory: AlarmFactory)
 ##### `addMaxCpuUsagePercentAlarm` <a name="addMaxCpuUsagePercentAlarm" id="cdk-monitoring-constructs.UsageAlarmFactory.addMaxCpuUsagePercentAlarm"></a>
 
 ```typescript
-public addMaxCpuUsagePercentAlarm(percentMetric: Metric | MathExpression, props: UsageThreshold, disambiguator?: string, usageType?: UsageType): AlarmWithAnnotation
+public addMaxCpuUsagePercentAlarm(percentMetric: Metric | MathExpression, props: UsageThreshold, disambiguator?: string, usageType?: UsageType, additionalAlarmNameSuffix?: string): AlarmWithAnnotation
 ```
 
 ###### `percentMetric`<sup>Required</sup> <a name="percentMetric" id="cdk-monitoring-constructs.UsageAlarmFactory.addMaxCpuUsagePercentAlarm.parameter.percentMetric"></a>
@@ -66564,6 +66663,12 @@ public addMaxCpuUsagePercentAlarm(percentMetric: Metric | MathExpression, props:
 ###### `usageType`<sup>Optional</sup> <a name="usageType" id="cdk-monitoring-constructs.UsageAlarmFactory.addMaxCpuUsagePercentAlarm.parameter.usageType"></a>
 
 - *Type:* <a href="#cdk-monitoring-constructs.UsageType">UsageType</a>
+
+---
+
+###### `additionalAlarmNameSuffix`<sup>Optional</sup> <a name="additionalAlarmNameSuffix" id="cdk-monitoring-constructs.UsageAlarmFactory.addMaxCpuUsagePercentAlarm.parameter.additionalAlarmNameSuffix"></a>
+
+- *Type:* string
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -16536,7 +16536,7 @@ public readonly addRedisEngineCpuUsageAlarm: {[ key: string ]: UsageThreshold};
 
 Add Redis engine CPU usage alarm.
 
-It is recommended to monitor CPU utilization with `addCpuUsageAlarm` 
+It is recommended to monitor CPU utilization with `addCpuUsageAlarm`
 as well for hosts with two vCPUs or less.
 
 ---
@@ -16766,7 +16766,7 @@ public readonly addRedisEngineCpuUsageAlarm: {[ key: string ]: UsageThreshold};
 
 Add Redis engine CPU usage alarm.
 
-It is recommended to monitor CPU utilization with `addCpuUsageAlarm` 
+It is recommended to monitor CPU utilization with `addCpuUsageAlarm`
 as well for hosts with two vCPUs or less.
 
 ---
@@ -51929,7 +51929,7 @@ public metricMaxRedisEngineCpuUtilizationInPercent(): Metric | MathExpression
 Because Redis is single-threaded, you can use this metric to analyze the load of the Redis process itself.
 
 Note that you may want to monitor both Engine CPU Utilization as well as CPU Utilization as background
-processes can take up a significant portion of the CPU workload. This is especially important for 
+processes can take up a significant portion of the CPU workload. This is especially important for
 hosts with 2 vCPUs or less.
 
 > [https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheMetrics.Redis.html](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheMetrics.Redis.html)

--- a/lib/common/monitoring/alarms/UsageAlarmFactory.ts
+++ b/lib/common/monitoring/alarms/UsageAlarmFactory.ts
@@ -67,7 +67,9 @@ export class UsageAlarmFactory {
       usageType,
       "CPU-Usage",
       additionalAlarmNameSuffix,
-    ].join("-");
+    ]
+      .filter((i) => i !== undefined)
+      .join("-");
     return this.alarmFactory.addAlarm(percentMetric, {
       treatMissingData:
         props.treatMissingDataOverride ?? TreatMissingData.MISSING,

--- a/lib/common/monitoring/alarms/UsageAlarmFactory.ts
+++ b/lib/common/monitoring/alarms/UsageAlarmFactory.ts
@@ -60,10 +60,14 @@ export class UsageAlarmFactory {
     percentMetric: MetricWithAlarmSupport,
     props: UsageThreshold,
     disambiguator?: string,
-    usageType?: UsageType
+    usageType?: UsageType,
+    additionalAlarmNameSuffix?: string
   ) {
-    const alarmNameSuffix: string =
-      usageType === undefined ? "CPU-Usage" : `${usageType}-CPU-Usage`;
+    const alarmNameSuffix: string = [
+      usageType,
+      "CPU-Usage",
+      additionalAlarmNameSuffix,
+    ].join("-");
     return this.alarmFactory.addAlarm(percentMetric, {
       treatMissingData:
         props.treatMissingDataOverride ?? TreatMissingData.MISSING,

--- a/lib/monitoring/aws-elasticache/ElastiCacheClusterMetricFactory.ts
+++ b/lib/monitoring/aws-elasticache/ElastiCacheClusterMetricFactory.ts
@@ -113,11 +113,12 @@ export class ElastiCacheClusterMetricFactory {
   }
 
   /**
-   * @see https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheMetrics.Redis.html
    * Because Redis is single-threaded, you can use this metric to analyze the load of the Redis process itself.
    * Note that you may want to monitor both Engine CPU Utilization as well as CPU Utilization as background
    * processes can take up a significant portion of the CPU workload. This is especially important for 
-   * hosts with 2 vCPUs or less
+   * hosts with 2 vCPUs or less.
+   *
+   * @see https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheMetrics.Redis.html
    */
   metricMaxRedisEngineCpuUtilizationInPercent() {
     return this.metricFactory.createMetric(

--- a/lib/monitoring/aws-elasticache/ElastiCacheClusterMetricFactory.ts
+++ b/lib/monitoring/aws-elasticache/ElastiCacheClusterMetricFactory.ts
@@ -115,7 +115,7 @@ export class ElastiCacheClusterMetricFactory {
   /**
    * Because Redis is single-threaded, you can use this metric to analyze the load of the Redis process itself.
    * Note that you may want to monitor both Engine CPU Utilization as well as CPU Utilization as background
-   * processes can take up a significant portion of the CPU workload. This is especially important for 
+   * processes can take up a significant portion of the CPU workload. This is especially important for
    * hosts with 2 vCPUs or less.
    *
    * @see https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheMetrics.Redis.html

--- a/lib/monitoring/aws-elasticache/ElastiCacheClusterMetricFactory.ts
+++ b/lib/monitoring/aws-elasticache/ElastiCacheClusterMetricFactory.ts
@@ -112,6 +112,21 @@ export class ElastiCacheClusterMetricFactory {
     );
   }
 
+  /**
+   * @see https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheMetrics.Redis.html
+   * Because Redis is single-threaded, you can use this metric to analyze the load of the Redis process itself.
+   */
+  metricMaxRedisEngineCpuUtilizationInPercent() {
+    return this.metricFactory.createMetric(
+      "EngineCPUUtilization",
+      MetricStatistic.MAX,
+      "Cluster Engine CPU Utilization",
+      this.dimensionsMap,
+      undefined,
+      Namespace
+    );
+  }
+
   metricAverageConnections() {
     return this.metricFactory.createMetric(
       "CurrConnections",

--- a/lib/monitoring/aws-elasticache/ElastiCacheClusterMetricFactory.ts
+++ b/lib/monitoring/aws-elasticache/ElastiCacheClusterMetricFactory.ts
@@ -115,6 +115,9 @@ export class ElastiCacheClusterMetricFactory {
   /**
    * @see https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheMetrics.Redis.html
    * Because Redis is single-threaded, you can use this metric to analyze the load of the Redis process itself.
+   * Note that you may want to monitor both Engine CPU Utilization as well as CPU Utilization as background
+   * processes can take up a significant portion of the CPU workload. This is especially important for 
+   * hosts with 2 vCPUs or less
    */
   metricMaxRedisEngineCpuUtilizationInPercent() {
     return this.metricFactory.createMetric(

--- a/lib/monitoring/aws-elasticache/ElastiCacheClusterMonitoring.ts
+++ b/lib/monitoring/aws-elasticache/ElastiCacheClusterMonitoring.ts
@@ -51,7 +51,7 @@ export interface ElastiCacheClusterMonitoringOptions
   /**
    * Add Redis engine CPU usage alarm.
    *
-   * It is recommended to monitor CPU utilization with `addCpuUsageAlarm` 
+   * It is recommended to monitor CPU utilization with `addCpuUsageAlarm`
    * as well for hosts with two vCPUs or less.
    */
   readonly addRedisEngineCpuUsageAlarm?: Record<string, UsageThreshold>;
@@ -176,8 +176,13 @@ export class ElastiCacheClusterMonitoring extends Monitoring {
       this.addAlarm(createdAlarm);
     }
 
-    if (props.addRedisEngineCpuUsageAlarm !== undefined && props.clusterType !== ElastiCacheClusterType.REDIS) {
-      throw new Error("It is only possible to alarm on Redis Engine CPU Usage for Redis clusters")
+    if (
+      props.addRedisEngineCpuUsageAlarm !== undefined &&
+      props.clusterType !== ElastiCacheClusterType.REDIS
+    ) {
+      throw new Error(
+        "It is only possible to alarm on Redis Engine CPU Usage for Redis clusters"
+      );
     }
 
     for (const disambiguator in props.addRedisEngineCpuUsageAlarm) {

--- a/lib/monitoring/aws-elasticache/ElastiCacheClusterMonitoring.ts
+++ b/lib/monitoring/aws-elasticache/ElastiCacheClusterMonitoring.ts
@@ -49,9 +49,10 @@ export interface ElastiCacheClusterMonitoringOptions
   readonly addCpuUsageAlarm?: Record<string, UsageThreshold>;
 
   /**
-   * Add redis engine CPU usage alarm
-   * Note: it is recommended to monitor CPU Utilization as well
-   * for hosts with two vCPUs or less
+   * Add Redis engine CPU usage alarm.
+   *
+   * It is recommended to monitor CPU utilization with `addCpuUsageAlarm` 
+   * as well for hosts with two vCPUs or less.
    */
   readonly addRedisEngineCpuUsageAlarm?: Record<string, UsageThreshold>;
 

--- a/lib/monitoring/aws-elasticache/ElastiCacheClusterMonitoring.ts
+++ b/lib/monitoring/aws-elasticache/ElastiCacheClusterMonitoring.ts
@@ -88,7 +88,7 @@ export interface ElastiCacheClusterMonitoringProps
 export class ElastiCacheClusterMonitoring extends Monitoring {
   readonly title: string;
   readonly clusterUrl?: string;
-  readonly elastiCacheClusterType: ElastiCacheClusterType;
+  readonly clusterType: ElastiCacheClusterType;
 
   readonly connectionsMetric: MetricWithAlarmSupport;
   readonly cpuUsageMetric: MetricWithAlarmSupport;
@@ -243,7 +243,7 @@ export class ElastiCacheClusterMonitoring extends Monitoring {
   }
 
   widgets(): IWidget[] {
-    if (this.elastiCacheClusterType == ElastiCacheClusterType.REDIS) {
+    if (this.clusterType === ElastiCacheClusterType.REDIS) {
       return [
         this.createTitleWidget(),
         new Column(

--- a/test/facade/__snapshots__/MonitoringAspect.test.ts.snap
+++ b/test/facade/__snapshots__/MonitoringAspect.test.ts.snap
@@ -4498,11 +4498,15 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"CurrItems\\",{\\"label\\":\\"Count\\",\\"stat\\":\\"Maximum\\"}],[\\"AWS/ElastiCache\\",\\"Evictions\\",{\\"label\\":\\"Evictions\\",\\"stat\\":\\"Sum\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":6,\\"properties\\":{\\"markdown\\":\\"### ElastiCache Cluster **Redis-ALL**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":7,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CPU Utilization\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"CurrItems\\",{\\"label\\":\\"Count\\",\\"stat\\":\\"Maximum\\"}],[\\"AWS/ElastiCache\\",\\"Evictions\\",{\\"label\\":\\"Evictions\\",\\"stat\\":\\"Sum\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":6,\\"properties\\":{\\"markdown\\":\\"### ElastiCache Cluster **Redis-ALL**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":3,\\"x\\":0,\\"y\\":7,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CPU Utilization\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"CPUUtilization\\",{\\"label\\":\\"Cluster CPU Utilization\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":100,\\"label\\":\\"%\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":7,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Memory Utilization\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"CPUUtilization\\",{\\"label\\":\\"Cluster CPU Utilization\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":100,\\"label\\":\\"%\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":3,\\"x\\":0,\\"y\\":10,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Engine CPU Utilization\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"EngineCPUUtilization\\",{\\"label\\":\\"Cluster Engine CPU Utilization\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":100,\\"label\\":\\"%\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":7,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Memory Utilization\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },

--- a/test/monitoring/aws-elasticache/ElastiCacheClusterMonitoring.test.ts
+++ b/test/monitoring/aws-elasticache/ElastiCacheClusterMonitoring.test.ts
@@ -90,3 +90,18 @@ test("snapshot test: cluster ID specified", () => {
 
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });
+
+test("validation test: redisEngineCpuUsageAlarm added for non-redis cluster ", () => {
+  const stack = new Stack();
+  const scope = new TestMonitoringScope(stack, "Scope");
+
+  expect(
+    () =>
+      new ElastiCacheClusterMonitoring(scope, {
+        clusterType: ElastiCacheClusterType.MEMCACHED,
+        addRedisEngineCpuUsageAlarm: { Warning: { maxUsagePercent: 10 } },
+      })
+  ).toThrowError(
+    "It is only possible to alarm on Redis Engine CPU Usage for Redis clusters"
+  );
+});

--- a/test/monitoring/aws-elasticache/ElastiCacheClusterMonitoring.test.ts
+++ b/test/monitoring/aws-elasticache/ElastiCacheClusterMonitoring.test.ts
@@ -52,6 +52,7 @@ test("snapshot test: all alarms", () => {
   new ElastiCacheClusterMonitoring(scope, {
     clusterType: ElastiCacheClusterType.REDIS,
     addCpuUsageAlarm: { Warning: { maxUsagePercent: 11 } },
+    addRedisEngineCpuUsageAlarm: { Warning: { maxUsagePercent: 10 } },
     addMaxItemsCountAlarm: { Warning: { maxItemsCount: 21 } },
     addMaxEvictedItemsCountAlarm: { Warning: { maxItemsCount: 31 } },
     addMinFreeableMemoryAlarm: { Warning: { minFreeableMemoryInBytes: 41 } },
@@ -64,7 +65,7 @@ test("snapshot test: all alarms", () => {
   });
 
   expect(numAlarmsCreatedForMemcached).toStrictEqual(5);
-  expect(numAlarmsCreatedForRedis).toStrictEqual(5);
+  expect(numAlarmsCreatedForRedis).toStrictEqual(6);
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });
 

--- a/test/monitoring/aws-elasticache/__snapshots__/ElastiCacheClusterMonitoring.test.ts.snap
+++ b/test/monitoring/aws-elasticache/__snapshots__/ElastiCacheClusterMonitoring.test.ts.snap
@@ -10,11 +10,11 @@ Object {
     },
   },
   "Resources": Object {
-    "ScopeTestMemcachedALLCPUUsageWarning87FE6DEF": Object {
+    "ScopeTestMemcachedALLCPUUsageWarningB9311F1B": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmDescription": "The CPU usage is too high.",
-        "AlarmName": "Test-Memcached-ALL--CPU-Usage--Warning",
+        "AlarmName": "Test-Memcached-ALL-CPU-Usage-Warning",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 3,
         "EvaluationPeriods": 3,
@@ -150,11 +150,11 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "ScopeTestRedisALLCPUUsageRedisEngineWarningABF817E0": Object {
+    "ScopeTestRedisALLCPUUsageRedisEngineWarningFFAEE1C0": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmDescription": "The CPU usage is too high.",
-        "AlarmName": "Test-Redis-ALL--CPU-Usage-RedisEngine-Warning",
+        "AlarmName": "Test-Redis-ALL-CPU-Usage-RedisEngine-Warning",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 3,
         "EvaluationPeriods": 3,
@@ -178,11 +178,11 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "ScopeTestRedisALLCPUUsageWarningC888D096": Object {
+    "ScopeTestRedisALLCPUUsageWarningF75B1746": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmDescription": "The CPU usage is too high.",
-        "AlarmName": "Test-Redis-ALL--CPU-Usage--Warning",
+        "AlarmName": "Test-Redis-ALL-CPU-Usage-Warning",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 3,
         "EvaluationPeriods": 3,

--- a/test/monitoring/aws-elasticache/__snapshots__/ElastiCacheClusterMonitoring.test.ts.snap
+++ b/test/monitoring/aws-elasticache/__snapshots__/ElastiCacheClusterMonitoring.test.ts.snap
@@ -10,11 +10,11 @@ Object {
     },
   },
   "Resources": Object {
-    "ScopeTestMemcachedALLCPUUsageWarningB9311F1B": Object {
+    "ScopeTestMemcachedALLCPUUsageWarning87FE6DEF": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmDescription": "The CPU usage is too high.",
-        "AlarmName": "Test-Memcached-ALL-CPU-Usage-Warning",
+        "AlarmName": "Test-Memcached-ALL--CPU-Usage--Warning",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 3,
         "EvaluationPeriods": 3,
@@ -150,11 +150,39 @@ Object {
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "ScopeTestRedisALLCPUUsageWarningF75B1746": Object {
+    "ScopeTestRedisALLCPUUsageRedisEngineWarningABF817E0": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmDescription": "The CPU usage is too high.",
-        "AlarmName": "Test-Redis-ALL-CPU-Usage-Warning",
+        "AlarmName": "Test-Redis-ALL--CPU-Usage-RedisEngine-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Cluster Engine CPU Utilization",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "EngineCPUUtilization",
+                "Namespace": "AWS/ElastiCache",
+              },
+              "Period": 300,
+              "Stat": "Maximum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 10,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestRedisALLCPUUsageWarningC888D096": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "The CPU usage is too high.",
+        "AlarmName": "Test-Redis-ALL--CPU-Usage--Warning",
         "ComparisonOperator": "GreaterThanThreshold",
         "DatapointsToAlarm": 3,
         "EvaluationPeriods": 3,


### PR DESCRIPTION
Monitor engine utilization by default for Redis ElastiCache clusters. Optionally add alarms based on this metric.

Redis is single-threaded and the Redis thread's utilization is available via the EngineCPUUtilization metric. This metric provides visibility into the load of the redis process itself.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_