### PR TITLE
feat(dynamo): add ability to alarm on min TTL deletions

### DIFF
--- a/API.md
+++ b/API.md
@@ -15319,6 +15319,7 @@ const dynamoTableMonitoringOptions: DynamoTableMonitoringOptions = { ... }
 | <code><a href="#cdk-monitoring-constructs.DynamoTableMonitoringOptions.property.addAverageSuccessfulUpdateItemLatencyAlarm">addAverageSuccessfulUpdateItemLatencyAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.DynamoTableMonitoringOptions.property.addConsumedReadCapacityAlarm">addConsumedReadCapacityAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ConsumedCapacityThreshold">ConsumedCapacityThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.DynamoTableMonitoringOptions.property.addConsumedWriteCapacityAlarm">addConsumedWriteCapacityAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ConsumedCapacityThreshold">ConsumedCapacityThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.DynamoTableMonitoringOptions.property.addMinTimeToLiveDeletedItemCountAlarm">addMinTimeToLiveDeletedItemCountAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.MinUsageCountThreshold">MinUsageCountThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.DynamoTableMonitoringOptions.property.addReadThrottledEventsCountAlarm">addReadThrottledEventsCountAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ThrottledEventsThreshold">ThrottledEventsThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.DynamoTableMonitoringOptions.property.addSystemErrorCountAlarm">addSystemErrorCountAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorCountThreshold">ErrorCountThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.DynamoTableMonitoringOptions.property.addWriteThrottledEventsCountAlarm">addWriteThrottledEventsCountAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ThrottledEventsThreshold">ThrottledEventsThreshold</a>}</code> | *No description.* |
@@ -15533,6 +15534,16 @@ public readonly addConsumedWriteCapacityAlarm: {[ key: string ]: ConsumedCapacit
 
 ---
 
+##### `addMinTimeToLiveDeletedItemCountAlarm`<sup>Optional</sup> <a name="addMinTimeToLiveDeletedItemCountAlarm" id="cdk-monitoring-constructs.DynamoTableMonitoringOptions.property.addMinTimeToLiveDeletedItemCountAlarm"></a>
+
+```typescript
+public readonly addMinTimeToLiveDeletedItemCountAlarm: {[ key: string ]: MinUsageCountThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.MinUsageCountThreshold">MinUsageCountThreshold</a>}
+
+---
+
 ##### `addReadThrottledEventsCountAlarm`<sup>Optional</sup> <a name="addReadThrottledEventsCountAlarm" id="cdk-monitoring-constructs.DynamoTableMonitoringOptions.property.addReadThrottledEventsCountAlarm"></a>
 
 ```typescript
@@ -15597,6 +15608,7 @@ const dynamoTableMonitoringProps: DynamoTableMonitoringProps = { ... }
 | <code><a href="#cdk-monitoring-constructs.DynamoTableMonitoringProps.property.addAverageSuccessfulUpdateItemLatencyAlarm">addAverageSuccessfulUpdateItemLatencyAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.DynamoTableMonitoringProps.property.addConsumedReadCapacityAlarm">addConsumedReadCapacityAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ConsumedCapacityThreshold">ConsumedCapacityThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.DynamoTableMonitoringProps.property.addConsumedWriteCapacityAlarm">addConsumedWriteCapacityAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ConsumedCapacityThreshold">ConsumedCapacityThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.DynamoTableMonitoringProps.property.addMinTimeToLiveDeletedItemCountAlarm">addMinTimeToLiveDeletedItemCountAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.MinUsageCountThreshold">MinUsageCountThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.DynamoTableMonitoringProps.property.addReadThrottledEventsCountAlarm">addReadThrottledEventsCountAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ThrottledEventsThreshold">ThrottledEventsThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.DynamoTableMonitoringProps.property.addSystemErrorCountAlarm">addSystemErrorCountAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorCountThreshold">ErrorCountThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.DynamoTableMonitoringProps.property.addWriteThrottledEventsCountAlarm">addWriteThrottledEventsCountAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ThrottledEventsThreshold">ThrottledEventsThreshold</a>}</code> | *No description.* |
@@ -15833,6 +15845,16 @@ public readonly addConsumedWriteCapacityAlarm: {[ key: string ]: ConsumedCapacit
 ```
 
 - *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.ConsumedCapacityThreshold">ConsumedCapacityThreshold</a>}
+
+---
+
+##### `addMinTimeToLiveDeletedItemCountAlarm`<sup>Optional</sup> <a name="addMinTimeToLiveDeletedItemCountAlarm" id="cdk-monitoring-constructs.DynamoTableMonitoringProps.property.addMinTimeToLiveDeletedItemCountAlarm"></a>
+
+```typescript
+public readonly addMinTimeToLiveDeletedItemCountAlarm: {[ key: string ]: MinUsageCountThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.MinUsageCountThreshold">MinUsageCountThreshold</a>}
 
 ---
 
@@ -53960,6 +53982,7 @@ new DynamoTableMetricFactory(metricFactory: MetricFactory, props: DynamoTableMet
 | <code><a href="#cdk-monitoring-constructs.DynamoTableMetricFactory.metricSystemErrorsCount">metricSystemErrorsCount</a></code> | This represents the number of requests that resulted in a 500 (server error) error code. |
 | <code><a href="#cdk-monitoring-constructs.DynamoTableMetricFactory.metricThrottledReadRequestCount">metricThrottledReadRequestCount</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.DynamoTableMetricFactory.metricThrottledWriteRequestCount">metricThrottledWriteRequestCount</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.DynamoTableMetricFactory.metricTimeToLiveDeletedItemCount">metricTimeToLiveDeletedItemCount</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.DynamoTableMetricFactory.metricWriteCapacityUtilizationPercentage">metricWriteCapacityUtilizationPercentage</a></code> | *No description.* |
 
 ---
@@ -54035,6 +54058,12 @@ public metricThrottledReadRequestCount(): Metric | MathExpression
 
 ```typescript
 public metricThrottledWriteRequestCount(): Metric | MathExpression
+```
+
+##### `metricTimeToLiveDeletedItemCount` <a name="metricTimeToLiveDeletedItemCount" id="cdk-monitoring-constructs.DynamoTableMetricFactory.metricTimeToLiveDeletedItemCount"></a>
+
+```typescript
+public metricTimeToLiveDeletedItemCount(): Metric | MathExpression
 ```
 
 ##### `metricWriteCapacityUtilizationPercentage` <a name="metricWriteCapacityUtilizationPercentage" id="cdk-monitoring-constructs.DynamoTableMetricFactory.metricWriteCapacityUtilizationPercentage"></a>
@@ -54315,7 +54344,9 @@ public createWriteCapacityWidget(width: number, height: number): GraphWidget
 | <code><a href="#cdk-monitoring-constructs.DynamoTableMonitoring.property.systemErrorMetric">systemErrorMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.DynamoTableMonitoring.property.tableBillingMode">tableBillingMode</a></code> | <code>aws-cdk-lib.aws_dynamodb.BillingMode</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.DynamoTableMonitoring.property.throttledEventsAnnotations">throttledEventsAnnotations</a></code> | <code>aws-cdk-lib.aws_cloudwatch.HorizontalAnnotation[]</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.DynamoTableMonitoring.property.timeToLiveDeletedItemCountMetric">timeToLiveDeletedItemCountMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.DynamoTableMonitoring.property.title">title</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.DynamoTableMonitoring.property.usageAlarmFactory">usageAlarmFactory</a></code> | <code><a href="#cdk-monitoring-constructs.UsageAlarmFactory">UsageAlarmFactory</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.DynamoTableMonitoring.property.writeCapacityUsageMetric">writeCapacityUsageMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.DynamoTableMonitoring.property.writeThrottleCountMetric">writeThrottleCountMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.DynamoTableMonitoring.property.tableUrl">tableUrl</a></code> | <code>string</code> | *No description.* |
@@ -54512,6 +54543,16 @@ public readonly throttledEventsAnnotations: HorizontalAnnotation[];
 
 ---
 
+##### `timeToLiveDeletedItemCountMetric`<sup>Required</sup> <a name="timeToLiveDeletedItemCountMetric" id="cdk-monitoring-constructs.DynamoTableMonitoring.property.timeToLiveDeletedItemCountMetric"></a>
+
+```typescript
+public readonly timeToLiveDeletedItemCountMetric: Metric | MathExpression;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.Metric | aws-cdk-lib.aws_cloudwatch.MathExpression
+
+---
+
 ##### `title`<sup>Required</sup> <a name="title" id="cdk-monitoring-constructs.DynamoTableMonitoring.property.title"></a>
 
 ```typescript
@@ -54519,6 +54560,16 @@ public readonly title: string;
 ```
 
 - *Type:* string
+
+---
+
+##### `usageAlarmFactory`<sup>Required</sup> <a name="usageAlarmFactory" id="cdk-monitoring-constructs.DynamoTableMonitoring.property.usageAlarmFactory"></a>
+
+```typescript
+public readonly usageAlarmFactory: UsageAlarmFactory;
+```
+
+- *Type:* <a href="#cdk-monitoring-constructs.UsageAlarmFactory">UsageAlarmFactory</a>
 
 ---
 

--- a/lib/monitoring/aws-dynamo/DynamoTableMetricFactory.ts
+++ b/lib/monitoring/aws-dynamo/DynamoTableMetricFactory.ts
@@ -4,13 +4,10 @@ import { BillingMode, ITable, Operation } from "aws-cdk-lib/aws-dynamodb";
 import { MetricFactory, MetricStatistic } from "../../common";
 
 const DynamoDbNamespace = "AWS/DynamoDB";
-const ProvisionedReadCapacityUnitsMetric = "ProvisionedReadCapacityUnits";
-const ProvisionedWriteCapacityUnitsMetric = "ProvisionedWriteCapacityUnits";
 const ProvisionedLabel = "Provisioned";
 const ConsumedLabel = "Consumed";
 const ReadThrottleEventsLabel = "Read";
 const WriteThrottleEventsLabel = "Write";
-const SystemErrorsLabel = "System Errors";
 
 export interface DynamoTableMetricFactoryProps {
   /**
@@ -39,7 +36,7 @@ export class DynamoTableMetricFactory {
 
   metricProvisionedReadCapacityUnits() {
     return this.metricFactory.adaptMetric(
-      this.table.metric(ProvisionedReadCapacityUnitsMetric, {
+      this.table.metric("ProvisionedReadCapacityUnits", {
         label: ProvisionedLabel,
         statistic: MetricStatistic.AVERAGE,
       })
@@ -48,7 +45,7 @@ export class DynamoTableMetricFactory {
 
   metricProvisionedWriteCapacityUnits() {
     return this.metricFactory.adaptMetric(
-      this.table.metric(ProvisionedWriteCapacityUnitsMetric, {
+      this.table.metric("ProvisionedWriteCapacityUnits", {
         label: ProvisionedLabel,
         statistic: MetricStatistic.AVERAGE,
       })
@@ -195,7 +192,16 @@ export class DynamoTableMetricFactory {
       // the metric is not emitted until error happens
       Object.keys(usingMetrics).join("+"),
       usingMetrics,
-      SystemErrorsLabel
+      "System Errors"
+    );
+  }
+
+  metricTimeToLiveDeletedItemCount() {
+    return this.metricFactory.adaptMetric(
+      this.table.metric("TimeToLiveDeletedItemCount", {
+        label: "TTL Deleted Item Count",
+        statistic: MetricStatistic.MAX,
+      })
     );
   }
 }

--- a/test/monitoring/aws-dynamo/DynamoTableMonitoring.test.ts
+++ b/test/monitoring/aws-dynamo/DynamoTableMonitoring.test.ts
@@ -1,5 +1,6 @@
 import { Duration, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
+import { TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
 import { AttributeType, BillingMode, Table } from "aws-cdk-lib/aws-dynamodb";
 
 import { AlarmWithAnnotation, DynamoTableMonitoring } from "../../../lib";
@@ -62,6 +63,11 @@ test("snapshot test: all alarms", () => {
         evaluationPeriods: 8,
       },
     },
+    addMinTimeToLiveDeletedItemCountAlarm: {
+      Warning: {
+        minCount: 5,
+      },
+    },
     addReadThrottledEventsCountAlarm: {
       Warning: {
         maxThrottledEventsThreshold: 5,
@@ -125,7 +131,7 @@ test("snapshot test: all alarms", () => {
   });
 
   addMonitoringDashboardsToStack(stack, monitoring);
-  expect(numAlarmsCreated).toStrictEqual(14);
+  expect(numAlarmsCreated).toStrictEqual(15);
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });
 
@@ -187,6 +193,12 @@ test("snapshot test: pay-per-request, all alarms", () => {
         evaluationPeriods: 8,
       },
     },
+    addMinTimeToLiveDeletedItemCountAlarm: {
+      Warning: {
+        minCount: 5,
+        treatMissingDataOverride: TreatMissingData.MISSING,
+      },
+    },
     addReadThrottledEventsCountAlarm: {
       Warning: {
         maxThrottledEventsThreshold: 5,
@@ -250,6 +262,6 @@ test("snapshot test: pay-per-request, all alarms", () => {
   });
 
   addMonitoringDashboardsToStack(stack, monitoring);
-  expect(numAlarmsCreated).toStrictEqual(14);
+  expect(numAlarmsCreated).toStrictEqual(15);
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });

--- a/test/monitoring/aws-dynamo/__snapshots__/DynamoTableMonitoring.test.ts.snap
+++ b/test/monitoring/aws-dynamo/__snapshots__/DynamoTableMonitoring.test.ts.snap
@@ -78,7 +78,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyTableLatencyAverageGetRecordsWarning82DF1F20",
+                  "ScopeTestDummyTableMinUsageCountWarning9A39C286",
                   "Arn",
                 ],
               },
@@ -89,7 +89,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyTableLatencyAverageQueryWarning49AF55CE",
+                  "ScopeTestDummyTableLatencyAverageGetRecordsWarning82DF1F20",
                   "Arn",
                 ],
               },
@@ -100,7 +100,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyTableLatencyAverageScanWarning609C9E1C",
+                  "ScopeTestDummyTableLatencyAverageQueryWarning49AF55CE",
                   "Arn",
                 ],
               },
@@ -111,7 +111,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyTableLatencyAveragePutItemWarningB14582BC",
+                  "ScopeTestDummyTableLatencyAverageScanWarning609C9E1C",
                   "Arn",
                 ],
               },
@@ -122,7 +122,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyTableLatencyAverageGetItemWarningE365AEB3",
+                  "ScopeTestDummyTableLatencyAveragePutItemWarningB14582BC",
                   "Arn",
                 ],
               },
@@ -133,7 +133,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyTableLatencyAverageUpdateItemWarning6A127C47",
+                  "ScopeTestDummyTableLatencyAverageGetItemWarningE365AEB3",
                   "Arn",
                 ],
               },
@@ -144,7 +144,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyTableLatencyAverageDeleteItemWarning13699989",
+                  "ScopeTestDummyTableLatencyAverageUpdateItemWarning6A127C47",
                   "Arn",
                 ],
               },
@@ -155,11 +155,22 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyTableLatencyAverageBatchGetItemWarning93533EB0",
+                  "ScopeTestDummyTableLatencyAverageDeleteItemWarning13699989",
                   "Arn",
                 ],
               },
               "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":6,\\"y\\":12,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyTableLatencyAverageBatchGetItemWarning93533EB0",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":12,\\"y\\":12,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -635,6 +646,42 @@ Object {
         ],
         "Threshold": 505,
         "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyTableMinUsageCountWarning9A39C286": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "The count is too low.",
+        "AlarmName": "Test-DummyTable-Min-Usage-Count-Warning",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TTL Deleted Item Count",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "TableName",
+                    "Value": Object {
+                      "Ref": "TableCD117FA1",
+                    },
+                  },
+                ],
+                "MetricName": "TimeToLiveDeletedItemCount",
+                "Namespace": "AWS/DynamoDB",
+              },
+              "Period": 300,
+              "Stat": "Maximum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 5,
+        "TreatMissingData": "breaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -1423,7 +1470,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyTableLatencyAverageGetRecordsWarning82DF1F20",
+                  "ScopeTestDummyTableMinUsageCountWarning9A39C286",
                   "Arn",
                 ],
               },
@@ -1434,7 +1481,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyTableLatencyAverageQueryWarning49AF55CE",
+                  "ScopeTestDummyTableLatencyAverageGetRecordsWarning82DF1F20",
                   "Arn",
                 ],
               },
@@ -1445,7 +1492,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyTableLatencyAverageScanWarning609C9E1C",
+                  "ScopeTestDummyTableLatencyAverageQueryWarning49AF55CE",
                   "Arn",
                 ],
               },
@@ -1456,7 +1503,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyTableLatencyAveragePutItemWarningB14582BC",
+                  "ScopeTestDummyTableLatencyAverageScanWarning609C9E1C",
                   "Arn",
                 ],
               },
@@ -1467,7 +1514,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyTableLatencyAverageGetItemWarningE365AEB3",
+                  "ScopeTestDummyTableLatencyAveragePutItemWarningB14582BC",
                   "Arn",
                 ],
               },
@@ -1478,7 +1525,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyTableLatencyAverageUpdateItemWarning6A127C47",
+                  "ScopeTestDummyTableLatencyAverageGetItemWarningE365AEB3",
                   "Arn",
                 ],
               },
@@ -1489,7 +1536,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyTableLatencyAverageDeleteItemWarning13699989",
+                  "ScopeTestDummyTableLatencyAverageUpdateItemWarning6A127C47",
                   "Arn",
                 ],
               },
@@ -1500,11 +1547,22 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyTableLatencyAverageBatchGetItemWarning93533EB0",
+                  "ScopeTestDummyTableLatencyAverageDeleteItemWarning13699989",
                   "Arn",
                 ],
               },
               "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":6,\\"y\\":12,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyTableLatencyAverageBatchGetItemWarning93533EB0",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":12,\\"y\\":12,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -1972,6 +2030,42 @@ Object {
         ],
         "Threshold": 505,
         "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyTableMinUsageCountWarning9A39C286": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "The count is too low.",
+        "AlarmName": "Test-DummyTable-Min-Usage-Count-Warning",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TTL Deleted Item Count",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "TableName",
+                    "Value": Object {
+                      "Ref": "TableCD117FA1",
+                    },
+                  },
+                ],
+                "MetricName": "TimeToLiveDeletedItemCount",
+                "Namespace": "AWS/DynamoDB",
+              },
+              "Period": 300,
+              "Stat": "Maximum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 5,
+        "TreatMissingData": "missing",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },


### PR DESCRIPTION
This can be used a proxy for ensuring that TTL is enabled and behaving as expected.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_