### PR TITLE
fix(MetricFactory): avoid specifying region/account if not different from environment

### DIFF
--- a/API.md
+++ b/API.md
@@ -65886,18 +65886,25 @@ public readonly title: string;
 ```typescript
 import { MetricFactory } from 'cdk-monitoring-constructs'
 
-new MetricFactory(props?: MetricFactoryProps)
+new MetricFactory(props?: MetricFactoryProps, scope?: Construct)
 ```
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.MetricFactory.Initializer.parameter.props">props</a></code> | <code><a href="#cdk-monitoring-constructs.MetricFactoryProps">MetricFactoryProps</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.MetricFactory.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
 
 ---
 
 ##### `props`<sup>Optional</sup> <a name="props" id="cdk-monitoring-constructs.MetricFactory.Initializer.parameter.props"></a>
 
 - *Type:* <a href="#cdk-monitoring-constructs.MetricFactoryProps">MetricFactoryProps</a>
+
+---
+
+##### `scope`<sup>Optional</sup> <a name="scope" id="cdk-monitoring-constructs.MetricFactory.Initializer.parameter.scope"></a>
+
+- *Type:* constructs.Construct
 
 ---
 

--- a/lib/facade/MonitoringFacade.ts
+++ b/lib/facade/MonitoringFacade.ts
@@ -202,7 +202,12 @@ export class MonitoringFacade extends MonitoringScope {
   }
 
   createMetricFactory(): MetricFactory {
-    return new MetricFactory({ globalDefaults: this.metricFactoryDefaults });
+    return new MetricFactory(
+      {
+        globalDefaults: this.metricFactoryDefaults,
+      },
+      this,
+    );
   }
 
   createWidgetFactory(): IWidgetFactory {

--- a/test/common/metric/MetricFactory.test.ts
+++ b/test/common/metric/MetricFactory.test.ts
@@ -1,5 +1,5 @@
-import { Duration } from "aws-cdk-lib";
-import { Metric } from "aws-cdk-lib/aws-cloudwatch";
+import { Duration, Stack } from "aws-cdk-lib";
+import { Color, Metric } from "aws-cdk-lib/aws-cloudwatch";
 
 import {
   MetricFactory,
@@ -167,16 +167,26 @@ test("snapshot test: createMetricMath", () => {
 });
 
 test("snapshot test: toRate with detail", () => {
-  const metricFactory = new MetricFactory({
-    globalDefaults: {
-      namespace: "DummyNamespace",
+  const stack = new Stack();
+  const metricFactory = new MetricFactory(
+    {
+      globalDefaults: {
+        namespace: "DummyNamespace",
+      },
     },
-  });
+    stack,
+  );
 
   const metric = metricFactory.createMetric(
     "Metric",
     MetricStatistic.SUM,
     "Label",
+    undefined,
+    Color.ORANGE,
+    "Namespace",
+    undefined,
+    "eu-west-1",
+    "01234567890",
   );
 
   const metricAverage = metricFactory.toRate(
@@ -185,6 +195,13 @@ test("snapshot test: toRate with detail", () => {
     true,
   );
   expect(metricAverage).toMatchSnapshot();
+
+  const metricAverageWithAccount = metricFactory.toRate(
+    metric.with({ account: "1111111111" }),
+    RateComputationMethod.AVERAGE,
+    true,
+  );
+  expect(metricAverageWithAccount).toMatchSnapshot();
 
   const metricPerSecond = metricFactory.toRate(
     metric,

--- a/test/common/metric/__snapshots__/MetricFactory.test.ts.snap
+++ b/test/common/metric/__snapshots__/MetricFactory.test.ts.snap
@@ -889,12 +889,12 @@ Object {
 
 exports[`snapshot test: toRate with detail 1`] = `
 Metric {
-  "account": undefined,
-  "color": undefined,
+  "account": "01234567890",
+  "color": "#ff7f0e",
   "dimensions": undefined,
   "label": "Label (avg) (min: \${MIN}, max: \${MAX})",
   "metricName": "Metric",
-  "namespace": "DummyNamespace",
+  "namespace": "Namespace",
   "period": Duration {
     "amount": 5,
     "unit": TimeUnit {
@@ -903,7 +903,7 @@ Metric {
       "label": "minutes",
     },
   },
-  "region": undefined,
+  "region": "eu-west-1",
   "statistic": "Average",
   "unit": undefined,
   "warnings": undefined,
@@ -911,8 +911,31 @@ Metric {
 `;
 
 exports[`snapshot test: toRate with detail 2`] = `
+Metric {
+  "account": "1111111111",
+  "color": "#ff7f0e",
+  "dimensions": undefined,
+  "label": "Label (avg) (min: \${MIN}, max: \${MAX})",
+  "metricName": "Metric",
+  "namespace": "Namespace",
+  "period": Duration {
+    "amount": 5,
+    "unit": TimeUnit {
+      "inMillis": 60000,
+      "isoLabel": "M",
+      "label": "minutes",
+    },
+  },
+  "region": "eu-west-1",
+  "statistic": "Average",
+  "unit": undefined,
+  "warnings": undefined,
+}
+`;
+
+exports[`snapshot test: toRate with detail 3`] = `
 MathExpression {
-  "color": undefined,
+  "color": "#ff7f0e",
   "expression": "m1 / PERIOD(m1)",
   "label": "Label/s (min: \${MIN}, max: \${MAX}, avg: \${AVG})",
   "period": Duration {
@@ -927,12 +950,12 @@ MathExpression {
   "searchRegion": undefined,
   "usingMetrics": Object {
     "m1": Metric {
-      "account": undefined,
-      "color": undefined,
+      "account": "01234567890",
+      "color": "#ff7f0e",
       "dimensions": undefined,
       "label": "Label",
       "metricName": "Metric",
-      "namespace": "DummyNamespace",
+      "namespace": "Namespace",
       "period": Duration {
         "amount": 5,
         "unit": TimeUnit {
@@ -941,7 +964,7 @@ MathExpression {
           "label": "minutes",
         },
       },
-      "region": undefined,
+      "region": "eu-west-1",
       "statistic": "Sum",
       "unit": undefined,
       "warnings": undefined,
@@ -950,9 +973,9 @@ MathExpression {
 }
 `;
 
-exports[`snapshot test: toRate with detail 3`] = `
+exports[`snapshot test: toRate with detail 4`] = `
 MathExpression {
-  "color": undefined,
+  "color": "#ff7f0e",
   "expression": "(60 * m1) / PERIOD(m1)",
   "label": "Label/m (min: \${MIN}, max: \${MAX}, avg: \${AVG})",
   "period": Duration {
@@ -967,12 +990,12 @@ MathExpression {
   "searchRegion": undefined,
   "usingMetrics": Object {
     "m1": Metric {
-      "account": undefined,
-      "color": undefined,
+      "account": "01234567890",
+      "color": "#ff7f0e",
       "dimensions": undefined,
       "label": "Label",
       "metricName": "Metric",
-      "namespace": "DummyNamespace",
+      "namespace": "Namespace",
       "period": Duration {
         "amount": 5,
         "unit": TimeUnit {
@@ -981,7 +1004,7 @@ MathExpression {
           "label": "minutes",
         },
       },
-      "region": undefined,
+      "region": "eu-west-1",
       "statistic": "Sum",
       "unit": undefined,
       "warnings": undefined,
@@ -990,9 +1013,9 @@ MathExpression {
 }
 `;
 
-exports[`snapshot test: toRate with detail 4`] = `
+exports[`snapshot test: toRate with detail 5`] = `
 MathExpression {
-  "color": undefined,
+  "color": "#ff7f0e",
   "expression": "(3600 * m1) / PERIOD(m1)",
   "label": "Label/h (min: \${MIN}, max: \${MAX}, avg: \${AVG})",
   "period": Duration {
@@ -1007,12 +1030,12 @@ MathExpression {
   "searchRegion": undefined,
   "usingMetrics": Object {
     "m1": Metric {
-      "account": undefined,
-      "color": undefined,
+      "account": "01234567890",
+      "color": "#ff7f0e",
       "dimensions": undefined,
       "label": "Label",
       "metricName": "Metric",
-      "namespace": "DummyNamespace",
+      "namespace": "Namespace",
       "period": Duration {
         "amount": 5,
         "unit": TimeUnit {
@@ -1021,7 +1044,7 @@ MathExpression {
           "label": "minutes",
         },
       },
-      "region": undefined,
+      "region": "eu-west-1",
       "statistic": "Sum",
       "unit": undefined,
       "warnings": undefined,
@@ -1030,9 +1053,9 @@ MathExpression {
 }
 `;
 
-exports[`snapshot test: toRate with detail 5`] = `
+exports[`snapshot test: toRate with detail 6`] = `
 MathExpression {
-  "color": undefined,
+  "color": "#ff7f0e",
   "expression": "(86400 * m1) / PERIOD(m1)",
   "label": "Label/d (min: \${MIN}, max: \${MAX}, avg: \${AVG})",
   "period": Duration {
@@ -1047,12 +1070,12 @@ MathExpression {
   "searchRegion": undefined,
   "usingMetrics": Object {
     "m1": Metric {
-      "account": undefined,
-      "color": undefined,
+      "account": "01234567890",
+      "color": "#ff7f0e",
       "dimensions": undefined,
       "label": "Label",
       "metricName": "Metric",
-      "namespace": "DummyNamespace",
+      "namespace": "Namespace",
       "period": Duration {
         "amount": 5,
         "unit": TimeUnit {
@@ -1061,7 +1084,7 @@ MathExpression {
           "label": "minutes",
         },
       },
-      "region": undefined,
+      "region": "eu-west-1",
       "statistic": "Sum",
       "unit": undefined,
       "warnings": undefined,

--- a/test/facade/MonitoringFacade.test.ts
+++ b/test/facade/MonitoringFacade.test.ts
@@ -2,6 +2,7 @@ import { Duration, Stack } from "aws-cdk-lib";
 import { Capture, Template } from "aws-cdk-lib/assertions";
 import { TextWidget } from "aws-cdk-lib/aws-cloudwatch";
 import { Table } from "aws-cdk-lib/aws-dynamodb";
+import { Function } from "aws-cdk-lib/aws-lambda";
 import { Topic } from "aws-cdk-lib/aws-sns";
 import {
   DefaultDashboardFactory,
@@ -92,6 +93,7 @@ describe("test of defaults", () => {
         action: notifySns(onAlarmTopic),
       },
     });
+
     facade
       .addLargeHeader("My App Dashboard")
       .monitorDynamoTable({
@@ -110,11 +112,18 @@ describe("test of defaults", () => {
         ),
         region: "us-west-2",
         account: "01234567890",
-        addAverageSuccessfulGetItemLatencyAlarm: {
-          Critical: {
-            maxLatency: Duration.seconds(10),
+      })
+      .monitorLambdaFunction({
+        account: "01234567890",
+        region: "us-west-2",
+        lambdaFunction: Function.fromFunctionAttributes(
+          stack,
+          "XaXrImportedFunction",
+          {
+            functionArn: `arn:aws:lambda:us-west-2:01234567890:function:MyFunction`,
+            sameEnvironment: false,
           },
-        },
+        ),
       });
 
     expect(Template.fromStack(stack)).toMatchSnapshot();

--- a/test/facade/__snapshots__/MonitoringAspect.test.ts.snap
+++ b/test/facade/__snapshots__/MonitoringAspect.test.ts.snap
@@ -9216,11 +9216,7 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"Rule\\",\\"ALL\\",{\\"label\\":\\"Allowed\\",\\"region\\":\\"",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              "\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":8,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Blocked Requests\\",\\"region\\":\\"",
+              "\\",\\"Rule\\",\\"ALL\\",{\\"label\\":\\"Allowed\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":8,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Blocked Requests\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -9228,11 +9224,7 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"Rule\\",\\"ALL\\",{\\"label\\":\\"Blocked\\",\\"region\\":\\"",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              "\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":16,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Blocked Requests (rate)\\",\\"region\\":\\"",
+              "\\",\\"Rule\\",\\"ALL\\",{\\"label\\":\\"Blocked\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":16,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Blocked Requests (rate)\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -9240,19 +9232,11 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"Rule\\",\\"ALL\\",{\\"label\\":\\"Allowed\\",\\"region\\":\\"",
+              "\\",\\"Rule\\",\\"ALL\\",{\\"label\\":\\"Allowed\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"allowed\\"}],[\\"AWS/WAFV2\\",\\"BlockedRequests\\",\\"Region\\",\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"allowed\\"}],[\\"AWS/WAFV2\\",\\"BlockedRequests\\",\\"Region\\",\\"",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              "\\",\\"Rule\\",\\"ALL\\",{\\"label\\":\\"Blocked\\",\\"region\\":\\"",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              "\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"blocked\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
+              "\\",\\"Rule\\",\\"ALL\\",{\\"label\\":\\"Blocked\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"blocked\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
             ],
           ],
         },
@@ -9274,11 +9258,7 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"Rule\\",\\"ALL\\",{\\"label\\":\\"Allowed\\",\\"region\\":\\"",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              "\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Blocked Requests\\",\\"region\\":\\"",
+              "\\",\\"Rule\\",\\"ALL\\",{\\"label\\":\\"Allowed\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Blocked Requests\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -9286,11 +9266,7 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"Rule\\",\\"ALL\\",{\\"label\\":\\"Blocked\\",\\"region\\":\\"",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              "\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Blocked Requests (rate)\\",\\"region\\":\\"",
+              "\\",\\"Rule\\",\\"ALL\\",{\\"label\\":\\"Blocked\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Blocked Requests (rate)\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -9298,19 +9274,11 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"Rule\\",\\"ALL\\",{\\"label\\":\\"Allowed\\",\\"region\\":\\"",
+              "\\",\\"Rule\\",\\"ALL\\",{\\"label\\":\\"Allowed\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"allowed\\"}],[\\"AWS/WAFV2\\",\\"BlockedRequests\\",\\"Region\\",\\"",
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"allowed\\"}],[\\"AWS/WAFV2\\",\\"BlockedRequests\\",\\"Region\\",\\"",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              "\\",\\"Rule\\",\\"ALL\\",{\\"label\\":\\"Blocked\\",\\"region\\":\\"",
-              Object {
-                "Ref": "AWS::Region",
-              },
-              "\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"blocked\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
+              "\\",\\"Rule\\",\\"ALL\\",{\\"label\\":\\"Blocked\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"blocked\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
             ],
           ],
         },

--- a/test/facade/__snapshots__/MonitoringFacade.test.ts.snap
+++ b/test/facade/__snapshots__/MonitoringFacade.test.ts.snap
@@ -48,7 +48,7 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[{\\"label\\":\\" \\",\\"expression\\":\\"SEARCH('{AWS/DynamoDB,TableName,Operation} TableName=\\\\\\"my-other-table\\\\\\" MetricName=\\\\\\"SuccessfulRequestLatency\\\\\\"', 'Average', 300)\\",\\"accountId\\":\\"09876543210\\",\\"region\\":\\"us-east-1\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"GetItem > 10000 for 3 datapoints within 15 minutes\\",\\"value\\":10000,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}},\\"legend\\":{\\"position\\":\\"right\\"}}},{\\"type\\":\\"metric\\",\\"width\\":3,\\"height\\":6,\\"x\\":15,\\"y\\":9,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Throttles\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[{\\"label\\":\\" \\",\\"expression\\":\\"SEARCH('{AWS/DynamoDB,TableName,Operation} TableName=\\\\\\"my-other-table\\\\\\" MetricName=\\\\\\"SuccessfulRequestLatency\\\\\\"', 'Average', 300)\\",\\"accountId\\":\\"09876543210\\",\\"region\\":\\"us-east-1\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}},\\"legend\\":{\\"position\\":\\"right\\"}}},{\\"type\\":\\"metric\\",\\"width\\":3,\\"height\\":6,\\"x\\":15,\\"y\\":9,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Throttles\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -56,7 +56,35 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[{\\"label\\":\\"System Errors\\",\\"expression\\":\\"systemErrorGetItem+systemErrorBatchGetItem+systemErrorScan+systemErrorQuery+systemErrorGetRecords+systemErrorPutItem+systemErrorDeleteItem+systemErrorUpdateItem+systemErrorBatchWriteItem\\",\\"accountId\\":\\"09876543210\\",\\"region\\":\\"us-east-1\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"GetItem\\",\\"TableName\\",\\"my-other-table\\",{\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorGetItem\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"BatchGetItem\\",\\"TableName\\",\\"my-other-table\\",{\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorBatchGetItem\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"Scan\\",\\"TableName\\",\\"my-other-table\\",{\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorScan\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"Query\\",\\"TableName\\",\\"my-other-table\\",{\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorQuery\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"GetRecords\\",\\"TableName\\",\\"my-other-table\\",{\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorGetRecords\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"PutItem\\",\\"TableName\\",\\"my-other-table\\",{\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorPutItem\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"DeleteItem\\",\\"TableName\\",\\"my-other-table\\",{\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorDeleteItem\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"UpdateItem\\",\\"TableName\\",\\"my-other-table\\",{\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorUpdateItem\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"BatchWriteItem\\",\\"TableName\\",\\"my-other-table\\",{\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorBatchWriteItem\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}}]}",
+              "\\",\\"metrics\\":[[{\\"label\\":\\"System Errors\\",\\"expression\\":\\"systemErrorGetItem+systemErrorBatchGetItem+systemErrorScan+systemErrorQuery+systemErrorGetRecords+systemErrorPutItem+systemErrorDeleteItem+systemErrorUpdateItem+systemErrorBatchWriteItem\\",\\"accountId\\":\\"09876543210\\",\\"region\\":\\"us-east-1\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"GetItem\\",\\"TableName\\",\\"my-other-table\\",{\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorGetItem\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"BatchGetItem\\",\\"TableName\\",\\"my-other-table\\",{\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorBatchGetItem\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"Scan\\",\\"TableName\\",\\"my-other-table\\",{\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorScan\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"Query\\",\\"TableName\\",\\"my-other-table\\",{\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorQuery\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"GetRecords\\",\\"TableName\\",\\"my-other-table\\",{\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorGetRecords\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"PutItem\\",\\"TableName\\",\\"my-other-table\\",{\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorPutItem\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"DeleteItem\\",\\"TableName\\",\\"my-other-table\\",{\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorDeleteItem\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"UpdateItem\\",\\"TableName\\",\\"my-other-table\\",{\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorUpdateItem\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"BatchWriteItem\\",\\"TableName\\",\\"my-other-table\\",{\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorBatchWriteItem\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":15,\\"properties\\":{\\"markdown\\":\\"### Lambda Function **[XaXrImportedFunction](https://us-east-1.console.aws.amazon.com/lambda/home?region=us-east-1#/functions/MyFunction)**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":16,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"TPS\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\",\\"accountId\\":\\"09876543210\\",\\"region\\":\\"us-east-1\\"}],[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"Invocations\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":16,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"p50\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"P90 (avg: \${AVG})\\",\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"p90\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"P99 (avg: \${AVG})\\",\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"p99\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":16,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"Faults (avg)\\",\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":16,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Rates\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"Throttles (avg)\\",\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\"}],[\\"AWS/Lambda\\",\\"ProvisionedConcurrencySpilloverInvocations\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"Provisioned Concurrency Spillovers (avg)\\",\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":0,\\"y\\":21,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Invocations\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"Invocations\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"Throttles\\",\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"ConcurrentExecutions\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"Concurrent\\",\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"ProvisionedConcurrencySpilloverInvocations\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"Provisioned Concurrency Spillovers\\",\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":8,\\"y\\":21,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Iterator\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"IteratorAge\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"Iterator Age\\",\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":16,\\"y\\":21,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"Faults\\",\\"accountId\\":\\"01234567890\\",\\"region\\":\\"us-west-2\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}}]}",
             ],
           ],
         },
@@ -91,50 +119,6 @@ Object {
                   Object {
                     "Name": "TableName",
                     "Value": "MyTableName",
-                  },
-                ],
-                "MetricName": "SuccessfulRequestLatency",
-                "Namespace": "AWS/DynamoDB",
-              },
-              "Period": 300,
-              "Stat": "Average",
-            },
-            "ReturnData": true,
-          },
-        ],
-        "Threshold": 10000,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "MyAppFacadeMyAppXaXrImportedTableLatencyAverageGetItemCritical3480F8E9": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmActions": Array [
-          Object {
-            "Ref": "OnAlarmTopicF22649A2",
-          },
-        ],
-        "AlarmDescription": "Average latency is too high.",
-        "AlarmName": "MyApp-XaXrImportedTable-Latency-Average-GetItem-Critical",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "DatapointsToAlarm": 3,
-        "EvaluationPeriods": 3,
-        "Metrics": Array [
-          Object {
-            "AccountId": "01234567890",
-            "Id": "m1",
-            "Label": "GetItem",
-            "MetricStat": Object {
-              "Metric": Object {
-                "Dimensions": Array [
-                  Object {
-                    "Name": "Operation",
-                    "Value": "GetItem",
-                  },
-                  Object {
-                    "Name": "TableName",
-                    "Value": "my-other-table",
                   },
                 ],
                 "MetricName": "SuccessfulRequestLatency",

--- a/test/monitoring/TestMonitoringScope.ts
+++ b/test/monitoring/TestMonitoringScope.ts
@@ -64,7 +64,10 @@ export class TestMonitoringScope extends MonitoringScope {
   }
 
   createMetricFactory(): MetricFactory {
-    return new MetricFactory({ globalDefaults: DummyGlobalMetricDefaults });
+    return new MetricFactory(
+      { globalDefaults: DummyGlobalMetricDefaults },
+      this,
+    );
   }
 
   createWidgetFactory(): IWidgetFactory {

--- a/test/monitoring/custom/CustomMonitoring.test.ts
+++ b/test/monitoring/custom/CustomMonitoring.test.ts
@@ -244,11 +244,14 @@ test("addToSummaryDashboard attribute takes value from CustomMonitoringProps if 
 
 test("anomaly detection", () => {
   const stack = new Stack();
-  const metricFactory = new MetricFactory({
-    globalDefaults: {
-      namespace: "AnomalyNamespace",
+  const metricFactory = new MetricFactory(
+    {
+      globalDefaults: {
+        namespace: "AnomalyNamespace",
+      },
     },
-  });
+    stack,
+  );
 
   const scope = new TestMonitoringScope(stack, "Scope");
 


### PR DESCRIPTION
Extracted from #544.

Fixes #428, in cases where the account/region is actually different from the construct scope.

Also updates the test in `MonitoringFacade.test.ts` since XAXR alarms aren't possible.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_