### PR TITLE
feat: drop peer dependency on @aws-cdk/aws-redshift-alpha

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -120,11 +120,6 @@
       "type": "override"
     },
     {
-      "name": "@aws-cdk/aws-redshift-alpha",
-      "version": "^2.112.0-alpha.0",
-      "type": "peer"
-    },
-    {
       "name": "aws-cdk-lib",
       "version": "^2.112.0",
       "type": "peer"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -80,10 +80,6 @@ _By submitting this pull request, I confirm that my contribution is made under t
 // Experimental modules
 ["@aws-cdk/aws-redshift-alpha"].forEach((dep) => {
   project.deps.addDependency(
-    `${dep}@^${CDK_VERSION}-alpha.0`,
-    DependencyType.PEER
-  );
-  project.deps.addDependency(
     `${dep}@${CDK_VERSION}-alpha.0`,
     DependencyType.DEVENV
   );

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ In your `package.json`:
     "cdk-monitoring-constructs": "^7.0.0",
 
     // peer dependencies of cdk-monitoring-constructs
-    "@aws-cdk/aws-redshift-alpha": "^2.112.0-alpha.0",
     "aws-cdk-lib": "^2.112.0",
     "constructs": "^10.0.5"
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "@aws-cdk/aws-redshift-alpha": "^2.112.0-alpha.0",
     "aws-cdk-lib": "^2.112.0",
     "constructs": "^10.0.5"
   },

--- a/test/facade/__snapshots__/MonitoringAspect.test.ts.snap
+++ b/test/facade/__snapshots__/MonitoringAspect.test.ts.snap
@@ -7457,7 +7457,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Redshift Cluster **[Default/DummyCluster](https://",
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Redshift Cluster **[Default/DummyCluster/Resource](https://",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -7539,7 +7539,7 @@ Object {
           "Fn::Join": Array [
             "",
             Array [
-              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Redshift Cluster **[Default/DummyCluster](https://",
+              "{\\"start\\":\\"-P14D\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Redshift Cluster **[Default/DummyCluster/Resource](https://",
               Object {
                 "Ref": "AWS::Region",
               },


### PR DESCRIPTION
Fixes #212.

We don't _really_ use the L2 constructs directly, so we add our own rough type checking logic to replace the one usage we did have but retain the dev dependency for testing purposes.

For reference, [here's the current L2 `Cluster` implementation](https://github.com/aws/aws-cdk/blob/v2.146.0/packages/@aws-cdk/aws-redshift-alpha/lib/cluster.ts#L432).

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_