### PR TITLE
Update Statistic for DatabaseConnection metric in RDS

### DIFF
--- a/lib/monitoring/aws-rds/RdsClusterMetricFactory.ts
+++ b/lib/monitoring/aws-rds/RdsClusterMetricFactory.ts
@@ -65,7 +65,7 @@ export class RdsClusterMetricFactory extends BaseMetricFactory<RdsClusterMetricF
   metricTotalConnectionCount() {
     return this.metric(
       "DatabaseConnections",
-      MetricStatistic.AVERAGE,
+      MetricStatistic.N,
       "Connections",
     );
   }


### PR DESCRIPTION
As per AWS documentation, DatabaseConnection should use sample count statistic for DatabaseConnection metric. 

AWS Documentation: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-metrics.html

Fixes #

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_