### PR TITLE
chore: replace usages of deprecated TPS metric methods

### DIFF
--- a/API.md
+++ b/API.md
@@ -54123,8 +54123,14 @@ public metricInvocationCount(): Metric | MathExpression
 ##### `metricInvocationRate` <a name="metricInvocationRate" id="cdk-monitoring-constructs.ApiGatewayMetricFactory.metricInvocationRate"></a>
 
 ```typescript
-public metricInvocationRate(): Metric | MathExpression
+public metricInvocationRate(rateComputationMethod?: RateComputationMethod): Metric | MathExpression
 ```
+
+###### `rateComputationMethod`<sup>Optional</sup> <a name="rateComputationMethod" id="cdk-monitoring-constructs.ApiGatewayMetricFactory.metricInvocationRate.parameter.rateComputationMethod"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.RateComputationMethod">RateComputationMethod</a>
+
+---
 
 ##### `metricLatencyInMillis` <a name="metricLatencyInMillis" id="cdk-monitoring-constructs.ApiGatewayMetricFactory.metricLatencyInMillis"></a>
 
@@ -54690,8 +54696,14 @@ public metricInvocationCount(): Metric | MathExpression
 ##### `metricInvocationRate` <a name="metricInvocationRate" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricInvocationRate"></a>
 
 ```typescript
-public metricInvocationRate(): Metric | MathExpression
+public metricInvocationRate(rateComputationMethod?: RateComputationMethod): Metric | MathExpression
 ```
+
+###### `rateComputationMethod`<sup>Optional</sup> <a name="rateComputationMethod" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricInvocationRate.parameter.rateComputationMethod"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.RateComputationMethod">RateComputationMethod</a>
+
+---
 
 ##### `metricLatencyInMillis` <a name="metricLatencyInMillis" id="cdk-monitoring-constructs.ApiGatewayV2HttpApiMetricFactory.metricLatencyInMillis"></a>
 
@@ -55343,8 +55355,14 @@ public metricRequestCount(): Metric | MathExpression
 ##### `metricRequestRate` <a name="metricRequestRate" id="cdk-monitoring-constructs.AppSyncMetricFactory.metricRequestRate"></a>
 
 ```typescript
-public metricRequestRate(): Metric | MathExpression
+public metricRequestRate(rateComputationMethod?: RateComputationMethod): Metric | MathExpression
 ```
+
+###### `rateComputationMethod`<sup>Optional</sup> <a name="rateComputationMethod" id="cdk-monitoring-constructs.AppSyncMetricFactory.metricRequestRate.parameter.rateComputationMethod"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.RateComputationMethod">RateComputationMethod</a>
+
+---
 
 ##### ~~`metricTps`~~ <a name="metricTps" id="cdk-monitoring-constructs.AppSyncMetricFactory.metricTps"></a>
 
@@ -57719,8 +57737,14 @@ public metricRequestCount(): Metric | MathExpression
 ##### `metricRequestRate` <a name="metricRequestRate" id="cdk-monitoring-constructs.CloudFrontDistributionMetricFactory.metricRequestRate"></a>
 
 ```typescript
-public metricRequestRate(): Metric | MathExpression
+public metricRequestRate(rateComputationMethod?: RateComputationMethod): Metric | MathExpression
 ```
+
+###### `rateComputationMethod`<sup>Optional</sup> <a name="rateComputationMethod" id="cdk-monitoring-constructs.CloudFrontDistributionMetricFactory.metricRequestRate.parameter.rateComputationMethod"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.RateComputationMethod">RateComputationMethod</a>
+
+---
 
 ##### ~~`metricRequestTps`~~ <a name="metricRequestTps" id="cdk-monitoring-constructs.CloudFrontDistributionMetricFactory.metricRequestTps"></a>
 
@@ -67034,8 +67058,14 @@ public metricInvocationCount(): Metric | MathExpression
 ##### `metricInvocationRate` <a name="metricInvocationRate" id="cdk-monitoring-constructs.LambdaFunctionMetricFactory.metricInvocationRate"></a>
 
 ```typescript
-public metricInvocationRate(): Metric | MathExpression
+public metricInvocationRate(rateComputationMethod?: RateComputationMethod): Metric | MathExpression
 ```
+
+###### `rateComputationMethod`<sup>Optional</sup> <a name="rateComputationMethod" id="cdk-monitoring-constructs.LambdaFunctionMetricFactory.metricInvocationRate.parameter.rateComputationMethod"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.RateComputationMethod">RateComputationMethod</a>
+
+---
 
 ##### `metricLatencyInMillis` <a name="metricLatencyInMillis" id="cdk-monitoring-constructs.LambdaFunctionMetricFactory.metricLatencyInMillis"></a>
 
@@ -70571,8 +70601,14 @@ public metricSearchLatencyP99InMillis(): Metric | MathExpression
 ##### `metricSearchRate` <a name="metricSearchRate" id="cdk-monitoring-constructs.OpenSearchClusterMetricFactory.metricSearchRate"></a>
 
 ```typescript
-public metricSearchRate(): Metric | MathExpression
+public metricSearchRate(rateComputationMethod?: RateComputationMethod): Metric | MathExpression
 ```
+
+###### `rateComputationMethod`<sup>Optional</sup> <a name="rateComputationMethod" id="cdk-monitoring-constructs.OpenSearchClusterMetricFactory.metricSearchRate.parameter.rateComputationMethod"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.RateComputationMethod">RateComputationMethod</a>
+
+---
 
 ##### ~~`metricTps`~~ <a name="metricTps" id="cdk-monitoring-constructs.OpenSearchClusterMetricFactory.metricTps"></a>
 

--- a/lib/monitoring/aws-apigateway/ApiGatewayMetricFactory.ts
+++ b/lib/monitoring/aws-apigateway/ApiGatewayMetricFactory.ts
@@ -67,19 +67,13 @@ export class ApiGatewayMetricFactory extends BaseMetricFactory<ApiGatewayMetricF
    * @deprecated use metricInvocationRate
    */
   metricTps() {
-    return this.metricFactory.toRate(
-      this.metricInvocationCount(),
-      RateComputationMethod.PER_SECOND,
-      false,
-      "requests",
-      this.fillTpsWithZeroes,
-    );
+    return this.metricInvocationRate(RateComputationMethod.PER_SECOND);
   }
 
-  metricInvocationRate() {
+  metricInvocationRate(rateComputationMethod?: RateComputationMethod) {
     return this.metricFactory.toRate(
       this.metricInvocationCount(),
-      this.rateComputationMethod,
+      rateComputationMethod ?? this.rateComputationMethod,
       false,
       "requests",
       this.fillTpsWithZeroes,

--- a/lib/monitoring/aws-apigateway/ApiGatewayMonitoring.ts
+++ b/lib/monitoring/aws-apigateway/ApiGatewayMonitoring.ts
@@ -28,6 +28,7 @@ import {
   MonitoringScope,
   QuarterWidth,
   RateAxisFromZero,
+  RateComputationMethod,
   ThirdWidth,
   TimeAxisMillisFromZero,
   TpsAlarmFactory,
@@ -151,7 +152,9 @@ export class ApiGatewayMonitoring extends Monitoring {
       props,
     );
 
-    this.tpsMetric = metricFactory.metricTps();
+    this.tpsMetric = metricFactory.metricInvocationRate(
+      RateComputationMethod.PER_SECOND,
+    );
 
     this.latencyMetrics = {};
     this.latencyTypesToRender = [

--- a/lib/monitoring/aws-apigatewayv2/ApiGatewayV2HttpApiMetricFactory.ts
+++ b/lib/monitoring/aws-apigatewayv2/ApiGatewayV2HttpApiMetricFactory.ts
@@ -65,18 +65,13 @@ export class ApiGatewayV2HttpApiMetricFactory extends BaseMetricFactory<ApiGatew
    * @deprecated use metricInvocationRate
    */
   metricTps() {
-    return this.metricFactory.toRate(
-      this.metricInvocationCount(),
-      RateComputationMethod.PER_SECOND,
-      false,
-      "requests",
-    );
+    return this.metricInvocationRate(RateComputationMethod.PER_SECOND);
   }
 
-  metricInvocationRate() {
+  metricInvocationRate(rateComputationMethod?: RateComputationMethod) {
     return this.metricFactory.toRate(
       this.metricInvocationCount(),
-      this.rateComputationMethod,
+      rateComputationMethod ?? this.rateComputationMethod,
       false,
       "requests",
     );

--- a/lib/monitoring/aws-apigatewayv2/ApiGatewayV2HttpApiMonitoring.ts
+++ b/lib/monitoring/aws-apigatewayv2/ApiGatewayV2HttpApiMonitoring.ts
@@ -29,6 +29,7 @@ import {
   MonitoringScope,
   QuarterWidth,
   RateAxisFromZero,
+  RateComputationMethod,
   ThirdWidth,
   TimeAxisMillisFromZero,
   TpsAlarmFactory,
@@ -196,7 +197,9 @@ export class ApiGatewayV2HttpApiMonitoring extends Monitoring {
       props,
     );
 
-    this.tpsMetric = metricFactory.metricTps();
+    this.tpsMetric = metricFactory.metricInvocationRate(
+      RateComputationMethod.PER_SECOND,
+    );
 
     this.latencyMetrics = {};
     this.integrationLatencyMetrics = {};

--- a/lib/monitoring/aws-appsync/AppSyncMetricFactory.ts
+++ b/lib/monitoring/aws-appsync/AppSyncMetricFactory.ts
@@ -48,19 +48,13 @@ export class AppSyncMetricFactory extends BaseMetricFactory<AppSyncMetricFactory
    * @deprecated use metricRequestRate
    */
   metricTps() {
-    return this.metricFactory.toRate(
-      this.metricRequestCount(),
-      RateComputationMethod.PER_SECOND,
-      true,
-      "requests",
-      this.fillTpsWithZeroes,
-    );
+    return this.metricRequestRate(RateComputationMethod.PER_SECOND);
   }
 
-  metricRequestRate() {
+  metricRequestRate(rateComputationMethod?: RateComputationMethod) {
     return this.metricFactory.toRate(
       this.metricRequestCount(),
-      this.rateComputationMethod,
+      rateComputationMethod ?? this.rateComputationMethod,
       true,
       "requests",
       this.fillTpsWithZeroes,

--- a/lib/monitoring/aws-appsync/AppSyncMonitoring.ts
+++ b/lib/monitoring/aws-appsync/AppSyncMonitoring.ts
@@ -28,6 +28,7 @@ import {
   MonitoringScope,
   QuarterWidth,
   RateAxisFromZero,
+  RateComputationMethod,
   ThirdWidth,
   TimeAxisMillisFromZero,
   TpsAlarmFactory,
@@ -100,7 +101,9 @@ export class AppSyncMonitoring extends Monitoring {
     this.errorCountAnnotations = [];
     this.errorRateAnnotations = [];
 
-    this.tpsMetric = this.metricFactory.metricTps();
+    this.tpsMetric = this.metricFactory.metricRequestRate(
+      RateComputationMethod.PER_SECOND,
+    );
     this.p50LatencyMetric = this.metricFactory.metricLatencyP50InMillis();
     this.p90LatencyMetric = this.metricFactory.metricLatencyP90InMillis();
     this.p99LatencyMetric = this.metricFactory.metricLatencyP99InMillis();

--- a/lib/monitoring/aws-cloudfront/CloudFrontDistributionMetricFactory.ts
+++ b/lib/monitoring/aws-cloudfront/CloudFrontDistributionMetricFactory.ts
@@ -76,10 +76,10 @@ export class CloudFrontDistributionMetricFactory extends BaseMetricFactory<Cloud
     );
   }
 
-  metricRequestRate() {
+  metricRequestRate(rateComputationMethod?: RateComputationMethod) {
     return this.metricFactory.toRate(
       this.metricRequestCount(),
-      this.rateComputationMethod,
+      rateComputationMethod ?? this.rateComputationMethod,
       false,
       "requests",
       this.fillTpsWithZeroes,
@@ -90,13 +90,7 @@ export class CloudFrontDistributionMetricFactory extends BaseMetricFactory<Cloud
    * @deprecated use metricRequestRate
    */
   metricRequestTps() {
-    return this.metricFactory.toRate(
-      this.metricRequestCount(),
-      RateComputationMethod.PER_SECOND,
-      false,
-      "requests",
-      this.fillTpsWithZeroes,
-    );
+    return this.metricRequestRate(RateComputationMethod.PER_SECOND);
   }
 
   metricTotalBytesUploaded() {

--- a/lib/monitoring/aws-cloudfront/CloudFrontDistributionMonitoring.ts
+++ b/lib/monitoring/aws-cloudfront/CloudFrontDistributionMonitoring.ts
@@ -25,6 +25,7 @@ import {
   PercentageAxisFromZeroToHundred,
   QuarterWidth,
   RateAxisFromZero,
+  RateComputationMethod,
   SizeAxisBytesFromZero,
   ThirdWidth,
   TpsAlarmFactory,
@@ -100,7 +101,9 @@ export class CloudFrontDistributionMonitoring extends Monitoring {
       scope.createMetricFactory(),
       props,
     );
-    this.tpsMetric = metricFactory.metricRequestTps();
+    this.tpsMetric = metricFactory.metricRequestRate(
+      RateComputationMethod.PER_SECOND,
+    );
     this.downloadedBytesMetric = metricFactory.metricTotalBytesDownloaded();
     this.uploadedBytesMetric = metricFactory.metricTotalBytesUploaded();
     this.error4xxRate = metricFactory.metric4xxErrorRateAverage();

--- a/lib/monitoring/aws-lambda/LambdaFunctionMetricFactory.ts
+++ b/lib/monitoring/aws-lambda/LambdaFunctionMetricFactory.ts
@@ -54,19 +54,13 @@ export class LambdaFunctionMetricFactory extends BaseMetricFactory<LambdaFunctio
    * @deprecated Use {@link metricInvocationRate} instead.
    */
   metricTps() {
-    return this.metricFactory.toRate(
-      this.metricInvocationCount(),
-      RateComputationMethod.PER_SECOND,
-      false,
-      "requests",
-      this.fillTpsWithZeroes,
-    );
+    return this.metricInvocationRate(RateComputationMethod.PER_SECOND);
   }
 
-  metricInvocationRate() {
+  metricInvocationRate(rateComputationMethod?: RateComputationMethod) {
     return this.metricFactory.toRate(
       this.metricInvocationCount(),
-      this.rateComputationMethod,
+      rateComputationMethod ?? this.rateComputationMethod,
       false,
       "requests",
       this.fillTpsWithZeroes,

--- a/lib/monitoring/aws-lambda/LambdaFunctionMonitoring.ts
+++ b/lib/monitoring/aws-lambda/LambdaFunctionMonitoring.ts
@@ -39,6 +39,7 @@ import {
   PercentageAxisFromZeroToHundred,
   QuarterWidth,
   RateAxisFromZero,
+  RateComputationMethod,
   RunningTaskCountThreshold,
   RunningTaskRateThreshold,
   TaskHealthAlarmFactory,
@@ -228,7 +229,9 @@ export class LambdaFunctionMonitoring extends Monitoring {
       scope.createMetricFactory(),
       props,
     );
-    this.tpsMetric = this.metricFactory.metricTps();
+    this.tpsMetric = this.metricFactory.metricInvocationRate(
+      RateComputationMethod.PER_SECOND,
+    );
     this.p50LatencyMetric = this.metricFactory.metricLatencyInMillis(
       LatencyType.P50,
     );

--- a/lib/monitoring/aws-opensearch/OpenSearchClusterMetricFactory.ts
+++ b/lib/monitoring/aws-opensearch/OpenSearchClusterMetricFactory.ts
@@ -50,10 +50,10 @@ export class OpenSearchClusterMetricFactory extends BaseMetricFactory<OpenSearch
     });
   }
 
-  metricSearchRate() {
+  metricSearchRate(rateComputationMethod?: RateComputationMethod) {
     return this.metricFactory.toRate(
       this.metricSearchCount(),
-      this.rateComputationMethod,
+      rateComputationMethod ?? this.rateComputationMethod,
       false,
       "requests",
       this.fillTpsWithZeroes,
@@ -64,13 +64,7 @@ export class OpenSearchClusterMetricFactory extends BaseMetricFactory<OpenSearch
    * @deprecated use metricSearchRate
    */
   metricTps() {
-    return this.metricFactory.toRate(
-      this.metricSearchCount(),
-      RateComputationMethod.PER_SECOND,
-      false,
-      "requests",
-      this.fillTpsWithZeroes,
-    );
+    return this.metricSearchRate(RateComputationMethod.PER_SECOND);
   }
 
   metricIndexingLatencyP50InMillis() {

--- a/lib/monitoring/aws-opensearch/OpenSearchClusterMonitoring.ts
+++ b/lib/monitoring/aws-opensearch/OpenSearchClusterMonitoring.ts
@@ -31,6 +31,7 @@ import {
   PercentageAxisFromZeroToHundred,
   QuarterWidth,
   RateAxisFromZero,
+  RateComputationMethod,
   ThirdWidth,
   TimeAxisMillisFromZero,
   UsageAlarmFactory,
@@ -164,7 +165,9 @@ export class OpenSearchClusterMonitoring extends Monitoring {
       scope.createMetricFactory(),
       props,
     );
-    this.tpsMetric = metricFactory.metricTps();
+    this.tpsMetric = metricFactory.metricSearchRate(
+      RateComputationMethod.PER_SECOND,
+    );
     this.p50IndexingLatencyMetric =
       metricFactory.metricIndexingLatencyP50InMillis();
     this.p90IndexingLatencyMetric =


### PR DESCRIPTION
So we can fully remove these later.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_