### PR TITLE
feat!: use stable api-gatewayv2 module

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -100,13 +100,8 @@
       "type": "build"
     },
     {
-      "name": "@aws-cdk/aws-apigatewayv2-alpha",
-      "version": "2.99.0-alpha.0",
-      "type": "devenv"
-    },
-    {
       "name": "@aws-cdk/aws-redshift-alpha",
-      "version": "2.99.0-alpha.0",
+      "version": "2.112.0-alpha.0",
       "type": "devenv"
     },
     {
@@ -125,18 +120,13 @@
       "type": "override"
     },
     {
-      "name": "@aws-cdk/aws-apigatewayv2-alpha",
-      "version": "^2.99.0-alpha.0",
-      "type": "peer"
-    },
-    {
       "name": "@aws-cdk/aws-redshift-alpha",
-      "version": "^2.99.0-alpha.0",
+      "version": "^2.112.0-alpha.0",
       "type": "peer"
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.99.0",
+      "version": "^2.112.0",
       "type": "peer"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -233,7 +233,7 @@
       "description": "Prepare a release from \"main\" branch",
       "env": {
         "RELEASE": "true",
-        "MAJOR": "6"
+        "MAJOR": "7"
       },
       "steps": [
         {
@@ -299,13 +299,13 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,eslint,jest-junit,jest,jsii-diff,jsii-docgen,jsii-pacmak,prettier,projen,standard-version,ts-jest,ts-node,typescript,@aws-cdk/aws-apigatewayv2-alpha,@aws-cdk/aws-redshift-alpha,aws-cdk-lib,constructs"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev,peer,prod,optional --filter=@types/jest,@types/node,@typescript-eslint/eslint-plugin,@typescript-eslint/parser,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-prettier,eslint,jest-junit,jest,jsii-diff,jsii-docgen,jsii-pacmak,prettier,projen,standard-version,ts-jest,ts-node,typescript,@aws-cdk/aws-redshift-alpha,aws-cdk-lib,constructs"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint jest-junit jest jsii-diff jsii-docgen jsii-pacmak prettier projen standard-version ts-jest ts-node typescript @aws-cdk/aws-apigatewayv2-alpha @aws-cdk/aws-redshift-alpha aws-cdk-lib constructs"
+          "exec": "yarn upgrade @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser eslint-config-prettier eslint-import-resolver-typescript eslint-plugin-import eslint-plugin-prettier eslint jest-junit jest jsii-diff jsii-docgen jsii-pacmak prettier projen standard-version ts-jest ts-node typescript @aws-cdk/aws-redshift-alpha aws-cdk-lib constructs"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,6 +1,6 @@
 import { awscdk, javascript, github, DependencyType } from "projen";
 
-const CDK_VERSION = "2.99.0";
+const CDK_VERSION = "2.112.0";
 
 const project = new awscdk.AwsCdkConstructLibrary({
   name: "cdk-monitoring-constructs",
@@ -11,7 +11,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   keywords: ["cloudwatch", "monitoring"],
 
   defaultReleaseBranch: "main",
-  majorVersion: 6,
+  majorVersion: 7,
   stability: "experimental",
 
   cdkVersion: CDK_VERSION,
@@ -69,18 +69,16 @@ _By submitting this pull request, I confirm that my contribution is made under t
 });
 
 // Experimental modules
-["@aws-cdk/aws-apigatewayv2-alpha", "@aws-cdk/aws-redshift-alpha"].forEach(
-  (dep) => {
-    project.deps.addDependency(
-      `${dep}@^${CDK_VERSION}-alpha.0`,
-      DependencyType.PEER
-    );
-    project.deps.addDependency(
-      `${dep}@${CDK_VERSION}-alpha.0`,
-      DependencyType.DEVENV
-    );
-  }
-);
+["@aws-cdk/aws-redshift-alpha"].forEach((dep) => {
+  project.deps.addDependency(
+    `${dep}@^${CDK_VERSION}-alpha.0`,
+    DependencyType.PEER
+  );
+  project.deps.addDependency(
+    `${dep}@${CDK_VERSION}-alpha.0`,
+    DependencyType.DEVENV
+  );
+});
 // https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/60310
 project.deps.addDependency("@types/prettier@2.6.0", DependencyType.DEVENV);
 

--- a/API.md
+++ b/API.md
@@ -5455,7 +5455,7 @@ const apiGatewayV2HttpApiMetricFactoryProps: ApiGatewayV2HttpApiMetricFactoryPro
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactoryProps.property.api">api</a></code> | <code>@aws-cdk/aws-apigatewayv2-alpha.IHttpApi</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactoryProps.property.api">api</a></code> | <code>aws-cdk-lib.aws_apigatewayv2.IHttpApi</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactoryProps.property.apiMethod">apiMethod</a></code> | <code>string</code> | On undefined value is not set in dimensions. |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactoryProps.property.apiResource">apiResource</a></code> | <code>string</code> | On undefined value is not set in dimensions. |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactoryProps.property.apiStage">apiStage</a></code> | <code>string</code> | *No description.* |
@@ -5470,7 +5470,7 @@ const apiGatewayV2HttpApiMetricFactoryProps: ApiGatewayV2HttpApiMetricFactoryPro
 public readonly api: IHttpApi;
 ```
 
-- *Type:* @aws-cdk/aws-apigatewayv2-alpha.IHttpApi
+- *Type:* aws-cdk-lib.aws_apigatewayv2.IHttpApi
 
 ---
 
@@ -5545,7 +5545,7 @@ const apiGatewayV2HttpApiMonitoringProps: ApiGatewayV2HttpApiMonitoringProps = {
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.api">api</a></code> | <code>@aws-cdk/aws-apigatewayv2-alpha.IHttpApi</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.api">api</a></code> | <code>aws-cdk-lib.aws_apigatewayv2.IHttpApi</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.apiMethod">apiMethod</a></code> | <code>string</code> | On undefined value is not set in dimensions. |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.apiResource">apiResource</a></code> | <code>string</code> | On undefined value is not set in dimensions. |
 | <code><a href="#cdk-monitoring-constructs.ApiGatewayV2HttpApiMonitoringProps.property.apiStage">apiStage</a></code> | <code>string</code> | *No description.* |
@@ -5614,7 +5614,7 @@ const apiGatewayV2HttpApiMonitoringProps: ApiGatewayV2HttpApiMonitoringProps = {
 public readonly api: IHttpApi;
 ```
 
-- *Type:* @aws-cdk/aws-apigatewayv2-alpha.IHttpApi
+- *Type:* aws-cdk-lib.aws_apigatewayv2.IHttpApi
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -26,12 +26,11 @@ In your `package.json`:
 ```json
 {
   "dependencies": {
-    "cdk-monitoring-constructs": "^6.0.0",
+    "cdk-monitoring-constructs": "^7.0.0",
 
     // peer dependencies of cdk-monitoring-constructs
-    "@aws-cdk/aws-apigatewayv2-alpha": "^2.99.0-alpha.0",
-    "@aws-cdk/aws-redshift-alpha": "^2.99.0-alpha.0",
-    "aws-cdk-lib": "^2.99.0",
+    "@aws-cdk/aws-redshift-alpha": "^2.112.0-alpha.0",
+    "aws-cdk-lib": "^2.112.0",
     "constructs": "^10.0.5"
 
     // ...your other dependencies...

--- a/lib/facade/MonitoringAspect.ts
+++ b/lib/facade/MonitoringAspect.ts
@@ -1,7 +1,7 @@
-import * as apigwv2 from "@aws-cdk/aws-apigatewayv2-alpha";
 import * as redshift from "@aws-cdk/aws-redshift-alpha";
 import { IAspect } from "aws-cdk-lib";
 import * as apigw from "aws-cdk-lib/aws-apigateway";
+import * as apigwv2 from "aws-cdk-lib/aws-apigatewayv2";
 import * as appsync from "aws-cdk-lib/aws-appsync";
 import * as autoscaling from "aws-cdk-lib/aws-autoscaling";
 import * as acm from "aws-cdk-lib/aws-certificatemanager";

--- a/lib/monitoring/aws-apigatewayv2/ApiGatewayV2HttpApiMetricFactory.ts
+++ b/lib/monitoring/aws-apigatewayv2/ApiGatewayV2HttpApiMetricFactory.ts
@@ -1,4 +1,4 @@
-import { IHttpApi } from "@aws-cdk/aws-apigatewayv2-alpha";
+import { IHttpApi } from "aws-cdk-lib/aws-apigatewayv2";
 import { DimensionsMap } from "aws-cdk-lib/aws-cloudwatch";
 
 import {
@@ -51,7 +51,7 @@ export class ApiGatewayV2HttpApiMetricFactory {
     this.rateComputationMethod =
       props.rateComputationMethod ?? RateComputationMethod.AVERAGE;
     this.dimensionsMap = {
-      ApiId: props.api.httpApiId,
+      ApiId: props.api.apiId,
       Stage: props.apiStage ?? "$default",
       ...(props.apiMethod && { Method: props.apiMethod }),
       ...(props.apiResource && { Resource: props.apiResource }),

--- a/package.json
+++ b/package.json
@@ -37,14 +37,13 @@
     "organization": false
   },
   "devDependencies": {
-    "@aws-cdk/aws-apigatewayv2-alpha": "2.99.0-alpha.0",
-    "@aws-cdk/aws-redshift-alpha": "2.99.0-alpha.0",
+    "@aws-cdk/aws-redshift-alpha": "2.112.0-alpha.0",
     "@types/jest": "^27",
     "@types/node": "^16",
     "@types/prettier": "2.6.0",
     "@typescript-eslint/eslint-plugin": "^6",
     "@typescript-eslint/parser": "^6",
-    "aws-cdk-lib": "2.99.0",
+    "aws-cdk-lib": "2.112.0",
     "constructs": "10.0.5",
     "eslint": "^8",
     "eslint-config-prettier": "^8.10.0",
@@ -66,9 +65,8 @@
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "@aws-cdk/aws-apigatewayv2-alpha": "^2.99.0-alpha.0",
-    "@aws-cdk/aws-redshift-alpha": "^2.99.0-alpha.0",
-    "aws-cdk-lib": "^2.99.0",
+    "@aws-cdk/aws-redshift-alpha": "^2.112.0-alpha.0",
+    "aws-cdk-lib": "^2.112.0",
     "constructs": "^10.0.5"
   },
   "resolutions": {

--- a/test/facade/MonitoringAspect.test.ts
+++ b/test/facade/MonitoringAspect.test.ts
@@ -1,9 +1,9 @@
 import path from "path";
-import * as apigwv2 from "@aws-cdk/aws-apigatewayv2-alpha";
 import * as redshift from "@aws-cdk/aws-redshift-alpha";
 import { App, Duration, SecretValue, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
 import * as apigw from "aws-cdk-lib/aws-apigateway";
+import * as apigwv2 from "aws-cdk-lib/aws-apigatewayv2";
 import * as appsync from "aws-cdk-lib/aws-appsync";
 import * as autoscaling from "aws-cdk-lib/aws-autoscaling";
 import * as acm from "aws-cdk-lib/aws-certificatemanager";

--- a/test/facade/__snapshots__/MonitoringAspect.test.ts.snap
+++ b/test/facade/__snapshots__/MonitoringAspect.test.ts.snap
@@ -3371,7 +3371,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "5bc602ecde93c947efe5899ae355f999986a1acbe610b1c0b9c468d738857555.zip",
+          "S3Key": "4e26bf2d0a26f2097fb2b261f22bb51e3f6b4b52635777b1e54edbd8e2d58c35.zip",
         },
         "Handler": "index.handler",
         "Role": Object {

--- a/test/monitoring/aws-apigatewayv2/ApiGatewayV2HttpApiMonitoring.test.ts
+++ b/test/monitoring/aws-apigatewayv2/ApiGatewayV2HttpApiMonitoring.test.ts
@@ -1,6 +1,6 @@
-import { HttpApi } from "@aws-cdk/aws-apigatewayv2-alpha";
 import { Duration, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
+import { HttpApi } from "aws-cdk-lib/aws-apigatewayv2";
 
 import {
   AlarmWithAnnotation,

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,7 +15,7 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@aws-cdk/asset-awscli-v1@^2.2.200":
+"@aws-cdk/asset-awscli-v1@^2.2.201":
   version "2.2.201"
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.201.tgz#a7b51d3ecc8ff3ca9798269eda3a1db2400b506a"
   integrity sha512-INZqcwDinNaIdb5CtW3ez5s943nX5stGBQS6VOP2JDlOFP81hM3fds/9NDknipqfUkZM43dx+HgVvkXYXXARCQ==
@@ -30,15 +30,10 @@
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz#6dc9b7cdb22ff622a7176141197962360c33e9ac"
   integrity sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg==
 
-"@aws-cdk/aws-apigatewayv2-alpha@2.99.0-alpha.0":
-  version "2.99.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigatewayv2-alpha/-/aws-apigatewayv2-alpha-2.99.0-alpha.0.tgz#a4e613c230f66d06ce06b5c6cb83b122162c509a"
-  integrity sha512-bYtSCyjsa9h7LVz2n0xbQowV+amztnT5U0K48Lbo18N5u+WswW4TP4wu/xxRcotP1PoiGLeyEt+Lpa757ac3ww==
-
-"@aws-cdk/aws-redshift-alpha@2.99.0-alpha.0":
-  version "2.99.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-redshift-alpha/-/aws-redshift-alpha-2.99.0-alpha.0.tgz#73130f7a3e2150c3ea8ea86fd4563e5e87401d01"
-  integrity sha512-cn57/nRmkaBRS4P7gQq5medLTyL+LSeMdBzggMkLJr8kyxztTT95w8A1jqaYg5OmKAW2BmUvD8tgQKIr3ZINEg==
+"@aws-cdk/aws-redshift-alpha@2.112.0-alpha.0":
+  version "2.112.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-redshift-alpha/-/aws-redshift-alpha-2.112.0-alpha.0.tgz#225dedf9fe860f049ec7f52214b0fbdae83ba449"
+  integrity sha512-vxGq1c/JPzJ9TT9Io222oE4WvjDQBuITOylVVDsWPCNXH8Detu147e5w6SfzIEESRwAlXwcgEonRb+arlMRplQ==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.22.13", "@babel/code-frame@^7.23.4":
   version "7.23.4"
@@ -1210,21 +1205,21 @@ available-typed-arrays@^1.0.5:
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-cdk-lib@2.99.0:
-  version "2.99.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.99.0.tgz#2bbd614ef84dfdcecb7db41dafebfe46f8b0e0af"
-  integrity sha512-SxCYjdzHJGi0s0xxD3OlojCgP02kzI9V/ME9XW6oX9K/zBIYiK+6SeGWzARobp9aAfDNQ8dKxWdCJb975DuZDA==
+aws-cdk-lib@2.112.0:
+  version "2.112.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.112.0.tgz#42a9e821b95a67636328defd536e3c7bc833d67a"
+  integrity sha512-nrxfXM05Lq6HRoOXdrGXcc1XqqJTtCW3EkjPqdT0kkZ+fR6yQgbzdW2nVxSBiVDNmcf82vLBTmFMezdEgj8N4w==
   dependencies:
-    "@aws-cdk/asset-awscli-v1" "^2.2.200"
+    "@aws-cdk/asset-awscli-v1" "^2.2.201"
     "@aws-cdk/asset-kubectl-v20" "^2.1.2"
     "@aws-cdk/asset-node-proxy-agent-v6" "^2.0.1"
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
     fs-extra "^11.1.1"
-    ignore "^5.2.4"
+    ignore "^5.3.0"
     jsonschema "^1.4.1"
     minimatch "^3.1.2"
-    punycode "^2.3.0"
+    punycode "^2.3.1"
     semver "^7.5.4"
     table "^6.8.1"
     yaml "1.10.2"
@@ -2732,7 +2727,7 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-ignore@^5.2.0, ignore@^5.2.4:
+ignore@^5.2.0, ignore@^5.2.4, ignore@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.0.tgz#67418ae40d34d6999c95ff56016759c718c82f78"
   integrity sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==
@@ -4324,7 +4319,7 @@ psl@^1.1.33:
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
   integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
 
-punycode@^2.1.0, punycode@^2.1.1, punycode@^2.3.0:
+punycode@^2.1.0, punycode@^2.1.1, punycode@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==


### PR DESCRIPTION
BREAKING CHANGE: requires aws-cdk-lib@^2.112.0

The API Gateway v2 modules were promoted to stable in https://github.com/aws/aws-cdk/releases/tag/v2.112.0.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_