### PR TITLE
fix(AlarmFactory): Fix wording for actionsSuppressorExtensionPeriod prop to use 'duration' instead of 'time in seconds'

### DIFF
--- a/API.md
+++ b/API.md
@@ -2815,7 +2815,7 @@ const addCompositeAlarmProps: AddCompositeAlarmProps = { ... }
 | <code><a href="#cdk-monitoring-constructs.AddCompositeAlarmProps.property.actionOverride">actionOverride</a></code> | <code><a href="#cdk-monitoring-constructs.IAlarmActionStrategy">IAlarmActionStrategy</a></code> | Allows to override the default action strategy. |
 | <code><a href="#cdk-monitoring-constructs.AddCompositeAlarmProps.property.actionsEnabled">actionsEnabled</a></code> | <code>boolean</code> | Enables the configured CloudWatch alarm ticketing actions. |
 | <code><a href="#cdk-monitoring-constructs.AddCompositeAlarmProps.property.actionsSuppressor">actionsSuppressor</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IAlarm</code> | Actions will be suppressed if the suppressor alarm is in the ALARM state. |
-| <code><a href="#cdk-monitoring-constructs.AddCompositeAlarmProps.property.actionsSuppressorExtensionPeriod">actionsSuppressorExtensionPeriod</a></code> | <code>aws-cdk-lib.Duration</code> | The maximum time in seconds that the composite alarm waits after suppressor alarm goes out of the ALARM state. |
+| <code><a href="#cdk-monitoring-constructs.AddCompositeAlarmProps.property.actionsSuppressorExtensionPeriod">actionsSuppressorExtensionPeriod</a></code> | <code>aws-cdk-lib.Duration</code> | The maximum duration that the composite alarm waits after suppressor alarm goes out of the ALARM state. |
 | <code><a href="#cdk-monitoring-constructs.AddCompositeAlarmProps.property.actionsSuppressorWaitPeriod">actionsSuppressorWaitPeriod</a></code> | <code>aws-cdk-lib.Duration</code> | The maximum duration that the composite alarm waits for the suppressor alarm to go into the ALARM state. |
 | <code><a href="#cdk-monitoring-constructs.AddCompositeAlarmProps.property.alarmDedupeStringSuffix">alarmDedupeStringSuffix</a></code> | <code>string</code> | If this is defined, the default resource-specific alarm dedupe string will be set and this will be added as a suffix. |
 | <code><a href="#cdk-monitoring-constructs.AddCompositeAlarmProps.property.alarmDescription">alarmDescription</a></code> | <code>string</code> | Alarm description is included in the ticket and therefore should describe what happened, with as much context as possible. |
@@ -2892,7 +2892,7 @@ public readonly actionsSuppressorExtensionPeriod: Duration;
 - *Type:* aws-cdk-lib.Duration
 - *Default:* 60 seconds
 
-The maximum time in seconds that the composite alarm waits after suppressor alarm goes out of the ALARM state.
+The maximum duration that the composite alarm waits after suppressor alarm goes out of the ALARM state.
 
 After this time, the composite alarm performs its actions.
 

--- a/lib/common/alarm/AlarmFactory.ts
+++ b/lib/common/alarm/AlarmFactory.ts
@@ -398,7 +398,7 @@ export interface AddCompositeAlarmProps {
   readonly actionsSuppressor?: IAlarm;
 
   /**
-   * The maximum time in seconds that the composite alarm waits after suppressor alarm goes out of the ALARM state.
+   * The maximum duration that the composite alarm waits after suppressor alarm goes out of the ALARM state.
    * After this time, the composite alarm performs its actions.
    *
    * @default - 60 seconds


### PR DESCRIPTION
### Description
No code logic changes.

Unfortunately missed changing `actionsSuppressorExtensionPeriod` prop description to use "duration" instead of "time in seconds". The "time in seconds" descriptor is used in [CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudwatch-compositealarm.html), but since the prop type required by CDK `CompositeAlarm` is `Duration`, it's more accurate to use "duration" (and to be consistent with the [CDK Composite Alarm definition](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_cloudwatch.CompositeAlarm.html)).

Note: This wording change was already done for `actionsSuppressorWaitPeriod`; only `actionsSuppressorExtensionPeriod` was missed.

### Testing
- `yarn build` -- no code logic changes so no additional unit tests necessary.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_