### PR TITLE
feat(AlarmFactory): add suppressor alarm props to AddCompositeAlarmProps

### DIFF
--- a/API.md
+++ b/API.md
@@ -2814,6 +2814,9 @@ const addCompositeAlarmProps: AddCompositeAlarmProps = { ... }
 | <code><a href="#cdk-monitoring-constructs.AddCompositeAlarmProps.property.disambiguator">disambiguator</a></code> | <code>string</code> | Disambiguator is a string that differentiates this alarm from other similar ones. |
 | <code><a href="#cdk-monitoring-constructs.AddCompositeAlarmProps.property.actionOverride">actionOverride</a></code> | <code><a href="#cdk-monitoring-constructs.IAlarmActionStrategy">IAlarmActionStrategy</a></code> | Allows to override the default action strategy. |
 | <code><a href="#cdk-monitoring-constructs.AddCompositeAlarmProps.property.actionsEnabled">actionsEnabled</a></code> | <code>boolean</code> | Enables the configured CloudWatch alarm ticketing actions. |
+| <code><a href="#cdk-monitoring-constructs.AddCompositeAlarmProps.property.actionsSuppressor">actionsSuppressor</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarm</code> | Actions will be suppressed if the suppressor alarm is in the ALARM state. |
+| <code><a href="#cdk-monitoring-constructs.AddCompositeAlarmProps.property.actionsSuppressorExtensionPeriod">actionsSuppressorExtensionPeriod</a></code> | <code>aws-cdk-lib.Duration</code> | The maximum time in seconds that the composite alarm waits after suppressor alarm goes out of the ALARM state. |
+| <code><a href="#cdk-monitoring-constructs.AddCompositeAlarmProps.property.actionsSuppressorWaitPeriod">actionsSuppressorWaitPeriod</a></code> | <code>aws-cdk-lib.Duration</code> | The maximum duration that the composite alarm waits for the suppressor alarm to go into the ALARM state. |
 | <code><a href="#cdk-monitoring-constructs.AddCompositeAlarmProps.property.alarmDedupeStringSuffix">alarmDedupeStringSuffix</a></code> | <code>string</code> | If this is defined, the default resource-specific alarm dedupe string will be set and this will be added as a suffix. |
 | <code><a href="#cdk-monitoring-constructs.AddCompositeAlarmProps.property.alarmDescription">alarmDescription</a></code> | <code>string</code> | Alarm description is included in the ticket and therefore should describe what happened, with as much context as possible. |
 | <code><a href="#cdk-monitoring-constructs.AddCompositeAlarmProps.property.alarmDescriptionOverride">alarmDescriptionOverride</a></code> | <code>string</code> | A text included in the generated ticket description body, which fully replaces the generated text. |
@@ -2864,6 +2867,49 @@ public readonly actionsEnabled: boolean;
 - *Default:* the same as monitoring facade default
 
 Enables the configured CloudWatch alarm ticketing actions.
+
+---
+
+##### `actionsSuppressor`<sup>Optional</sup> <a name="actionsSuppressor" id="cdk-monitoring-constructs.AddCompositeAlarmProps.property.actionsSuppressor"></a>
+
+```typescript
+public readonly actionsSuppressor: IAlarm;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IAlarm
+- *Default:* no suppressor alarm
+
+Actions will be suppressed if the suppressor alarm is in the ALARM state.
+
+---
+
+##### `actionsSuppressorExtensionPeriod`<sup>Optional</sup> <a name="actionsSuppressorExtensionPeriod" id="cdk-monitoring-constructs.AddCompositeAlarmProps.property.actionsSuppressorExtensionPeriod"></a>
+
+```typescript
+public readonly actionsSuppressorExtensionPeriod: Duration;
+```
+
+- *Type:* aws-cdk-lib.Duration
+- *Default:* 60 seconds
+
+The maximum time in seconds that the composite alarm waits after suppressor alarm goes out of the ALARM state.
+
+After this time, the composite alarm performs its actions.
+
+---
+
+##### `actionsSuppressorWaitPeriod`<sup>Optional</sup> <a name="actionsSuppressorWaitPeriod" id="cdk-monitoring-constructs.AddCompositeAlarmProps.property.actionsSuppressorWaitPeriod"></a>
+
+```typescript
+public readonly actionsSuppressorWaitPeriod: Duration;
+```
+
+- *Type:* aws-cdk-lib.Duration
+- *Default:* 60 seconds
+
+The maximum duration that the composite alarm waits for the suppressor alarm to go into the ALARM state.
+
+After this time, the composite alarm performs its actions.
 
 ---
 

--- a/lib/common/alarm/AlarmFactory.ts
+++ b/lib/common/alarm/AlarmFactory.ts
@@ -6,6 +6,7 @@ import {
   ComparisonOperator,
   CompositeAlarm,
   HorizontalAnnotation,
+  IAlarm,
   IAlarmRule,
   IMetric,
   MathExpression,
@@ -388,6 +389,29 @@ export interface AddCompositeAlarmProps {
    * @default - OR
    */
   readonly compositeOperator?: CompositeAlarmOperator;
+
+  /**
+   * Actions will be suppressed if the suppressor alarm is in the ALARM state.
+   *
+   * @default - no suppressor alarm
+   */
+  readonly actionsSuppressor?: IAlarm;
+
+  /**
+   * The maximum time in seconds that the composite alarm waits after suppressor alarm goes out of the ALARM state.
+   * After this time, the composite alarm performs its actions.
+   *
+   * @default - 60 seconds
+   */
+  readonly actionsSuppressorExtensionPeriod?: Duration;
+
+  /**
+   * The maximum duration that the composite alarm waits for the suppressor alarm to go into the ALARM state.
+   * After this time, the composite alarm performs its actions.
+   *
+   * @default - 60 seconds
+   */
+  readonly actionsSuppressorWaitPeriod?: Duration;
 }
 
 /**
@@ -779,6 +803,9 @@ export class AlarmFactory {
       alarmDescription,
       alarmRule,
       actionsEnabled,
+      actionsSuppressor: props?.actionsSuppressor,
+      actionsSuppressorExtensionPeriod: props?.actionsSuppressorExtensionPeriod,
+      actionsSuppressorWaitPeriod: props?.actionsSuppressorWaitPeriod,
     });
 
     action.addAlarmActions({

--- a/test/common/alarm/__snapshots__/AlarmFactory.test.ts.snap
+++ b/test/common/alarm/__snapshots__/AlarmFactory.test.ts.snap
@@ -245,3 +245,272 @@ Object {
   },
 }
 `;
+
+exports[`addCompositeAlarm: snapshot for suppressor alarm props 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "DummyServiceAlarmsprefixAlarm1F4FCF957": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmDescription": "Testing alarm 1",
+        "AlarmName": "DummyServiceAlarms-prefix-Alarm1",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 6,
+        "Dimensions": Array [
+          Object {
+            "Name": "CustomDimension",
+            "Value": "CustomDimensionValue",
+          },
+        ],
+        "EvaluationPeriods": 6,
+        "MetricName": "DummyMetric1",
+        "Namespace": "DummyCustomNamespace",
+        "Period": 300,
+        "Statistic": "Average",
+        "Threshold": 1,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "DummyServiceAlarmsprefixAlarm25ADF8B37": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmDescription": "Testing alarm 2",
+        "AlarmName": "DummyServiceAlarms-prefix-Alarm2",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 6,
+        "Dimensions": Array [
+          Object {
+            "Name": "CustomDimension",
+            "Value": "CustomDimensionValue",
+          },
+        ],
+        "EvaluationPeriods": 6,
+        "MetricName": "DummyMetric1",
+        "Namespace": "DummyCustomNamespace",
+        "Period": 300,
+        "Statistic": "Average",
+        "Threshold": 2,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "DummyServiceAlarmsprefixSuppressedAlarmDefault3397EEAA": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "ActionsSuppressor": Object {
+          "Fn::GetAtt": Array [
+            "DummyServiceAlarmsprefixSuppressorAlarm7A8145E7",
+            "Arn",
+          ],
+        },
+        "ActionsSuppressorExtensionPeriod": 60,
+        "ActionsSuppressorWaitPeriod": 60,
+        "AlarmDescription": "Composite alarm",
+        "AlarmName": "DummyServiceAlarms-prefix-SuppressedAlarmDefault",
+        "AlarmRule": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "(ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "DummyServiceAlarmsprefixAlarm1F4FCF957",
+                  "Arn",
+                ],
+              },
+              "\\") OR ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "DummyServiceAlarmsprefixAlarm25ADF8B37",
+                  "Arn",
+                ],
+              },
+              "\\"))",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
+    },
+    "DummyServiceAlarmsprefixSuppressedAlarmTestBothExtensionAndWaitPeriodAD8EE66D": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "ActionsSuppressor": Object {
+          "Fn::GetAtt": Array [
+            "DummyServiceAlarmsprefixSuppressorAlarm7A8145E7",
+            "Arn",
+          ],
+        },
+        "ActionsSuppressorExtensionPeriod": 100,
+        "ActionsSuppressorWaitPeriod": 100,
+        "AlarmDescription": "Composite alarm",
+        "AlarmName": "DummyServiceAlarms-prefix-SuppressedAlarmTestBothExtensionAndWaitPeriod",
+        "AlarmRule": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "(ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "DummyServiceAlarmsprefixAlarm1F4FCF957",
+                  "Arn",
+                ],
+              },
+              "\\") OR ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "DummyServiceAlarmsprefixAlarm25ADF8B37",
+                  "Arn",
+                ],
+              },
+              "\\"))",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
+    },
+    "DummyServiceAlarmsprefixSuppressedAlarmTestExtensionPeriodE8E43F86": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "ActionsSuppressor": Object {
+          "Fn::GetAtt": Array [
+            "DummyServiceAlarmsprefixSuppressorAlarm7A8145E7",
+            "Arn",
+          ],
+        },
+        "ActionsSuppressorExtensionPeriod": 100,
+        "ActionsSuppressorWaitPeriod": 60,
+        "AlarmDescription": "Composite alarm",
+        "AlarmName": "DummyServiceAlarms-prefix-SuppressedAlarmTestExtensionPeriod",
+        "AlarmRule": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "(ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "DummyServiceAlarmsprefixAlarm1F4FCF957",
+                  "Arn",
+                ],
+              },
+              "\\") OR ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "DummyServiceAlarmsprefixAlarm25ADF8B37",
+                  "Arn",
+                ],
+              },
+              "\\"))",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
+    },
+    "DummyServiceAlarmsprefixSuppressedAlarmTestWaitPeriod09DC1879": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "ActionsSuppressor": Object {
+          "Fn::GetAtt": Array [
+            "DummyServiceAlarmsprefixSuppressorAlarm7A8145E7",
+            "Arn",
+          ],
+        },
+        "ActionsSuppressorExtensionPeriod": 60,
+        "ActionsSuppressorWaitPeriod": 100,
+        "AlarmDescription": "Composite alarm",
+        "AlarmName": "DummyServiceAlarms-prefix-SuppressedAlarmTestWaitPeriod",
+        "AlarmRule": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "(ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "DummyServiceAlarmsprefixAlarm1F4FCF957",
+                  "Arn",
+                ],
+              },
+              "\\") OR ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "DummyServiceAlarmsprefixAlarm25ADF8B37",
+                  "Arn",
+                ],
+              },
+              "\\"))",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
+    },
+    "DummyServiceAlarmsprefixSuppressorAlarm7A8145E7": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmDescription": "Composite alarm",
+        "AlarmName": "DummyServiceAlarms-prefix-SuppressorAlarm",
+        "AlarmRule": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "(ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "DummyServiceAlarmsprefixAlarm1F4FCF957",
+                  "Arn",
+                ],
+              },
+              "\\") OR ALARM(\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "DummyServiceAlarmsprefixAlarm25ADF8B37",
+                  "Arn",
+                ],
+              },
+              "\\"))",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::CompositeAlarm",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;


### PR DESCRIPTION
### Description
Closes #516

CloudWatch `CompositeAlarm` now supports specifying a suppressor alarm `actionsSuppressor` when initializing (see [CompositeAlarm API reference](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudwatch-compositealarm.html)). However, this additional parameter is not present within `AddCompositeAlarmProps`, and thus, it is not possible to create a `CompositeAlarm` using `AlarmFactory.addCompositeAlarm(...)` while simultaneously specifying a suppressor alarm. This pull request adds this functionality, while being backwards-compatible, since all new props are optional.

### Testing
- `yarn build`
  - Added suite of unit tests to test suppressor alarm prop behavior.
  
---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_