### PR TITLE
chore(workflow): Update slack notification action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -275,7 +275,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Send notification
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@v1.27.0
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -143,7 +143,7 @@ project.release?.addJobs({
       },
       {
         name: "Send notification",
-        uses: "slackapi/slack-github-action@v1.24.0",
+        uses: "slackapi/slack-github-action@v1.27.0",
         with: {
           payload: `{"html_url": "\${{ steps.get_release.outputs.html_url }}", "tag_name": "\${{ steps.get_release.outputs.tag_name }}"}`,
         },


### PR DESCRIPTION
> The following actions use a deprecated Node.js version and will be forced to run on node20: slackapi/slack-github-action@v1.24.0. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

eg: https://github.com/cdklabs/cdk-monitoring-constructs/actions/runs/11822135099/job/32938877139

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_