### PR TITLE
feat(MetricFactory): add API for creating metrics better handling optional props

### DIFF
--- a/API.md
+++ b/API.md
@@ -33151,6 +33151,146 @@ Allows you to specify the global defaults, which can be overridden in the indivi
 
 ---
 
+### MetricProps <a name="MetricProps" id="cdk-monitoring-constructs.MetricProps"></a>
+
+#### Initializer <a name="Initializer" id="cdk-monitoring-constructs.MetricProps.Initializer"></a>
+
+```typescript
+import { MetricProps } from 'cdk-monitoring-constructs'
+
+const metricProps: MetricProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#cdk-monitoring-constructs.MetricProps.property.metricName">metricName</a></code> | <code>string</code> | Metric name. |
+| <code><a href="#cdk-monitoring-constructs.MetricProps.property.statistic">statistic</a></code> | <code><a href="#cdk-monitoring-constructs.MetricStatistic">MetricStatistic</a></code> | Aggregation statistic to use. |
+| <code><a href="#cdk-monitoring-constructs.MetricProps.property.account">account</a></code> | <code>string</code> | Custom account. |
+| <code><a href="#cdk-monitoring-constructs.MetricProps.property.color">color</a></code> | <code>string</code> | Metric color. |
+| <code><a href="#cdk-monitoring-constructs.MetricProps.property.dimensionsMap">dimensionsMap</a></code> | <code>{[ key: string ]: string}</code> | Additional dimensions to be added. |
+| <code><a href="#cdk-monitoring-constructs.MetricProps.property.label">label</a></code> | <code>string</code> | Metric label. |
+| <code><a href="#cdk-monitoring-constructs.MetricProps.property.namespace">namespace</a></code> | <code>string</code> | Custom namespace. |
+| <code><a href="#cdk-monitoring-constructs.MetricProps.property.period">period</a></code> | <code>aws-cdk-lib.Duration</code> | Custom period. |
+| <code><a href="#cdk-monitoring-constructs.MetricProps.property.region">region</a></code> | <code>string</code> | SCustom region. |
+
+---
+
+##### `metricName`<sup>Required</sup> <a name="metricName" id="cdk-monitoring-constructs.MetricProps.property.metricName"></a>
+
+```typescript
+public readonly metricName: string;
+```
+
+- *Type:* string
+
+Metric name.
+
+---
+
+##### `statistic`<sup>Required</sup> <a name="statistic" id="cdk-monitoring-constructs.MetricProps.property.statistic"></a>
+
+```typescript
+public readonly statistic: MetricStatistic;
+```
+
+- *Type:* <a href="#cdk-monitoring-constructs.MetricStatistic">MetricStatistic</a>
+
+Aggregation statistic to use.
+
+---
+
+##### `account`<sup>Optional</sup> <a name="account" id="cdk-monitoring-constructs.MetricProps.property.account"></a>
+
+```typescript
+public readonly account: string;
+```
+
+- *Type:* string
+- *Default:* Global default.
+
+Custom account.
+
+---
+
+##### `color`<sup>Optional</sup> <a name="color" id="cdk-monitoring-constructs.MetricProps.property.color"></a>
+
+```typescript
+public readonly color: string;
+```
+
+- *Type:* string
+- *Default:* CloudWatch provided color (preferred).
+
+Metric color.
+
+---
+
+##### `dimensionsMap`<sup>Optional</sup> <a name="dimensionsMap" id="cdk-monitoring-constructs.MetricProps.property.dimensionsMap"></a>
+
+```typescript
+public readonly dimensionsMap: {[ key: string ]: string};
+```
+
+- *Type:* {[ key: string ]: string}
+
+Additional dimensions to be added.
+
+---
+
+##### `label`<sup>Optional</sup> <a name="label" id="cdk-monitoring-constructs.MetricProps.property.label"></a>
+
+```typescript
+public readonly label: string;
+```
+
+- *Type:* string
+- *Default:* Metric name is used by CloudWatch.
+
+Metric label.
+
+---
+
+##### `namespace`<sup>Optional</sup> <a name="namespace" id="cdk-monitoring-constructs.MetricProps.property.namespace"></a>
+
+```typescript
+public readonly namespace: string;
+```
+
+- *Type:* string
+- *Default:* Global default.
+
+Custom namespace.
+
+---
+
+##### `period`<sup>Optional</sup> <a name="period" id="cdk-monitoring-constructs.MetricProps.property.period"></a>
+
+```typescript
+public readonly period: Duration;
+```
+
+- *Type:* aws-cdk-lib.Duration
+- *Default:* Global default.
+
+Custom period.
+
+---
+
+##### `region`<sup>Optional</sup> <a name="region" id="cdk-monitoring-constructs.MetricProps.property.region"></a>
+
+```typescript
+public readonly region: string;
+```
+
+- *Type:* string
+- *Default:* Global default.
+
+SCustom region.
+
+---
+
 ### MinFreeableMemoryThreshold <a name="MinFreeableMemoryThreshold" id="cdk-monitoring-constructs.MinFreeableMemoryThreshold"></a>
 
 #### Initializer <a name="Initializer" id="cdk-monitoring-constructs.MinFreeableMemoryThreshold.Initializer"></a>
@@ -65953,6 +66093,7 @@ new MetricFactory(props?: MetricFactoryProps, scope?: Construct)
 | <code><a href="#cdk-monitoring-constructs.MetricFactory.createMetricSearch">createMetricSearch</a></code> | Factory method that creates a metric search query. |
 | <code><a href="#cdk-monitoring-constructs.MetricFactory.divideMetric">divideMetric</a></code> | Creates a metric math expression that divides the given metric by given coefficient. |
 | <code><a href="#cdk-monitoring-constructs.MetricFactory.getNamespaceWithFallback">getNamespaceWithFallback</a></code> | Returns the given namespace (if defined) or the global namespace as a fallback. |
+| <code><a href="#cdk-monitoring-constructs.MetricFactory.metric">metric</a></code> | Factory method that creates a metric. |
 | <code><a href="#cdk-monitoring-constructs.MetricFactory.multiplyMetric">multiplyMetric</a></code> | Creates a metric math expression that multiplies the given metric by given coefficient. |
 | <code><a href="#cdk-monitoring-constructs.MetricFactory.sanitizeMetricExpressionIdSuffix">sanitizeMetricExpressionIdSuffix</a></code> | Helper method that helps to sanitize the given expression ID and removes all invalid characters. |
 | <code><a href="#cdk-monitoring-constructs.MetricFactory.toRate">toRate</a></code> | Creates a metric math expression that computes a rate from a regular metric. |
@@ -66021,7 +66162,7 @@ additional dimensions.
 
 ---
 
-##### `createMetric` <a name="createMetric" id="cdk-monitoring-constructs.MetricFactory.createMetric"></a>
+##### ~~`createMetric`~~ <a name="createMetric" id="cdk-monitoring-constructs.MetricFactory.createMetric"></a>
 
 ```typescript
 public createMetric(metricName: string, statistic: MetricStatistic, label?: string, dimensionsMap?: {[ key: string ]: string}, color?: string, namespace?: string, period?: Duration, region?: string, account?: string): Metric | MathExpression
@@ -66031,11 +66172,11 @@ Factory method that creates a metric.
 
 The metric properties will already be updated to comply with the global defaults.
 
+> [MetricProps.account}](MetricProps.account})
+
 ###### `metricName`<sup>Required</sup> <a name="metricName" id="cdk-monitoring-constructs.MetricFactory.createMetric.parameter.metricName"></a>
 
 - *Type:* string
-
-metric name.
 
 ---
 
@@ -66043,17 +66184,11 @@ metric name.
 
 - *Type:* <a href="#cdk-monitoring-constructs.MetricStatistic">MetricStatistic</a>
 
-aggregation statistic to use.
-
 ---
 
 ###### `label`<sup>Optional</sup> <a name="label" id="cdk-monitoring-constructs.MetricFactory.createMetric.parameter.label"></a>
 
 - *Type:* string
-
-metric label;
-
-if undefined, metric name is used by CloudWatch
 
 ---
 
@@ -66061,17 +66196,11 @@ if undefined, metric name is used by CloudWatch
 
 - *Type:* {[ key: string ]: string}
 
-additional dimensions to be added.
-
 ---
 
 ###### `color`<sup>Optional</sup> <a name="color" id="cdk-monitoring-constructs.MetricFactory.createMetric.parameter.color"></a>
 
 - *Type:* string
-
-metric color;
-
-if undefined, uses a CloudWatch provided color (preferred)
 
 ---
 
@@ -66079,19 +66208,11 @@ if undefined, uses a CloudWatch provided color (preferred)
 
 - *Type:* string
 
-specify a custom namespace;
-
-if undefined, uses the global default
-
 ---
 
 ###### `period`<sup>Optional</sup> <a name="period" id="cdk-monitoring-constructs.MetricFactory.createMetric.parameter.period"></a>
 
 - *Type:* aws-cdk-lib.Duration
-
-specify a custom period;
-
-if undefined, uses the global default
 
 ---
 
@@ -66099,19 +66220,11 @@ if undefined, uses the global default
 
 - *Type:* string
 
-specify a custom region;
-
-if undefined, uses the global default
-
 ---
 
 ###### `account`<sup>Optional</sup> <a name="account" id="cdk-monitoring-constructs.MetricFactory.createMetric.parameter.account"></a>
 
 - *Type:* string
-
-specify a custom account;
-
-if undefined, uses the global default
 
 ---
 
@@ -66424,6 +66537,22 @@ If there is no namespace to fallback to (neither the custom or the default one),
 - *Type:* string
 
 custom namespace.
+
+---
+
+##### `metric` <a name="metric" id="cdk-monitoring-constructs.MetricFactory.metric"></a>
+
+```typescript
+public metric(props: MetricProps): Metric | MathExpression
+```
+
+Factory method that creates a metric.
+
+The metric properties will already be updated to comply with the global defaults.
+
+###### `props`<sup>Required</sup> <a name="props" id="cdk-monitoring-constructs.MetricFactory.metric.parameter.props"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.MetricProps">MetricProps</a>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ const m1 = new Metric(/* ... */);
 const metricFactory = monitoringFacade.createMetricFactory();
 
 // create metrics using metric factory
-const m1 = metricFactory.createMetric(/* ... */);
+const m1 = metricFactory.metric(/* ... */);
 ```
 
 #### Example: metric with anomaly detection

--- a/lib/monitoring/aws-acm/CertificateManagerMetricFactory.ts
+++ b/lib/monitoring/aws-acm/CertificateManagerMetricFactory.ts
@@ -31,16 +31,14 @@ export class CertificateManagerMetricFactory extends BaseMetricFactory<Certifica
   }
 
   metricDaysToExpiry(): MetricWithAlarmSupport {
-    return this.metricFactory.createMetric(
-      "DaysToExpiry",
-      MetricStatistic.MIN,
-      "Days to expiry",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "DaysToExpiry",
+      statistic: MetricStatistic.MIN,
+      label: "Days to expiry",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 }

--- a/lib/monitoring/aws-apigateway/ApiGatewayMetricFactory.ts
+++ b/lib/monitoring/aws-apigateway/ApiGatewayMetricFactory.ts
@@ -87,31 +87,27 @@ export class ApiGatewayMetricFactory extends BaseMetricFactory<ApiGatewayMetricF
   }
 
   metricInvocationCount() {
-    return this.metricFactory.createMetric(
-      "Count",
-      MetricStatistic.SUM,
-      "Count",
-      this.dimensionsMap,
-      undefined,
-      ApiGatewayNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "Count",
+      statistic: MetricStatistic.SUM,
+      label: "Count",
+      dimensionsMap: this.dimensionsMap,
+      namespace: ApiGatewayNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metric4XXErrorCount() {
-    return this.metricFactory.createMetric(
-      "4XXError",
-      MetricStatistic.SUM,
-      "4XX Error",
-      this.dimensionsMap,
-      undefined,
-      ApiGatewayNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "4XXError",
+      statistic: MetricStatistic.SUM,
+      label: "4XX Error",
+      dimensionsMap: this.dimensionsMap,
+      namespace: ApiGatewayNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metric4XXErrorRate() {
@@ -124,17 +120,15 @@ export class ApiGatewayMetricFactory extends BaseMetricFactory<ApiGatewayMetricF
   }
 
   metric5XXFaultCount() {
-    return this.metricFactory.createMetric(
-      "5XXError",
-      MetricStatistic.SUM,
-      "5XX Fault",
-      this.dimensionsMap,
-      undefined,
-      ApiGatewayNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "5XXError",
+      statistic: MetricStatistic.SUM,
+      label: "5XX Fault",
+      dimensionsMap: this.dimensionsMap,
+      namespace: ApiGatewayNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metric5XXFaultRate() {
@@ -169,16 +163,14 @@ export class ApiGatewayMetricFactory extends BaseMetricFactory<ApiGatewayMetricF
 
   metricLatencyInMillis(latencyType: LatencyType) {
     const label = getLatencyTypeLabel(latencyType);
-    return this.metricFactory.createMetric(
-      "Latency",
-      getLatencyTypeStatistic(latencyType),
-      label,
-      this.dimensionsMap,
-      undefined,
-      ApiGatewayNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "Latency",
+      statistic: getLatencyTypeStatistic(latencyType),
+      label: label,
+      dimensionsMap: this.dimensionsMap,
+      namespace: ApiGatewayNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 }

--- a/lib/monitoring/aws-apigatewayv2/ApiGatewayV2HttpApiMetricFactory.ts
+++ b/lib/monitoring/aws-apigatewayv2/ApiGatewayV2HttpApiMetricFactory.ts
@@ -83,28 +83,27 @@ export class ApiGatewayV2HttpApiMetricFactory extends BaseMetricFactory<ApiGatew
   }
 
   metricInvocationCount() {
-    return this.metricFactory.createMetric(
-      "Count",
-      MetricStatistic.SUM,
-      "Invocations",
-      this.dimensionsMap,
-      undefined,
-      ApiGatewayNamespace,
-    );
+    return this.metricFactory.metric({
+      metricName: "Count",
+      statistic: MetricStatistic.SUM,
+      label: "Invocations",
+      dimensionsMap: this.dimensionsMap,
+      namespace: ApiGatewayNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metric4xxCount() {
-    return this.metricFactory.createMetric(
-      "4xx",
-      MetricStatistic.SUM,
-      "4xx",
-      this.dimensionsMap,
-      undefined,
-      ApiGatewayNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "4xx",
+      statistic: MetricStatistic.SUM,
+      label: "4xx",
+      dimensionsMap: this.dimensionsMap,
+      namespace: ApiGatewayNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metric4xxRate() {
@@ -117,17 +116,15 @@ export class ApiGatewayV2HttpApiMetricFactory extends BaseMetricFactory<ApiGatew
   }
 
   metric5xxCount() {
-    return this.metricFactory.createMetric(
-      "5xx",
-      MetricStatistic.SUM,
-      "5xx",
-      this.dimensionsMap,
-      undefined,
-      ApiGatewayNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "5xx",
+      statistic: MetricStatistic.SUM,
+      label: "5xx",
+      dimensionsMap: this.dimensionsMap,
+      namespace: ApiGatewayNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metric5xxRate() {
@@ -183,31 +180,27 @@ export class ApiGatewayV2HttpApiMetricFactory extends BaseMetricFactory<ApiGatew
 
   metricIntegrationLatencyInMillis(latencyType: LatencyType) {
     const label = getLatencyTypeLabel(latencyType);
-    return this.metricFactory.createMetric(
-      "IntegrationLatency",
-      getLatencyTypeStatistic(latencyType),
-      label,
-      this.dimensionsMap,
-      undefined,
-      ApiGatewayNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "IntegrationLatency",
+      statistic: getLatencyTypeStatistic(latencyType),
+      label: label,
+      dimensionsMap: this.dimensionsMap,
+      namespace: ApiGatewayNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricLatencyInMillis(latencyType: LatencyType) {
     const label = getLatencyTypeLabel(latencyType);
-    return this.metricFactory.createMetric(
-      "Latency",
-      getLatencyTypeStatistic(latencyType),
-      label,
-      this.dimensionsMap,
-      undefined,
-      ApiGatewayNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "Latency",
+      statistic: getLatencyTypeStatistic(latencyType),
+      label: label,
+      dimensionsMap: this.dimensionsMap,
+      namespace: ApiGatewayNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 }

--- a/lib/monitoring/aws-appsync/AppSyncMetricFactory.ts
+++ b/lib/monitoring/aws-appsync/AppSyncMetricFactory.ts
@@ -68,73 +68,63 @@ export class AppSyncMetricFactory extends BaseMetricFactory<AppSyncMetricFactory
   }
 
   metricRequestCount() {
-    return this.metricFactory.createMetric(
-      "Latency",
-      MetricStatistic.N,
-      "Requests",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "Latency",
+      statistic: MetricStatistic.N,
+      label: "Requests",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricLatencyP50InMillis() {
-    return this.metricFactory.createMetric(
-      "Latency",
-      MetricStatistic.P50,
-      "P50",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "Latency",
+      statistic: MetricStatistic.P50,
+      label: "P50",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricLatencyP90InMillis() {
-    return this.metricFactory.createMetric(
-      "Latency",
-      MetricStatistic.P90,
-      "P90",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "Latency",
+      statistic: MetricStatistic.P90,
+      label: "P90",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricLatencyP99InMillis() {
-    return this.metricFactory.createMetric(
-      "Latency",
-      MetricStatistic.P99,
-      "P99",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "Latency",
+      statistic: MetricStatistic.P99,
+      label: "P99",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metric4XXErrorCount() {
-    return this.metricFactory.createMetric(
-      "4XXError",
-      MetricStatistic.SUM,
-      "4XX Error",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "4XXError",
+      statistic: MetricStatistic.SUM,
+      label: "4XX Error",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metric4XXErrorRate() {
@@ -147,17 +137,15 @@ export class AppSyncMetricFactory extends BaseMetricFactory<AppSyncMetricFactory
   }
 
   metric5XXFaultCount() {
-    return this.metricFactory.createMetric(
-      "5XXError",
-      MetricStatistic.SUM,
-      "5XX Fault",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "5XXError",
+      statistic: MetricStatistic.SUM,
+      label: "5XX Fault",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metric5XXFaultRate() {

--- a/lib/monitoring/aws-cloudfront/CloudFrontDistributionMetricFactory.ts
+++ b/lib/monitoring/aws-cloudfront/CloudFrontDistributionMetricFactory.ts
@@ -63,17 +63,15 @@ export class CloudFrontDistributionMetricFactory extends BaseMetricFactory<Cloud
   }
 
   metricRequestCount() {
-    return this.metricFactory.createMetric(
-      "Requests",
-      MetricStatistic.SUM,
-      "Uploaded",
-      this.dimensionsMap,
-      undefined,
-      CloudFrontNamespace,
-      undefined,
-      CloudFrontDefaultMetricRegion,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "Requests",
+      statistic: MetricStatistic.SUM,
+      label: "Uploaded",
+      dimensionsMap: this.dimensionsMap,
+      namespace: CloudFrontNamespace,
+      region: CloudFrontDefaultMetricRegion,
+      account: this.account,
+    });
   }
 
   metricRequestRate() {
@@ -100,31 +98,27 @@ export class CloudFrontDistributionMetricFactory extends BaseMetricFactory<Cloud
   }
 
   metricTotalBytesUploaded() {
-    return this.metricFactory.createMetric(
-      "BytesUploaded",
-      MetricStatistic.SUM,
-      "Uploaded",
-      this.dimensionsMap,
-      undefined,
-      CloudFrontNamespace,
-      undefined,
-      CloudFrontDefaultMetricRegion,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "BytesUploaded",
+      statistic: MetricStatistic.SUM,
+      label: "Uploaded",
+      dimensionsMap: this.dimensionsMap,
+      namespace: CloudFrontNamespace,
+      region: CloudFrontDefaultMetricRegion,
+      account: this.account,
+    });
   }
 
   metricTotalBytesDownloaded() {
-    return this.metricFactory.createMetric(
-      "BytesDownloaded",
-      MetricStatistic.SUM,
-      "Downloaded",
-      this.dimensionsMap,
-      undefined,
-      CloudFrontNamespace,
-      undefined,
-      CloudFrontDefaultMetricRegion,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "BytesDownloaded",
+      statistic: MetricStatistic.SUM,
+      label: "Downloaded",
+      dimensionsMap: this.dimensionsMap,
+      namespace: CloudFrontNamespace,
+      region: CloudFrontDefaultMetricRegion,
+      account: this.account,
+    });
   }
 
   /**
@@ -133,58 +127,50 @@ export class CloudFrontDistributionMetricFactory extends BaseMetricFactory<Cloud
    * @see https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/viewing-cloudfront-metrics.html#monitoring-console.distributions-additional
    */
   metricCacheHitRateAverageInPercent() {
-    return this.metricFactory.createMetric(
-      "CacheHitRate",
-      MetricStatistic.AVERAGE,
-      "Hit Rate",
-      this.dimensionsMap,
-      undefined,
-      CloudFrontNamespace,
-      undefined,
-      CloudFrontDefaultMetricRegion,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "CacheHitRate",
+      statistic: MetricStatistic.AVERAGE,
+      label: "Hit Rate",
+      dimensionsMap: this.dimensionsMap,
+      namespace: CloudFrontNamespace,
+      region: CloudFrontDefaultMetricRegion,
+      account: this.account,
+    });
   }
 
   metric4xxErrorRateAverage() {
-    return this.metricFactory.createMetric(
-      "4xxErrorRate",
-      MetricStatistic.AVERAGE,
-      "4XX",
-      this.dimensionsMap,
-      undefined,
-      CloudFrontNamespace,
-      undefined,
-      CloudFrontDefaultMetricRegion,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "4xxErrorRate",
+      statistic: MetricStatistic.AVERAGE,
+      label: "4XX",
+      dimensionsMap: this.dimensionsMap,
+      namespace: CloudFrontNamespace,
+      region: CloudFrontDefaultMetricRegion,
+      account: this.account,
+    });
   }
 
   metric5xxErrorRateAverage() {
-    return this.metricFactory.createMetric(
-      "5xxErrorRate",
-      MetricStatistic.AVERAGE,
-      "5XX",
-      this.dimensionsMap,
-      undefined,
-      CloudFrontNamespace,
-      undefined,
-      CloudFrontDefaultMetricRegion,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "5xxErrorRate",
+      statistic: MetricStatistic.AVERAGE,
+      label: "5XX",
+      dimensionsMap: this.dimensionsMap,
+      namespace: CloudFrontNamespace,
+      region: CloudFrontDefaultMetricRegion,
+      account: this.account,
+    });
   }
 
   metricTotalErrorRateAverage() {
-    return this.metricFactory.createMetric(
-      "TotalErrorRate",
-      MetricStatistic.AVERAGE,
-      "Total",
-      this.dimensionsMap,
-      undefined,
-      CloudFrontNamespace,
-      undefined,
-      CloudFrontDefaultMetricRegion,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "TotalErrorRate",
+      statistic: MetricStatistic.AVERAGE,
+      label: "Total",
+      dimensionsMap: this.dimensionsMap,
+      namespace: CloudFrontNamespace,
+      region: CloudFrontDefaultMetricRegion,
+      account: this.account,
+    });
   }
 }

--- a/lib/monitoring/aws-cloudwatch/CloudWatchLogsMetricFactory.ts
+++ b/lib/monitoring/aws-cloudwatch/CloudWatchLogsMetricFactory.ts
@@ -32,16 +32,14 @@ export class CloudWatchLogsMetricFactory extends BaseMetricFactory<CloudWatchLog
   }
 
   metricIncomingLogEvents() {
-    return this.metricFactory.createMetric(
-      "IncomingLogEvents",
-      MetricStatistic.N,
-      "Logs",
-      this.dimensionsMap,
-      undefined,
-      CloudWatchLogsNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "IncomingLogEvents",
+      statistic: MetricStatistic.N,
+      label: "Logs",
+      dimensionsMap: this.dimensionsMap,
+      namespace: CloudWatchLogsNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 }

--- a/lib/monitoring/aws-docdb/DocumentDbMetricFactory.ts
+++ b/lib/monitoring/aws-docdb/DocumentDbMetricFactory.ts
@@ -87,16 +87,14 @@ export class DocumentDbMetricFactory extends BaseMetricFactory<DocumentDbMetricF
     statistic: MetricStatistic,
     label: string,
   ) {
-    return this.metricFactory.createMetric(
+    return this.metricFactory.metric({
       metricName,
       statistic,
       label,
-      this.dimensionsMap,
-      undefined,
-      DocumentDbNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+      dimensionsMap: this.dimensionsMap,
+      namespace: DocumentDbNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 }

--- a/lib/monitoring/aws-dynamo/DynamoTableGlobalSecondaryIndexMetricFactory.ts
+++ b/lib/monitoring/aws-dynamo/DynamoTableGlobalSecondaryIndexMetricFactory.ts
@@ -34,31 +34,27 @@ export class DynamoTableGlobalSecondaryIndexMetricFactory extends BaseMetricFact
   }
 
   metricProvisionedReadCapacityUnits() {
-    return this.metricFactory.createMetric(
-      "ProvisionedReadCapacityUnits",
-      MetricStatistic.SUM,
-      "Provisioned",
-      this.dimensionsMap,
-      undefined,
-      DynamoDbNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ProvisionedReadCapacityUnits",
+      statistic: MetricStatistic.SUM,
+      label: "Provisioned",
+      dimensionsMap: this.dimensionsMap,
+      namespace: DynamoDbNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricProvisionedWriteCapacityUnits() {
-    return this.metricFactory.createMetric(
-      "ProvisionedWriteCapacityUnits",
-      MetricStatistic.SUM,
-      "Provisioned",
-      this.dimensionsMap,
-      undefined,
-      DynamoDbNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ProvisionedWriteCapacityUnits",
+      statistic: MetricStatistic.SUM,
+      label: "Provisioned",
+      dimensionsMap: this.dimensionsMap,
+      namespace: DynamoDbNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricConsumedReadCapacityUnits() {
@@ -92,31 +88,26 @@ export class DynamoTableGlobalSecondaryIndexMetricFactory extends BaseMetricFact
   }
 
   metricIndexConsumedWriteUnitsMetric() {
-    return this.metricFactory.createMetric(
-      "OnlineIndexConsumedWriteCapacity",
-      MetricStatistic.SUM,
-      "Consumed by index",
-      this.dimensionsMap,
-      undefined,
-      DynamoDbNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "OnlineIndexConsumedWriteCapacity",
+      statistic: MetricStatistic.SUM,
+      label: "Consumed by index",
+      dimensionsMap: this.dimensionsMap,
+      namespace: DynamoDbNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricThrottledReadRequestCount() {
-    const readThrottles = this.metricFactory.createMetric(
-      "ReadThrottleEvents",
-      MetricStatistic.SUM,
-      undefined,
-      this.dimensionsMap,
-      undefined,
-      DynamoDbNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    const readThrottles = this.metricFactory.metric({
+      metricName: "ReadThrottleEvents",
+      statistic: MetricStatistic.SUM,
+      dimensionsMap: this.dimensionsMap,
+      namespace: DynamoDbNamespace,
+      region: this.region,
+      account: this.account,
+    });
 
     return this.metricFactory.createMetricMath(
       "FILL(readThrottles,0)",
@@ -126,17 +117,14 @@ export class DynamoTableGlobalSecondaryIndexMetricFactory extends BaseMetricFact
   }
 
   metricThrottledWriteRequestCount() {
-    const writeThrottles = this.metricFactory.createMetric(
-      "WriteThrottleEvents",
-      MetricStatistic.SUM,
-      undefined,
-      this.dimensionsMap,
-      undefined,
-      DynamoDbNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    const writeThrottles = this.metricFactory.metric({
+      metricName: "WriteThrottleEvents",
+      statistic: MetricStatistic.SUM,
+      dimensionsMap: this.dimensionsMap,
+      namespace: DynamoDbNamespace,
+      region: this.region,
+      account: this.account,
+    });
 
     return this.metricFactory.createMetricMath(
       "FILL(writeThrottles,0)",
@@ -146,17 +134,14 @@ export class DynamoTableGlobalSecondaryIndexMetricFactory extends BaseMetricFact
   }
 
   metricThrottledIndexRequestCount() {
-    const indexThrottles = this.metricFactory.createMetric(
-      "OnlineIndexThrottleEvents",
-      MetricStatistic.SUM,
-      undefined,
-      this.dimensionsMap,
-      undefined,
-      DynamoDbNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    const indexThrottles = this.metricFactory.metric({
+      metricName: "OnlineIndexThrottleEvents",
+      statistic: MetricStatistic.SUM,
+      dimensionsMap: this.dimensionsMap,
+      namespace: DynamoDbNamespace,
+      region: this.region,
+      account: this.account,
+    });
 
     return this.metricFactory.createMetricMath(
       "FILL(indexThrottles,0)",

--- a/lib/monitoring/aws-ec2/AutoScalingGroupMetricFactory.ts
+++ b/lib/monitoring/aws-ec2/AutoScalingGroupMetricFactory.ts
@@ -116,16 +116,14 @@ export class AutoScalingGroupMetricFactory extends BaseMetricFactory<AutoScaling
     label: string,
     statistic: MetricStatistic,
   ) {
-    return this.metricFactory.createMetric(
+    return this.metricFactory.metric({
       metricName,
       statistic,
       label,
-      this.dimensionsMap,
-      undefined,
-      AutoScalingNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+      dimensionsMap: this.dimensionsMap,
+      namespace: AutoScalingNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 }

--- a/lib/monitoring/aws-ec2/EC2MetricFactory.ts
+++ b/lib/monitoring/aws-ec2/EC2MetricFactory.ts
@@ -38,17 +38,14 @@ class AutoScalingGroupStrategy implements IEC2MetricFactoryStrategy {
     account?: string,
   ) {
     return [
-      metricFactory.createMetric(
+      metricFactory.metric({
         metricName,
         statistic,
-        undefined,
-        resolveDimensions(this.autoScalingGroup, undefined),
-        undefined,
-        EC2Namespace,
-        undefined,
+        dimensionsMap: resolveDimensions(this.autoScalingGroup, undefined),
+        namespace: EC2Namespace,
         region,
         account,
-      ),
+      }),
     ];
   }
 }
@@ -73,17 +70,15 @@ class SelectedInstancesStrategy implements IEC2MetricFactoryStrategy {
     account?: string,
   ) {
     return this.instanceIds.map((instanceId) => {
-      return metricFactory.createMetric(
+      return metricFactory.metric({
         metricName,
         statistic,
-        `${metricName} (${instanceId})`,
-        resolveDimensions(this.autoScalingGroup, instanceId),
-        undefined,
-        EC2Namespace,
-        undefined,
+        label: `${metricName} (${instanceId})`,
+        dimensionsMap: resolveDimensions(this.autoScalingGroup, instanceId),
+        namespace: EC2Namespace,
         region,
         account,
-      );
+      });
     });
   }
 }

--- a/lib/monitoring/aws-ecs-patterns/BaseServiceMetricFactory.ts
+++ b/lib/monitoring/aws-ecs-patterns/BaseServiceMetricFactory.ts
@@ -42,73 +42,63 @@ export class BaseServiceMetricFactory extends BaseMetricFactory<BaseServiceMetri
   }
 
   metricClusterCpuUtilisationInPercent() {
-    return this.metricFactory.createMetric(
-      "CPUUtilization",
-      MetricStatistic.AVERAGE,
-      "Cluster CPU Utilization",
-      this.dimensionsMap,
-      undefined,
-      EcsNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "CPUUtilization",
+      statistic: MetricStatistic.AVERAGE,
+      label: "Cluster CPU Utilization",
+      dimensionsMap: this.dimensionsMap,
+      namespace: EcsNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricClusterMemoryUtilisationInPercent() {
-    return this.metricFactory.createMetric(
-      "MemoryUtilization",
-      MetricStatistic.AVERAGE,
-      "Cluster Memory Utilization",
-      this.dimensionsMap,
-      undefined,
-      EcsNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "MemoryUtilization",
+      statistic: MetricStatistic.AVERAGE,
+      label: "Cluster Memory Utilization",
+      dimensionsMap: this.dimensionsMap,
+      namespace: EcsNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricRunningTaskCount() {
-    return this.metricFactory.createMetric(
-      "RunningTaskCount",
-      MetricStatistic.AVERAGE,
-      "Running Tasks",
-      this.dimensionsMap,
-      undefined,
-      EcsContainerInsightsNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "RunningTaskCount",
+      statistic: MetricStatistic.AVERAGE,
+      label: "Running Tasks",
+      dimensionsMap: this.dimensionsMap,
+      namespace: EcsContainerInsightsNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricEphemeralStorageReserved() {
-    return this.metricFactory.createMetric(
-      "EphemeralStorageReserved",
-      MetricStatistic.MAX,
-      "Ephemeral Storage Reserved",
-      this.dimensionsMap,
-      undefined,
-      EcsContainerInsightsNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "EphemeralStorageReserved",
+      statistic: MetricStatistic.MAX,
+      label: "Ephemeral Storage Reserved",
+      dimensionsMap: this.dimensionsMap,
+      namespace: EcsContainerInsightsNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricEphemeralStorageUtilized() {
-    return this.metricFactory.createMetric(
-      "EphemeralStorageUtilized",
-      MetricStatistic.MAX,
-      "Ephemeral Storage Utilized",
-      this.dimensionsMap,
-      undefined,
-      EcsContainerInsightsNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "EphemeralStorageUtilized",
+      statistic: MetricStatistic.MAX,
+      label: "Ephemeral Storage Utilized",
+      dimensionsMap: this.dimensionsMap,
+      namespace: EcsContainerInsightsNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricEphemeralStorageUsageInPercent() {

--- a/lib/monitoring/aws-elasticache/ElastiCacheClusterMetricFactory.ts
+++ b/lib/monitoring/aws-elasticache/ElastiCacheClusterMetricFactory.ts
@@ -42,101 +42,87 @@ export class ElastiCacheClusterMetricFactory extends BaseMetricFactory<ElastiCac
   }
 
   metricMaxItemCount() {
-    return this.metricFactory.createMetric(
-      "CurrItems",
-      MetricStatistic.MAX,
-      "Count",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "CurrItems",
+      statistic: MetricStatistic.MAX,
+      label: "Count",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricEvictions() {
-    return this.metricFactory.createMetric(
-      "Evictions",
-      MetricStatistic.SUM,
-      "Evictions",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "Evictions",
+      statistic: MetricStatistic.SUM,
+      label: "Evictions",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricAverageFreeableMemoryInBytes() {
-    return this.metricFactory.createMetric(
-      "FreeableMemory",
-      MetricStatistic.AVERAGE,
-      "Freeable",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "FreeableMemory",
+      statistic: MetricStatistic.AVERAGE,
+      label: "Freeable",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricAverageUnusedMemoryInBytes() {
-    return this.metricFactory.createMetric(
-      "UnusedMemory",
-      MetricStatistic.AVERAGE,
-      "Unused",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "UnusedMemory",
+      statistic: MetricStatistic.AVERAGE,
+      label: "Unused",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricAverageCachedItemsSizeInBytes() {
-    return this.metricFactory.createMetric(
-      "BytesUsedForCacheItems",
-      MetricStatistic.AVERAGE,
-      "Items",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "BytesUsedForCacheItems",
+      statistic: MetricStatistic.AVERAGE,
+      label: "Items",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricAverageSwapUsageInBytes() {
-    return this.metricFactory.createMetric(
-      "SwapUsage",
-      MetricStatistic.AVERAGE,
-      "Swap",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "SwapUsage",
+      statistic: MetricStatistic.AVERAGE,
+      label: "Swap",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricMaxCpuUtilizationInPercent() {
-    return this.metricFactory.createMetric(
-      "CPUUtilization",
-      MetricStatistic.MAX,
-      "Cluster CPU Utilization",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "CPUUtilization",
+      statistic: MetricStatistic.MAX,
+      label: "Cluster CPU Utilization",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   /**
@@ -148,58 +134,50 @@ export class ElastiCacheClusterMetricFactory extends BaseMetricFactory<ElastiCac
    * @see https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheMetrics.Redis.html
    */
   metricMaxRedisEngineCpuUtilizationInPercent() {
-    return this.metricFactory.createMetric(
-      "EngineCPUUtilization",
-      MetricStatistic.MAX,
-      "Cluster Engine CPU Utilization",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "EngineCPUUtilization",
+      statistic: MetricStatistic.MAX,
+      label: "Cluster Engine CPU Utilization",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricAverageConnections() {
-    return this.metricFactory.createMetric(
-      "CurrConnections",
-      MetricStatistic.AVERAGE,
-      "Current",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "CurrConnections",
+      statistic: MetricStatistic.AVERAGE,
+      label: "Current",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricNetworkBytesIn() {
-    return this.metricFactory.createMetric(
-      "NetworkBytesIn",
-      MetricStatistic.SUM,
-      "Bytes In",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "NetworkBytesIn",
+      statistic: MetricStatistic.SUM,
+      label: "Bytes In",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricNetworkBytesOut() {
-    return this.metricFactory.createMetric(
-      "NetworkBytesOut",
-      MetricStatistic.SUM,
-      "Bytes Out",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "NetworkBytesOut",
+      statistic: MetricStatistic.SUM,
+      label: "Bytes Out",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 }

--- a/lib/monitoring/aws-glue/GlueJobMetricFactory.ts
+++ b/lib/monitoring/aws-glue/GlueJobMetricFactory.ts
@@ -40,119 +40,104 @@ export class GlueJobMetricFactory extends BaseMetricFactory<GlueJobMetricFactory
   }
 
   metricTotalReadBytesFromS3() {
-    return this.metricFactory.createMetric(
-      "glue.ALL.s3.filesystem.read_bytes",
-      MetricStatistic.SUM,
-      "Read (S3)",
-      this.dimensionsMap,
-      undefined,
-      GlueNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "glue.ALL.s3.filesystem.read_bytes",
+      statistic: MetricStatistic.SUM,
+      label: "Read (S3)",
+      dimensionsMap: this.dimensionsMap,
+      namespace: GlueNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricTotalWrittenBytesToS3() {
-    return this.metricFactory.createMetric(
-      "glue.ALL.s3.filesystem.write_bytes",
-      MetricStatistic.SUM,
-      "Write (S3)",
-      this.dimensionsMap,
-      undefined,
-      GlueNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "glue.ALL.s3.filesystem.write_bytes",
+      statistic: MetricStatistic.SUM,
+      label: "Write (S3)",
+      dimensionsMap: this.dimensionsMap,
+      namespace: GlueNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricAverageExecutorCpuUsagePercentage() {
     const label = "CPU Usage (executor average)";
-    const metric = this.metricFactory.createMetric(
-      "glue.ALL.system.cpuSystemLoad",
-      MetricStatistic.AVERAGE,
-      label,
-      this.dimensionsMap,
-      undefined,
-      GlueNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    const metric = this.metricFactory.metric({
+      metricName: "glue.ALL.system.cpuSystemLoad",
+      statistic: MetricStatistic.AVERAGE,
+      label: label,
+      dimensionsMap: this.dimensionsMap,
+      namespace: GlueNamespace,
+      region: this.region,
+      account: this.account,
+    });
     return this.metricFactory.multiplyMetric(metric, 100, label, "cpu");
   }
 
   metricAverageExecutorMemoryUsagePercentage() {
     const label = "JVM Heap usage (executor average)";
-    const metric = this.metricFactory.createMetric(
-      "glue.ALL.jvm.heap.usage",
-      MetricStatistic.AVERAGE,
-      label,
-      this.dimensionsMap,
-      undefined,
-      GlueNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    const metric = this.metricFactory.metric({
+      metricName: "glue.ALL.jvm.heap.usage",
+      statistic: MetricStatistic.AVERAGE,
+      label: label,
+      dimensionsMap: this.dimensionsMap,
+      namespace: GlueNamespace,
+      region: this.region,
+      account: this.account,
+    });
     return this.metricFactory.multiplyMetric(metric, 100, label, "heap");
   }
 
   metricActiveExecutorsAverage() {
-    return this.metricFactory.createMetric(
-      "glue.driver.ExecutorAllocationManager.executors.numberAllExecutors",
-      MetricStatistic.AVERAGE,
-      "Active Executors",
-      this.dimensionsMap,
-      undefined,
-      GlueNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName:
+        "glue.driver.ExecutorAllocationManager.executors.numberAllExecutors",
+      statistic: MetricStatistic.AVERAGE,
+      label: "Active Executors",
+      dimensionsMap: this.dimensionsMap,
+      namespace: GlueNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricCompletedStagesSum() {
-    return this.metricFactory.createMetric(
-      "glue.driver.aggregate.numCompletedStages",
-      MetricStatistic.SUM,
-      "Completed Stages",
-      this.typeCountDimensionsMap,
-      undefined,
-      GlueNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "glue.driver.aggregate.numCompletedStages",
+      statistic: MetricStatistic.SUM,
+      label: "Completed Stages",
+      dimensionsMap: this.typeCountDimensionsMap,
+      namespace: GlueNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricCompletedTasksSum() {
-    return this.metricFactory.createMetric(
-      "glue.driver.aggregate.numCompletedTasks",
-      MetricStatistic.SUM,
-      "Completed Tasks",
-      this.typeCountDimensionsMap,
-      undefined,
-      GlueNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "glue.driver.aggregate.numCompletedTasks",
+      statistic: MetricStatistic.SUM,
+      label: "Completed Tasks",
+      dimensionsMap: this.typeCountDimensionsMap,
+      namespace: GlueNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricFailedTasksSum() {
-    return this.metricFactory.createMetric(
-      "glue.driver.aggregate.numFailedTasks",
-      MetricStatistic.SUM,
-      "Failed Tasks",
-      this.typeCountDimensionsMap,
-      undefined,
-      GlueNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "glue.driver.aggregate.numFailedTasks",
+      statistic: MetricStatistic.SUM,
+      label: "Failed Tasks",
+      dimensionsMap: this.typeCountDimensionsMap,
+      namespace: GlueNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricFailedTasksRate() {
@@ -166,17 +151,15 @@ export class GlueJobMetricFactory extends BaseMetricFactory<GlueJobMetricFactory
   }
 
   metricKilledTasksSum() {
-    return this.metricFactory.createMetric(
-      "glue.driver.aggregate.numKilledTasks",
-      MetricStatistic.SUM,
-      "Killed Tasks",
-      this.typeCountDimensionsMap,
-      undefined,
-      GlueNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "glue.driver.aggregate.numKilledTasks",
+      statistic: MetricStatistic.SUM,
+      label: "Killed Tasks",
+      dimensionsMap: this.typeCountDimensionsMap,
+      namespace: GlueNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricKilledTasksRate() {
@@ -190,16 +173,15 @@ export class GlueJobMetricFactory extends BaseMetricFactory<GlueJobMetricFactory
   }
 
   metricMaximumNeededExecutors() {
-    return this.metricFactory.createMetric(
-      "glue.driver.ExecutorAllocationManager.executors.numberMaxNeededExecutors",
-      MetricStatistic.MAX,
-      "Maximum Needed Executors",
-      this.dimensionsMap,
-      undefined,
-      GlueNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName:
+        "glue.driver.ExecutorAllocationManager.executors.numberMaxNeededExecutors",
+      statistic: MetricStatistic.MAX,
+      label: "Maximum Needed Executors",
+      dimensionsMap: this.dimensionsMap,
+      namespace: GlueNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 }

--- a/lib/monitoring/aws-kinesis/KinesisDataStreamMetricFactory.ts
+++ b/lib/monitoring/aws-kinesis/KinesisDataStreamMetricFactory.ts
@@ -32,241 +32,207 @@ export class KinesisDataStreamMetricFactory extends BaseMetricFactory<KinesisDat
   }
 
   metricGetRecordsSumBytes() {
-    return this.metricFactory.createMetric(
-      "GetRecords.Bytes",
-      MetricStatistic.SUM,
-      "GetRecords",
-      this.dimensionsMap,
-      undefined,
-      DataStreamNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "GetRecords.Bytes",
+      statistic: MetricStatistic.SUM,
+      label: "GetRecords",
+      dimensionsMap: this.dimensionsMap,
+      namespace: DataStreamNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricGetRecordsIteratorAgeMaxMs() {
-    return this.metricFactory.createMetric(
-      "GetRecords.IteratorAgeMilliseconds",
-      MetricStatistic.MAX,
-      "Iterator Age",
-      this.dimensionsMap,
-      undefined,
-      DataStreamNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "GetRecords.IteratorAgeMilliseconds",
+      statistic: MetricStatistic.MAX,
+      label: "Iterator Age",
+      dimensionsMap: this.dimensionsMap,
+      namespace: DataStreamNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricGetRecordsLatencyAverageMs() {
-    return this.metricFactory.createMetric(
-      "GetRecords.Latency",
-      MetricStatistic.AVERAGE,
-      "GetRecords",
-      this.dimensionsMap,
-      undefined,
-      DataStreamNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "GetRecords.Latency",
+      statistic: MetricStatistic.AVERAGE,
+      label: "GetRecords",
+      dimensionsMap: this.dimensionsMap,
+      namespace: DataStreamNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricGetRecordsSumCount() {
-    return this.metricFactory.createMetric(
-      "GetRecords.Records",
-      MetricStatistic.SUM,
-      "GetRecords.Records",
-      this.dimensionsMap,
-      undefined,
-      DataStreamNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "GetRecords.Records",
+      statistic: MetricStatistic.SUM,
+      label: "GetRecords.Records",
+      dimensionsMap: this.dimensionsMap,
+      namespace: DataStreamNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricGetRecordsSuccessCount() {
-    return this.metricFactory.createMetric(
-      "GetRecords.Success",
-      MetricStatistic.SUM,
-      "GetRecords",
-      this.dimensionsMap,
-      undefined,
-      DataStreamNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "GetRecords.Success",
+      statistic: MetricStatistic.SUM,
+      label: "GetRecords",
+      dimensionsMap: this.dimensionsMap,
+      namespace: DataStreamNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricIncomingDataSumBytes() {
-    return this.metricFactory.createMetric(
-      "IncomingBytes",
-      MetricStatistic.SUM,
-      "Incoming Bytes",
-      this.dimensionsMap,
-      undefined,
-      DataStreamNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "IncomingBytes",
+      statistic: MetricStatistic.SUM,
+      label: "Incoming Bytes",
+      dimensionsMap: this.dimensionsMap,
+      namespace: DataStreamNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricIncomingDataSumCount() {
-    return this.metricFactory.createMetric(
-      "IncomingRecords",
-      MetricStatistic.SUM,
-      "Incoming Records",
-      this.dimensionsMap,
-      undefined,
-      DataStreamNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "IncomingRecords",
+      statistic: MetricStatistic.SUM,
+      label: "Incoming Records",
+      dimensionsMap: this.dimensionsMap,
+      namespace: DataStreamNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricPutRecordSumBytes() {
-    return this.metricFactory.createMetric(
-      "PutRecord.Bytes",
-      MetricStatistic.SUM,
-      "PutRecord",
-      this.dimensionsMap,
-      undefined,
-      DataStreamNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "PutRecord.Bytes",
+      statistic: MetricStatistic.SUM,
+      label: "PutRecord",
+      dimensionsMap: this.dimensionsMap,
+      namespace: DataStreamNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricPutRecordLatencyAverageMs() {
-    return this.metricFactory.createMetric(
-      "PutRecord.Latency",
-      MetricStatistic.AVERAGE,
-      "PutRecord",
-      this.dimensionsMap,
-      undefined,
-      DataStreamNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "PutRecord.Latency",
+      statistic: MetricStatistic.AVERAGE,
+      label: "PutRecord",
+      dimensionsMap: this.dimensionsMap,
+      namespace: DataStreamNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricPutRecordSuccessCount() {
-    return this.metricFactory.createMetric(
-      "PutRecord.Success",
-      MetricStatistic.SUM,
-      "PutRecord",
-      this.dimensionsMap,
-      undefined,
-      DataStreamNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "PutRecord.Success",
+      statistic: MetricStatistic.SUM,
+      label: "PutRecord",
+      dimensionsMap: this.dimensionsMap,
+      namespace: DataStreamNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricPutRecordsSumBytes() {
-    return this.metricFactory.createMetric(
-      "PutRecords.Bytes",
-      MetricStatistic.SUM,
-      "PutRecords",
-      this.dimensionsMap,
-      undefined,
-      DataStreamNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "PutRecords.Bytes",
+      statistic: MetricStatistic.SUM,
+      label: "PutRecords",
+      dimensionsMap: this.dimensionsMap,
+      namespace: DataStreamNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricPutRecordsLatencyAverageMs() {
-    return this.metricFactory.createMetric(
-      "PutRecords.Latency",
-      MetricStatistic.AVERAGE,
-      "PutRecords",
-      this.dimensionsMap,
-      undefined,
-      DataStreamNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "PutRecords.Latency",
+      statistic: MetricStatistic.AVERAGE,
+      label: "PutRecords",
+      dimensionsMap: this.dimensionsMap,
+      namespace: DataStreamNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricPutRecordsSuccessCount() {
-    return this.metricFactory.createMetric(
-      "PutRecords.Success",
-      MetricStatistic.SUM,
-      "PutRecords",
-      this.dimensionsMap,
-      undefined,
-      DataStreamNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "PutRecords.Success",
+      statistic: MetricStatistic.SUM,
+      label: "PutRecords",
+      dimensionsMap: this.dimensionsMap,
+      namespace: DataStreamNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricPutRecordsSuccessfulRecordsCount() {
-    return this.metricFactory.createMetric(
-      "PutRecords.SuccessfulRecords",
-      MetricStatistic.SUM,
-      "PutRecords.SuccessfulRecords",
-      this.dimensionsMap,
-      undefined,
-      DataStreamNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "PutRecords.SuccessfulRecords",
+      statistic: MetricStatistic.SUM,
+      label: "PutRecords.SuccessfulRecords",
+      dimensionsMap: this.dimensionsMap,
+      namespace: DataStreamNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricPutRecordsTotalRecordsCount() {
-    return this.metricFactory.createMetric(
-      "PutRecords.TotalRecords",
-      MetricStatistic.SUM,
-      "PutRecords.TotalRecords",
-      this.dimensionsMap,
-      undefined,
-      DataStreamNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "PutRecords.TotalRecords",
+      statistic: MetricStatistic.SUM,
+      label: "PutRecords.TotalRecords",
+      dimensionsMap: this.dimensionsMap,
+      namespace: DataStreamNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricPutRecordsFailedRecordsCount() {
-    return this.metricFactory.createMetric(
-      "PutRecords.FailedRecords",
-      MetricStatistic.SUM,
-      "PutRecords.FailedRecords",
-      this.dimensionsMap,
-      undefined,
-      DataStreamNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "PutRecords.FailedRecords",
+      statistic: MetricStatistic.SUM,
+      label: "PutRecords.FailedRecords",
+      dimensionsMap: this.dimensionsMap,
+      namespace: DataStreamNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricPutRecordsThrottledRecordsCount() {
-    return this.metricFactory.createMetric(
-      "PutRecords.ThrottledRecords",
-      MetricStatistic.SUM,
-      "PutRecords.ThrottledRecords",
-      this.dimensionsMap,
-      undefined,
-      DataStreamNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "PutRecords.ThrottledRecords",
+      statistic: MetricStatistic.SUM,
+      label: "PutRecords.ThrottledRecords",
+      dimensionsMap: this.dimensionsMap,
+      namespace: DataStreamNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   /**
@@ -284,30 +250,26 @@ export class KinesisDataStreamMetricFactory extends BaseMetricFactory<KinesisDat
   }
 
   metricReadProvisionedThroughputExceeded() {
-    return this.metricFactory.createMetric(
-      "ReadProvisionedThroughputExceeded",
-      MetricStatistic.AVERAGE,
-      "Read",
-      this.dimensionsMap,
-      undefined,
-      DataStreamNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ReadProvisionedThroughputExceeded",
+      statistic: MetricStatistic.AVERAGE,
+      label: "Read",
+      dimensionsMap: this.dimensionsMap,
+      namespace: DataStreamNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricWriteProvisionedThroughputExceeded() {
-    return this.metricFactory.createMetric(
-      "WriteProvisionedThroughputExceeded",
-      MetricStatistic.AVERAGE,
-      "Write",
-      this.dimensionsMap,
-      undefined,
-      DataStreamNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "WriteProvisionedThroughputExceeded",
+      statistic: MetricStatistic.AVERAGE,
+      label: "Write",
+      dimensionsMap: this.dimensionsMap,
+      namespace: DataStreamNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 }

--- a/lib/monitoring/aws-kinesis/KinesisFirehoseMetricFactory.ts
+++ b/lib/monitoring/aws-kinesis/KinesisFirehoseMetricFactory.ts
@@ -32,115 +32,99 @@ export class KinesisFirehoseMetricFactory extends BaseMetricFactory<KinesisFireh
   }
 
   metricSuccessfulConversionCount() {
-    return this.metricFactory.createMetric(
-      "SucceedConversion.Records",
-      MetricStatistic.SUM,
-      "Succeed",
-      this.dimensionsMap,
-      undefined,
-      FirehoseNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "SucceedConversion.Records",
+      statistic: MetricStatistic.SUM,
+      label: "Succeed",
+      dimensionsMap: this.dimensionsMap,
+      namespace: FirehoseNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricFailedConversionCount() {
-    return this.metricFactory.createMetric(
-      "FailedConversion.Records",
-      MetricStatistic.SUM,
-      "Failed",
-      this.dimensionsMap,
-      undefined,
-      FirehoseNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "FailedConversion.Records",
+      statistic: MetricStatistic.SUM,
+      label: "Failed",
+      dimensionsMap: this.dimensionsMap,
+      namespace: FirehoseNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricIncomingBytes() {
-    return this.metricFactory.createMetric(
-      "IncomingBytes",
-      MetricStatistic.SUM,
-      "Incoming (bytes)",
-      this.dimensionsMap,
-      undefined,
-      FirehoseNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "IncomingBytes",
+      statistic: MetricStatistic.SUM,
+      label: "Incoming (bytes)",
+      dimensionsMap: this.dimensionsMap,
+      namespace: FirehoseNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricIncomingPutRequests() {
-    return this.metricFactory.createMetric(
-      "IncomingPutRequests",
-      MetricStatistic.SUM,
-      "Incoming (PutRequest)",
-      this.dimensionsMap,
-      undefined,
-      FirehoseNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "IncomingPutRequests",
+      statistic: MetricStatistic.SUM,
+      label: "Incoming (PutRequest)",
+      dimensionsMap: this.dimensionsMap,
+      namespace: FirehoseNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricIncomingRecordCount() {
-    return this.metricFactory.createMetric(
-      "IncomingRecords",
-      MetricStatistic.SUM,
-      "Incoming (Records)",
-      this.dimensionsMap,
-      undefined,
-      FirehoseNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "IncomingRecords",
+      statistic: MetricStatistic.SUM,
+      label: "Incoming (Records)",
+      dimensionsMap: this.dimensionsMap,
+      namespace: FirehoseNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricThrottledRecordCount() {
-    return this.metricFactory.createMetric(
-      "ThrottledRecords",
-      MetricStatistic.SUM,
-      "Throttled",
-      this.dimensionsMap,
-      undefined,
-      FirehoseNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ThrottledRecords",
+      statistic: MetricStatistic.SUM,
+      label: "Throttled",
+      dimensionsMap: this.dimensionsMap,
+      namespace: FirehoseNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricPutRecordLatencyP90InMillis() {
-    return this.metricFactory.createMetric(
-      "PutRecord.Latency",
-      MetricStatistic.P90,
-      "PutRecord P90",
-      this.dimensionsMap,
-      undefined,
-      FirehoseNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "PutRecord.Latency",
+      statistic: MetricStatistic.P90,
+      label: "PutRecord P90",
+      dimensionsMap: this.dimensionsMap,
+      namespace: FirehoseNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricPutRecordBatchLatencyP90InMillis() {
-    return this.metricFactory.createMetric(
-      "PutRecordBatch.Latency",
-      MetricStatistic.P90,
-      "PutRecordBatch P90",
-      this.dimensionsMap,
-      undefined,
-      FirehoseNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "PutRecordBatch.Latency",
+      statistic: MetricStatistic.P90,
+      label: "PutRecordBatch P90",
+      dimensionsMap: this.dimensionsMap,
+      namespace: FirehoseNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricIncomingBytesToLimitRate() {
@@ -189,44 +173,38 @@ export class KinesisFirehoseMetricFactory extends BaseMetricFactory<KinesisFireh
   }
 
   metricBytesPerSecondLimit() {
-    return this.metricFactory.createMetric(
-      "BytesPerSecondLimit",
-      MetricStatistic.AVERAGE,
-      "Incoming Bytes/s Limit",
-      this.dimensionsMap,
-      undefined,
-      FirehoseNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "BytesPerSecondLimit",
+      statistic: MetricStatistic.AVERAGE,
+      label: "Incoming Bytes/s Limit",
+      dimensionsMap: this.dimensionsMap,
+      namespace: FirehoseNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricRecordsPerSecondLimit() {
-    return this.metricFactory.createMetric(
-      "RecordsPerSecondLimit",
-      MetricStatistic.AVERAGE,
-      "Records/s Limit",
-      this.dimensionsMap,
-      undefined,
-      FirehoseNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "RecordsPerSecondLimit",
+      statistic: MetricStatistic.AVERAGE,
+      label: "Records/s Limit",
+      dimensionsMap: this.dimensionsMap,
+      namespace: FirehoseNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricPutRequestsPerSecondLimit() {
-    return this.metricFactory.createMetric(
-      "PutRequestsPerSecondLimit",
-      MetricStatistic.AVERAGE,
-      "PutRequests/s Limit",
-      this.dimensionsMap,
-      undefined,
-      FirehoseNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "PutRequestsPerSecondLimit",
+      statistic: MetricStatistic.AVERAGE,
+      label: "PutRequests/s Limit",
+      dimensionsMap: this.dimensionsMap,
+      namespace: FirehoseNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 }

--- a/lib/monitoring/aws-kinesisanalytics/KinesisDataAnalyticsMetricFactory.ts
+++ b/lib/monitoring/aws-kinesisanalytics/KinesisDataAnalyticsMetricFactory.ts
@@ -119,16 +119,14 @@ export class KinesisDataAnalyticsMetricFactory extends BaseMetricFactory<Kinesis
   }
 
   private metric(metricsSpec: MetricsSpec) {
-    return this.metricFactory.createMetric(
-      metricsSpec.name,
-      metricsSpec.metricStatistic ?? MetricStatistic.AVERAGE,
-      metricsSpec.description,
-      this.dimensionsMap,
-      undefined,
-      "AWS/KinesisAnalytics",
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: metricsSpec.name,
+      statistic: metricsSpec.metricStatistic ?? MetricStatistic.AVERAGE,
+      label: metricsSpec.description,
+      dimensionsMap: this.dimensionsMap,
+      namespace: "AWS/KinesisAnalytics",
+      region: this.region,
+      account: this.account,
+    });
   }
 }

--- a/lib/monitoring/aws-lambda/LambdaFunctionEnhancedMetricFactory.ts
+++ b/lib/monitoring/aws-lambda/LambdaFunctionEnhancedMetricFactory.ts
@@ -99,23 +99,20 @@ export class LambdaFunctionEnhancedMetricFactory extends BaseMetricFactory<Lambd
     metricName: string,
     statistic: MetricStatistic,
     label: string,
-    color?: string,
   ) {
     const [functionName, functionVersion] =
       this.lambdaFunction.functionName.split(":");
-    return this.metricFactory.createMetric(
+    return this.metricFactory.metric({
       metricName,
       statistic,
       label,
-      {
+      dimensionsMap: {
         function_name: functionName,
         version: functionVersion,
       },
-      color,
-      LambdaInsightsNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+      namespace: LambdaInsightsNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 }

--- a/lib/monitoring/aws-rds/RdsClusterMetricFactory.ts
+++ b/lib/monitoring/aws-rds/RdsClusterMetricFactory.ts
@@ -132,16 +132,14 @@ export class RdsClusterMetricFactory extends BaseMetricFactory<RdsClusterMetricF
     statistic: MetricStatistic,
     label: string,
   ) {
-    return this.metricFactory.createMetric(
+    return this.metricFactory.metric({
       metricName,
       statistic,
       label,
-      this.dimensionsMap,
-      undefined,
-      RdsNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+      dimensionsMap: this.dimensionsMap,
+      namespace: RdsNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 }

--- a/lib/monitoring/aws-rds/RdsInstanceMetricFactory.ts
+++ b/lib/monitoring/aws-rds/RdsInstanceMetricFactory.ts
@@ -141,16 +141,14 @@ export class RdsInstanceMetricFactory extends BaseMetricFactory<RdsInstanceMetri
     statistic: MetricStatistic,
     label: string,
   ) {
-    return this.metricFactory.createMetric(
+    return this.metricFactory.metric({
       metricName,
       statistic,
       label,
-      this.dimensionsMap,
-      undefined,
-      RdsNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+      dimensionsMap: this.dimensionsMap,
+      namespace: RdsNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 }

--- a/lib/monitoring/aws-redshift/RedshiftClusterMetricFactory.ts
+++ b/lib/monitoring/aws-redshift/RedshiftClusterMetricFactory.ts
@@ -146,17 +146,15 @@ export class RedshiftClusterMetricFactory extends BaseMetricFactory<RedshiftClus
     statistic: MetricStatistic,
   ) {
     const dimensions = { ...this.dimensionsMap, latency };
-    return this.metricFactory.createMetric(
-      "QueryDuration",
+    return this.metricFactory.metric({
+      metricName: "QueryDuration",
       statistic,
-      latency,
-      dimensions,
-      undefined,
-      RedshiftNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+      label: latency,
+      dimensionsMap: dimensions,
+      namespace: RedshiftNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   private metric(
@@ -164,16 +162,14 @@ export class RedshiftClusterMetricFactory extends BaseMetricFactory<RedshiftClus
     statistic: MetricStatistic,
     label: string,
   ) {
-    return this.metricFactory.createMetric(
+    return this.metricFactory.metric({
       metricName,
       statistic,
       label,
-      this.dimensionsMap,
-      undefined,
-      RedshiftNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+      dimensionsMap: this.dimensionsMap,
+      namespace: RedshiftNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 }

--- a/lib/monitoring/aws-s3/S3BucketMetricFactory.ts
+++ b/lib/monitoring/aws-s3/S3BucketMetricFactory.ts
@@ -43,36 +43,32 @@ export class S3BucketMetricFactory extends BaseMetricFactory<S3BucketMetricFacto
   }
 
   metricBucketSizeBytes() {
-    return this.metricFactory.createMetric(
-      "BucketSizeBytes",
-      MetricStatistic.AVERAGE,
-      "BucketSizeBytes",
-      {
+    return this.metricFactory.metric({
+      metricName: "BucketSizeBytes",
+      statistic: MetricStatistic.AVERAGE,
+      label: "BucketSizeBytes",
+      dimensionsMap: {
         BucketName: this.props.bucket.bucketName,
         StorageType: this.props.storageType ?? StorageType.STANDARD_STORAGE,
       },
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricNumberOfObjects() {
-    return this.metricFactory.createMetric(
-      "NumberOfObjects",
-      MetricStatistic.AVERAGE,
-      "NumberOfObjects",
-      {
+    return this.metricFactory.metric({
+      metricName: "NumberOfObjects",
+      statistic: MetricStatistic.AVERAGE,
+      label: "NumberOfObjects",
+      dimensionsMap: {
         BucketName: this.props.bucket.bucketName,
         StorageType: "AllStorageTypes",
       },
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 }

--- a/lib/monitoring/aws-secretsmanager/SecretsManagerMetricFactory.ts
+++ b/lib/monitoring/aws-secretsmanager/SecretsManagerMetricFactory.ts
@@ -6,13 +6,7 @@ import {
   MetricStatistic,
 } from "../../common";
 
-const CLASS = "None";
-const DEFAULT_METRIC_PERIOD = Duration.hours(1);
-const METRICNAMESECRETCOUNT = "ResourceCount";
 const NAMESPACE = "AWS/SecretsManager";
-const RESOURCE = "SecretCount";
-const SERVICE = "Secrets Manager";
-const TYPE = "Resource";
 
 export type SecretsManagerMetricFactoryProps = BaseMetricFactoryProps;
 
@@ -25,23 +19,20 @@ export class SecretsManagerMetricFactory extends BaseMetricFactory<SecretsManage
   }
 
   metricSecretCount() {
-    const dimensionsMap = {
-      Class: CLASS,
-      Resource: RESOURCE,
-      Service: SERVICE,
-      Type: TYPE,
-    };
-
-    return this.metricFactory.createMetric(
-      METRICNAMESECRETCOUNT,
-      MetricStatistic.AVERAGE,
-      "Count",
-      dimensionsMap,
-      undefined,
-      NAMESPACE,
-      DEFAULT_METRIC_PERIOD,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ResourceCount",
+      statistic: MetricStatistic.AVERAGE,
+      label: "Count",
+      dimensionsMap: {
+        Class: "None",
+        Resource: "SecretCount",
+        Service: "Secrets Manager",
+        Type: "Resource",
+      },
+      namespace: NAMESPACE,
+      period: Duration.hours(1),
+      region: this.region,
+      account: this.account,
+    });
   }
 }

--- a/lib/monitoring/aws-secretsmanager/SecretsManagerSecretMetricFactory.ts
+++ b/lib/monitoring/aws-secretsmanager/SecretsManagerSecretMetricFactory.ts
@@ -33,30 +33,28 @@ export class SecretsManagerSecretMetricFactory extends BaseMetricFactory<Secrets
   }
 
   metricDaysSinceLastChange() {
-    return this.metricFactory.createMetric(
-      SecretsManagerSecretMetricFactory.MetricNameDaysSinceLastChange,
-      MetricStatistic.MAX,
-      "Days",
-      this.dimensionsMap,
-      undefined,
-      SecretsManagerSecretMetricFactory.Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName:
+        SecretsManagerSecretMetricFactory.MetricNameDaysSinceLastChange,
+      statistic: MetricStatistic.MAX,
+      label: "Days",
+      dimensionsMap: this.dimensionsMap,
+      namespace: SecretsManagerSecretMetricFactory.Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricDaysSinceLastRotation() {
-    return this.metricFactory.createMetric(
-      SecretsManagerSecretMetricFactory.MetricNameDaysSinceLastRotation,
-      MetricStatistic.MAX,
-      "Days",
-      this.dimensionsMap,
-      undefined,
-      SecretsManagerSecretMetricFactory.Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName:
+        SecretsManagerSecretMetricFactory.MetricNameDaysSinceLastRotation,
+      statistic: MetricStatistic.MAX,
+      label: "Days",
+      dimensionsMap: this.dimensionsMap,
+      namespace: SecretsManagerSecretMetricFactory.Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 }

--- a/lib/monitoring/aws-step-functions/StepFunctionActivityMetricFactory.ts
+++ b/lib/monitoring/aws-step-functions/StepFunctionActivityMetricFactory.ts
@@ -37,143 +37,123 @@ export class StepFunctionActivityMetricFactory extends BaseMetricFactory<StepFun
   }
 
   metricActivityRunTimeP99InMillis() {
-    return this.metricFactory.createMetric(
-      "ActivityRunTime",
-      MetricStatistic.P99,
-      "P99",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ActivityRunTime",
+      statistic: MetricStatistic.P99,
+      label: "P99",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricActivityRunTimeP90InMillis() {
-    return this.metricFactory.createMetric(
-      "ActivityRunTime",
-      MetricStatistic.P90,
-      "P90",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ActivityRunTime",
+      statistic: MetricStatistic.P90,
+      label: "P90",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricActivityRunTimeP50InMillis() {
-    return this.metricFactory.createMetric(
-      "ActivityRunTime",
-      MetricStatistic.P50,
-      "P50",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ActivityRunTime",
+      statistic: MetricStatistic.P50,
+      label: "P50",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricActivityScheduleTimeP99InMillis() {
-    return this.metricFactory.createMetric(
-      "ActivityScheduleTime",
-      MetricStatistic.P99,
-      "P99",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ActivityScheduleTime",
+      statistic: MetricStatistic.P99,
+      label: "P99",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricActivityScheduleTimeP90InMillis() {
-    return this.metricFactory.createMetric(
-      "ActivityScheduleTime",
-      MetricStatistic.P90,
-      "P90",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ActivityScheduleTime",
+      statistic: MetricStatistic.P90,
+      label: "P90",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricActivityScheduleTimeP50InMillis() {
-    return this.metricFactory.createMetric(
-      "ActivityScheduleTime",
-      MetricStatistic.P50,
-      "P50",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ActivityScheduleTime",
+      statistic: MetricStatistic.P50,
+      label: "P50",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricActivityTimeP99InMillis() {
-    return this.metricFactory.createMetric(
-      "ActivityTime",
-      MetricStatistic.P99,
-      "P99",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ActivityTime",
+      statistic: MetricStatistic.P99,
+      label: "P99",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricActivityTimeP90InMillis() {
-    return this.metricFactory.createMetric(
-      "ActivityTime",
-      MetricStatistic.P90,
-      "P90",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ActivityTime",
+      statistic: MetricStatistic.P90,
+      label: "P90",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricActivityTimeP50InMillis() {
-    return this.metricFactory.createMetric(
-      "ActivityTime",
-      MetricStatistic.P50,
-      "P50",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ActivityTime",
+      statistic: MetricStatistic.P50,
+      label: "P50",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricActivitiesFailed() {
-    return this.metricFactory.createMetric(
-      "ActivitiesFailed",
-      MetricStatistic.SUM,
-      "Failed",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ActivitiesFailed",
+      statistic: MetricStatistic.SUM,
+      label: "Failed",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricActivitiesFailedRate() {
@@ -187,72 +167,62 @@ export class StepFunctionActivityMetricFactory extends BaseMetricFactory<StepFun
   }
 
   metricActivitiesHeartbeatTimedOut() {
-    return this.metricFactory.createMetric(
-      "ActivitiesHeartbeatTimedOut",
-      MetricStatistic.SUM,
-      "HeartbeatTimedOut",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ActivitiesHeartbeatTimedOut",
+      statistic: MetricStatistic.SUM,
+      label: "HeartbeatTimedOut",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricActivitiesScheduled() {
-    return this.metricFactory.createMetric(
-      "ActivitiesScheduled",
-      MetricStatistic.SUM,
-      "Scheduled",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ActivitiesScheduled",
+      statistic: MetricStatistic.SUM,
+      label: "Scheduled",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricActivitiesStarted() {
-    return this.metricFactory.createMetric(
-      "ActivitiesStarted",
-      MetricStatistic.SUM,
-      "Started",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ActivitiesStarted",
+      statistic: MetricStatistic.SUM,
+      label: "Started",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricActivitiesSucceeded() {
-    return this.metricFactory.createMetric(
-      "ActivitiesSucceeded",
-      MetricStatistic.SUM,
-      "Succeeded",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ActivitiesSucceeded",
+      statistic: MetricStatistic.SUM,
+      label: "Succeeded",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricActivitiesTimedOut() {
-    return this.metricFactory.createMetric(
-      "ActivitiesTimedOut",
-      MetricStatistic.SUM,
-      "Timeout",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ActivitiesTimedOut",
+      statistic: MetricStatistic.SUM,
+      label: "Timeout",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 }

--- a/lib/monitoring/aws-step-functions/StepFunctionLambdaIntegrationMetricFactory.ts
+++ b/lib/monitoring/aws-step-functions/StepFunctionLambdaIntegrationMetricFactory.ts
@@ -37,143 +37,123 @@ export class StepFunctionLambdaIntegrationMetricFactory extends BaseMetricFactor
   }
 
   metricFunctionRunTimeP99InMillis() {
-    return this.metricFactory.createMetric(
-      "LambdaFunctionRunTime",
-      MetricStatistic.P99,
-      "P99",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "LambdaFunctionRunTime",
+      statistic: MetricStatistic.P99,
+      label: "P99",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricFunctionRunTimeP90InMillis() {
-    return this.metricFactory.createMetric(
-      "LambdaFunctionRunTime",
-      MetricStatistic.P90,
-      "P90",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "LambdaFunctionRunTime",
+      statistic: MetricStatistic.P90,
+      label: "P90",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricFunctionRunTimeP50InMillis() {
-    return this.metricFactory.createMetric(
-      "LambdaFunctionRunTime",
-      MetricStatistic.P50,
-      "P50",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "LambdaFunctionRunTime",
+      statistic: MetricStatistic.P50,
+      label: "P50",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricFunctionScheduleTimeP99InMillis() {
-    return this.metricFactory.createMetric(
-      "LambdaFunctionScheduleTime",
-      MetricStatistic.P99,
-      "P99",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "LambdaFunctionScheduleTime",
+      statistic: MetricStatistic.P99,
+      label: "P99",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricFunctionScheduleTimeP90InMillis() {
-    return this.metricFactory.createMetric(
-      "LambdaFunctionScheduleTime",
-      MetricStatistic.P90,
-      "P90",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "LambdaFunctionScheduleTime",
+      statistic: MetricStatistic.P90,
+      label: "P90",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricFunctionScheduleTimeP50InMillis() {
-    return this.metricFactory.createMetric(
-      "LambdaFunctionScheduleTime",
-      MetricStatistic.P50,
-      "P50",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "LambdaFunctionScheduleTime",
+      statistic: MetricStatistic.P50,
+      label: "P50",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricFunctionTimeP99InMillis() {
-    return this.metricFactory.createMetric(
-      "LambdaFunctionTime",
-      MetricStatistic.P99,
-      "P99",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "LambdaFunctionTime",
+      statistic: MetricStatistic.P99,
+      label: "P99",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricFunctionTimeP90InMillis() {
-    return this.metricFactory.createMetric(
-      "LambdaFunctionTime",
-      MetricStatistic.P90,
-      "P90",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "LambdaFunctionTime",
+      statistic: MetricStatistic.P90,
+      label: "P90",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricFunctionTimeP50InMillis() {
-    return this.metricFactory.createMetric(
-      "LambdaFunctionTime",
-      MetricStatistic.P50,
-      "P50",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "LambdaFunctionTime",
+      statistic: MetricStatistic.P50,
+      label: "P50",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricFunctionsFailed() {
-    return this.metricFactory.createMetric(
-      "LambdaFunctionsFailed",
-      MetricStatistic.SUM,
-      "Failed",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "LambdaFunctionsFailed",
+      statistic: MetricStatistic.SUM,
+      label: "Failed",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricFunctionsFailedRate() {
@@ -186,58 +166,50 @@ export class StepFunctionLambdaIntegrationMetricFactory extends BaseMetricFactor
   }
 
   metricFunctionsScheduled() {
-    return this.metricFactory.createMetric(
-      "LambdaFunctionsScheduled",
-      MetricStatistic.SUM,
-      "Scheduled",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "LambdaFunctionsScheduled",
+      statistic: MetricStatistic.SUM,
+      label: "Scheduled",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricFunctionsStarted() {
-    return this.metricFactory.createMetric(
-      "LambdaFunctionsStarted",
-      MetricStatistic.SUM,
-      "Started",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "LambdaFunctionsStarted",
+      statistic: MetricStatistic.SUM,
+      label: "Started",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricFunctionsSucceeded() {
-    return this.metricFactory.createMetric(
-      "LambdaFunctionsSucceeded",
-      MetricStatistic.SUM,
-      "Succeeded",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "LambdaFunctionsSucceeded",
+      statistic: MetricStatistic.SUM,
+      label: "Succeeded",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricFunctionsTimedOut() {
-    return this.metricFactory.createMetric(
-      "LambdaFunctionsTimedOut",
-      MetricStatistic.SUM,
-      "Timeout",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "LambdaFunctionsTimedOut",
+      statistic: MetricStatistic.SUM,
+      label: "Timeout",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 }

--- a/lib/monitoring/aws-step-functions/StepFunctionMetricFactory.ts
+++ b/lib/monitoring/aws-step-functions/StepFunctionMetricFactory.ts
@@ -36,59 +36,51 @@ export class StepFunctionMetricFactory extends BaseMetricFactory<StepFunctionMet
   }
 
   metricExecutionTimeP99InMillis() {
-    return this.metricFactory.createMetric(
-      "ExecutionTime",
-      MetricStatistic.P99,
-      "P99",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ExecutionTime",
+      statistic: MetricStatistic.P99,
+      label: "P99",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricExecutionTimeP90InMillis() {
-    return this.metricFactory.createMetric(
-      "ExecutionTime",
-      MetricStatistic.P90,
-      "P90",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ExecutionTime",
+      statistic: MetricStatistic.P90,
+      label: "P90",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricExecutionTimeP50InMillis() {
-    return this.metricFactory.createMetric(
-      "ExecutionTime",
-      MetricStatistic.P50,
-      "P50",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ExecutionTime",
+      statistic: MetricStatistic.P50,
+      label: "P50",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricExecutionsFailed() {
-    return this.metricFactory.createMetric(
-      "ExecutionsFailed",
-      MetricStatistic.SUM,
-      "Failed",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ExecutionsFailed",
+      statistic: MetricStatistic.SUM,
+      label: "Failed",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricExecutionsFailedRate() {
@@ -101,72 +93,62 @@ export class StepFunctionMetricFactory extends BaseMetricFactory<StepFunctionMet
   }
 
   metricExecutionsTimedOut() {
-    return this.metricFactory.createMetric(
-      "ExecutionsTimedOut",
-      MetricStatistic.SUM,
-      "Timeout",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ExecutionsTimedOut",
+      statistic: MetricStatistic.SUM,
+      label: "Timeout",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricExecutionThrottled() {
-    return this.metricFactory.createMetric(
-      "ExecutionThrottled",
-      MetricStatistic.SUM,
-      "Throttled",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ExecutionThrottled",
+      statistic: MetricStatistic.SUM,
+      label: "Throttled",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricExecutionsAborted() {
-    return this.metricFactory.createMetric(
-      "ExecutionsAborted",
-      MetricStatistic.SUM,
-      "Aborted",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ExecutionsAborted",
+      statistic: MetricStatistic.SUM,
+      label: "Aborted",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricExecutionsStarted() {
-    return this.metricFactory.createMetric(
-      "ExecutionsStarted",
-      MetricStatistic.SUM,
-      "Started",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ExecutionsStarted",
+      statistic: MetricStatistic.SUM,
+      label: "Started",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricExecutionsSucceeded() {
-    return this.metricFactory.createMetric(
-      "ExecutionsSucceeded",
-      MetricStatistic.SUM,
-      "Succeeded",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ExecutionsSucceeded",
+      statistic: MetricStatistic.SUM,
+      label: "Succeeded",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 }

--- a/lib/monitoring/aws-step-functions/StepFunctionServiceIntegrationMetricFactory.ts
+++ b/lib/monitoring/aws-step-functions/StepFunctionServiceIntegrationMetricFactory.ts
@@ -36,143 +36,123 @@ export class StepFunctionServiceIntegrationMetricFactory extends BaseMetricFacto
   }
 
   metricServiceIntegrationRunTimeP99InMillis() {
-    return this.metricFactory.createMetric(
-      "ServiceIntegrationRunTime",
-      MetricStatistic.P99,
-      "P99",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ServiceIntegrationRunTime",
+      statistic: MetricStatistic.P99,
+      label: "P99",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricServiceIntegrationRunTimeP90InMillis() {
-    return this.metricFactory.createMetric(
-      "ServiceIntegrationRunTime",
-      MetricStatistic.P90,
-      "P90",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ServiceIntegrationRunTime",
+      statistic: MetricStatistic.P90,
+      label: "P90",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricServiceIntegrationRunTimeP50InMillis() {
-    return this.metricFactory.createMetric(
-      "ServiceIntegrationRunTime",
-      MetricStatistic.P50,
-      "P50",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ServiceIntegrationRunTime",
+      statistic: MetricStatistic.P50,
+      label: "P50",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricServiceIntegrationScheduleTimeP99InMillis() {
-    return this.metricFactory.createMetric(
-      "ServiceIntegrationScheduleTime",
-      MetricStatistic.P99,
-      "P99",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ServiceIntegrationScheduleTime",
+      statistic: MetricStatistic.P99,
+      label: "P99",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricServiceIntegrationScheduleTimeP90InMillis() {
-    return this.metricFactory.createMetric(
-      "ServiceIntegrationScheduleTime",
-      MetricStatistic.P90,
-      "P90",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ServiceIntegrationScheduleTime",
+      statistic: MetricStatistic.P90,
+      label: "P90",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricServiceIntegrationScheduleTimeP50InMillis() {
-    return this.metricFactory.createMetric(
-      "ServiceIntegrationScheduleTime",
-      MetricStatistic.P50,
-      "P50",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ServiceIntegrationScheduleTime",
+      statistic: MetricStatistic.P50,
+      label: "P50",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricServiceIntegrationTimeP99InMillis() {
-    return this.metricFactory.createMetric(
-      "ServiceIntegrationTime",
-      MetricStatistic.P99,
-      "P99",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ServiceIntegrationTime",
+      statistic: MetricStatistic.P99,
+      label: "P99",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricServiceIntegrationTimeP90InMillis() {
-    return this.metricFactory.createMetric(
-      "ServiceIntegrationTime",
-      MetricStatistic.P90,
-      "P90",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ServiceIntegrationTime",
+      statistic: MetricStatistic.P90,
+      label: "P90",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricServiceIntegrationTimeP50InMillis() {
-    return this.metricFactory.createMetric(
-      "ServiceIntegrationTime",
-      MetricStatistic.P50,
-      "P50",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ServiceIntegrationTime",
+      statistic: MetricStatistic.P50,
+      label: "P50",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricServiceIntegrationsFailed() {
-    return this.metricFactory.createMetric(
-      "ServiceIntegrationsFailed",
-      MetricStatistic.SUM,
-      "Failed",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ServiceIntegrationsFailed",
+      statistic: MetricStatistic.SUM,
+      label: "Failed",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricServiceIntegrationsFailedRate() {
@@ -185,58 +165,50 @@ export class StepFunctionServiceIntegrationMetricFactory extends BaseMetricFacto
   }
 
   metricServiceIntegrationsScheduled() {
-    return this.metricFactory.createMetric(
-      "ServiceIntegrationsScheduled",
-      MetricStatistic.SUM,
-      "Scheduled",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ServiceIntegrationsScheduled",
+      statistic: MetricStatistic.SUM,
+      label: "Scheduled",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricServiceIntegrationsStarted() {
-    return this.metricFactory.createMetric(
-      "ServiceIntegrationsStarted",
-      MetricStatistic.SUM,
-      "Started",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ServiceIntegrationsStarted",
+      statistic: MetricStatistic.SUM,
+      label: "Started",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricServiceIntegrationsSucceeded() {
-    return this.metricFactory.createMetric(
-      "ServiceIntegrationsSucceeded",
-      MetricStatistic.SUM,
-      "Succeeded",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ServiceIntegrationsSucceeded",
+      statistic: MetricStatistic.SUM,
+      label: "Succeeded",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricServiceIntegrationsTimedOut() {
-    return this.metricFactory.createMetric(
-      "ServiceIntegrationsTimedOut",
-      MetricStatistic.SUM,
-      "Timeout",
-      this.dimensionsMap,
-      undefined,
-      Namespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "ServiceIntegrationsTimedOut",
+      statistic: MetricStatistic.SUM,
+      label: "Timeout",
+      dimensionsMap: this.dimensionsMap,
+      namespace: Namespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 }

--- a/lib/monitoring/aws-synthetics/SyntheticsCanaryMetricFactory.ts
+++ b/lib/monitoring/aws-synthetics/SyntheticsCanaryMetricFactory.ts
@@ -65,17 +65,15 @@ export class SyntheticsCanaryMetricFactory extends BaseMetricFactory<SyntheticsC
   }
 
   metric4xxErrorCount() {
-    return this.metricFactory.createMetric(
-      "4xx",
-      MetricStatistic.SUM,
-      "4xx",
-      this.dimensionsMap,
-      undefined,
-      MetricNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "4xx",
+      statistic: MetricStatistic.SUM,
+      label: "4xx",
+      dimensionsMap: this.dimensionsMap,
+      namespace: MetricNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metric4xxErrorRate() {
@@ -88,17 +86,15 @@ export class SyntheticsCanaryMetricFactory extends BaseMetricFactory<SyntheticsC
   }
 
   metric5xxFaultCount() {
-    return this.metricFactory.createMetric(
-      "5xx",
-      MetricStatistic.SUM,
-      "5xx",
-      this.dimensionsMap,
-      undefined,
-      MetricNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "5xx",
+      statistic: MetricStatistic.SUM,
+      label: "5xx",
+      dimensionsMap: this.dimensionsMap,
+      namespace: MetricNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metric5xxFaultRate() {

--- a/lib/monitoring/aws-wafv2/WafV2MetricFactory.ts
+++ b/lib/monitoring/aws-wafv2/WafV2MetricFactory.ts
@@ -38,31 +38,27 @@ export class WafV2MetricFactory extends BaseMetricFactory<WafV2MetricFactoryProp
   }
 
   metricAllowedRequests() {
-    return this.metricFactory.createMetric(
-      "AllowedRequests",
-      MetricStatistic.SUM,
-      "Allowed",
-      this.dimensions,
-      undefined,
-      MetricNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "AllowedRequests",
+      statistic: MetricStatistic.SUM,
+      label: "Allowed",
+      dimensionsMap: this.dimensions,
+      namespace: MetricNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricBlockedRequests() {
-    return this.metricFactory.createMetric(
-      "BlockedRequests",
-      MetricStatistic.SUM,
-      "Blocked",
-      this.dimensions,
-      undefined,
-      MetricNamespace,
-      undefined,
-      this.region,
-      this.account,
-    );
+    return this.metricFactory.metric({
+      metricName: "BlockedRequests",
+      statistic: MetricStatistic.SUM,
+      label: "Blocked",
+      dimensionsMap: this.dimensions,
+      namespace: MetricNamespace,
+      region: this.region,
+      account: this.account,
+    });
   }
 
   metricBlockedRequestsRate() {

--- a/test/common/metric/MetricFactory.test.ts
+++ b/test/common/metric/MetricFactory.test.ts
@@ -10,14 +10,55 @@ import {
 
 const DummyColor = "#abcdef";
 
+test("deprecated createMetric method creates equivalent metrics", () => {
+  const metricFactory = new MetricFactory({
+    globalDefaults: {
+      namespace: "GlobalNamespace",
+    },
+  });
+
+  expect(
+    metricFactory.createMetric(
+      "Name",
+      MetricStatistic.AVERAGE,
+      "Label",
+      { foo: "bar" },
+      "Color",
+      "Namespace",
+      Duration.hours(6),
+      "us-west-2",
+      "1234",
+    ),
+  ).toEqual(
+    metricFactory.metric({
+      metricName: "Name",
+      statistic: MetricStatistic.AVERAGE,
+      label: "Label",
+      dimensionsMap: { foo: "bar" },
+      color: "Color",
+      namespace: "Namespace",
+      period: Duration.hours(6),
+      region: "us-west-2",
+      account: "1234",
+    }),
+  );
+
+  expect(metricFactory.createMetric("Name", MetricStatistic.AVERAGE)).toEqual(
+    metricFactory.metric({
+      metricName: "Name",
+      statistic: MetricStatistic.AVERAGE,
+    }),
+  );
+});
+
 test("createMetric without global namespace throws an error", () => {
   const metricFactory = new MetricFactory();
 
   expect(() =>
-    metricFactory.createMetric(
-      "DummyMetricName-NoOptionalParams",
-      MetricStatistic.P90,
-    ),
+    metricFactory.metric({
+      metricName: "DummyMetricName-NoOptionalParams",
+      statistic: MetricStatistic.P90,
+    }),
   ).toThrowError();
 });
 
@@ -30,10 +71,10 @@ describe("snapshot test: global defaults", () => {
       },
     });
 
-    const metric = metricFactory.createMetric(
-      "DummyMetricName",
-      MetricStatistic.P90,
-    );
+    const metric = metricFactory.metric({
+      metricName: "DummyMetricName",
+      statistic: MetricStatistic.P90,
+    });
     const metricMath = metricFactory.createMetricMath(
       "DummyExpression",
       {},
@@ -102,38 +143,38 @@ test("snapshot test: createMetric", () => {
     },
   });
 
-  const metricWithNoOptionalParams = metricFactory.createMetric(
-    "DummyMetricName-NoOptionalParams",
-    MetricStatistic.P90,
-  );
+  const metricWithNoOptionalParams = metricFactory.metric({
+    metricName: "DummyMetricName-NoOptionalParams",
+    statistic: MetricStatistic.P90,
+  });
 
   expect(metricWithNoOptionalParams).toMatchSnapshot();
 
-  const metricWithAllOptionalParams = metricFactory.createMetric(
-    "DummyMetricName-AllOptionalParams",
-    MetricStatistic.P90,
-    "DummyLabel",
-    { DummyDimension: "DummyDimensionValue" },
-    DummyColor,
-    "DummyNamespaceOverride",
-  );
+  const metricWithAllOptionalParams = metricFactory.metric({
+    metricName: "DummyMetricName-AllOptionalParams",
+    statistic: MetricStatistic.P90,
+    label: "DummyLabel",
+    dimensionsMap: { DummyDimension: "DummyDimensionValue" },
+    color: DummyColor,
+    namespace: "DummyNamespaceOverride",
+  });
 
   expect(metricWithAllOptionalParams).toMatchSnapshot();
 
-  const metricWithUndefinedDimensions = metricFactory.createMetric(
-    "DummyMetricName-AllOptionalParams",
-    MetricStatistic.P90,
-    "DummyLabel",
-    {
+  const metricWithUndefinedDimensions = metricFactory.metric({
+    metricName: "DummyMetricName-AllOptionalParams",
+    statistic: MetricStatistic.P90,
+    label: "DummyLabel",
+    dimensionsMap: {
       DummyDimension: undefined as unknown as string,
       AnotherDummyDimension: undefined as unknown as string,
     },
-    DummyColor,
-    "DummyNamespaceOverride",
-    Duration.minutes(15),
-    "us-west-2",
-    "123456789",
-  );
+    color: DummyColor,
+    namespace: "DummyNamespaceOverride",
+    period: Duration.minutes(15),
+    region: "us-west-2",
+    account: "123456789",
+  });
 
   expect(metricWithUndefinedDimensions).toMatchSnapshot();
 });
@@ -145,8 +186,14 @@ test("snapshot test: createMetricMath", () => {
     },
   });
 
-  const a = metricFactory.createMetric("a", MetricStatistic.SUM);
-  const b = metricFactory.createMetric("b", MetricStatistic.SUM);
+  const a = metricFactory.metric({
+    metricName: "a",
+    statistic: MetricStatistic.SUM,
+  });
+  const b = metricFactory.metric({
+    metricName: "b",
+    statistic: MetricStatistic.SUM,
+  });
 
   const metricWithNoOptionalParams = metricFactory.createMetricMath(
     "a+b",
@@ -177,17 +224,15 @@ test("snapshot test: toRate with detail", () => {
     stack,
   );
 
-  const metric = metricFactory.createMetric(
-    "Metric",
-    MetricStatistic.SUM,
-    "Label",
-    undefined,
-    Color.ORANGE,
-    "Namespace",
-    undefined,
-    "eu-west-1",
-    "01234567890",
-  );
+  const metric = metricFactory.metric({
+    metricName: "Metric",
+    statistic: MetricStatistic.SUM,
+    label: "Label",
+    color: Color.ORANGE,
+    namespace: "Namespace",
+    region: "eu-west-1",
+    account: "01234567890",
+  });
 
   const metricAverage = metricFactory.toRate(
     metric,
@@ -239,11 +284,11 @@ test("snapshot test: toRate without detail", () => {
     },
   });
 
-  const metric = metricFactory.createMetric(
-    "Metric",
-    MetricStatistic.SUM,
-    "Label",
-  );
+  const metric = metricFactory.metric({
+    metricName: "Metric",
+    statistic: MetricStatistic.SUM,
+    label: "Label",
+  });
 
   const metricAverage = metricFactory.toRate(
     metric,


### PR DESCRIPTION
These have always been awkward APIs since you had to get the ordering right, and you had to pass in `undefined` for optional things.

I'll also be adding replacements for `createMetricMath`, `createMetricSearch`, and `createMetricAnomalyDetection` in future separate PRs.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_