### PR TITLE
feat: allow periods (".") in alarm names

### DIFF
--- a/lib/dashboard/MonitoringNamingStrategy.ts
+++ b/lib/dashboard/MonitoringNamingStrategy.ts
@@ -62,7 +62,7 @@ export class MonitoringNamingStrategy {
   static isAlarmFriendly(str: string) {
     // we do not know the exact pattern yet, but this is a safe approximation
     // also, tokens are not allowed in alarm names
-    return str && !Token.isUnresolved(str) && /^[a-zA-Z0-9\-_]+$/.test(str);
+    return str && !Token.isUnresolved(str) && /^[a-zA-Z0-9\-_\.]+$/.test(str);
   }
 
   private getFallbackAlarmFriendlyName() {

--- a/test/dashboard/MonitoringNamingStrategy.test.ts
+++ b/test/dashboard/MonitoringNamingStrategy.test.ts
@@ -21,7 +21,7 @@ test("string with comma is not alarm friendly", () => {
 
 test("this string is alarm friendly", () => {
   expect(
-    MonitoringNamingStrategy.isAlarmFriendly("This_is__Valid-Alarm-Name"),
+    MonitoringNamingStrategy.isAlarmFriendly("This_is__Valid-Alarm.Name"),
   ).toBeTruthy();
 });
 


### PR DESCRIPTION
FIFO queues require a suffix of ".fifo" and thus do not work without alarm name overrides. This is tedious.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_