### PR TITLE
feat: add PercentageAxisUpToHundred convenience axis

### DIFF
--- a/lib/common/widget/axis.ts
+++ b/lib/common/widget/axis.ts
@@ -20,6 +20,15 @@ export const PercentageAxisFromZeroToHundred: YAxisProps = {
 };
 
 /**
+ * Y-Axis showing percentage, ranged up to 100.
+ */
+export const PercentageAxisUpToHundred: YAxisProps = {
+  max: 100,
+  label: "%",
+  showUnits: false,
+};
+
+/**
  * Y-Axis showing time in milliseconds, ranged from 0.
  */
 export const TimeAxisMillisFromZero: YAxisProps = {


### PR DESCRIPTION
Useful for graphs where it'd go up to 100% but we want to see dips in it that might otherwise be difficult to see if the axis was 0 to 100 (like availability).

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_