### PR TITLE
feat(AlarmFactory): allow accessing action strategy as part of alarm naming strategy

### DIFF
--- a/API.md
+++ b/API.md
@@ -3765,6 +3765,7 @@ const alarmNamingInput: AlarmNamingInput = { ... }
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.AlarmNamingInput.property.alarmNameSuffix">alarmNameSuffix</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.AlarmNamingInput.property.action">action</a></code> | <code><a href="#cdk-monitoring-constructs.IAlarmActionStrategy">IAlarmActionStrategy</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.AlarmNamingInput.property.alarmDedupeStringSuffix">alarmDedupeStringSuffix</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.AlarmNamingInput.property.alarmNameOverride">alarmNameOverride</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.AlarmNamingInput.property.dedupeStringOverride">dedupeStringOverride</a></code> | <code>string</code> | *No description.* |
@@ -3779,6 +3780,16 @@ public readonly alarmNameSuffix: string;
 ```
 
 - *Type:* string
+
+---
+
+##### `action`<sup>Optional</sup> <a name="action" id="cdk-monitoring-constructs.AlarmNamingInput.property.action"></a>
+
+```typescript
+public readonly action: IAlarmActionStrategy;
+```
+
+- *Type:* <a href="#cdk-monitoring-constructs.IAlarmActionStrategy">IAlarmActionStrategy</a>
 
 ---
 

--- a/lib/common/alarm/AlarmFactory.ts
+++ b/lib/common/alarm/AlarmFactory.ts
@@ -23,7 +23,7 @@ import {
   IAlarmAnnotationStrategy,
 } from "./IAlarmAnnotationStrategy";
 import { IAlarmDedupeStringProcessor } from "./IAlarmDedupeStringProcessor";
-import { IAlarmNamingStrategy } from "./IAlarmNamingStrategy";
+import { AlarmNamingInput, IAlarmNamingStrategy } from "./IAlarmNamingStrategy";
 import {
   CompositeMetricAdjuster,
   DefaultMetricAdjuster,
@@ -580,16 +580,22 @@ export class AlarmFactory {
       props.disambiguator,
       props.actionOverride,
     );
-    const alarmName = this.alarmNamingStrategy.getName(props);
+    const alarmNamingInput: AlarmNamingInput = {
+      ...props,
+      action,
+    };
+    const alarmName = this.alarmNamingStrategy.getName(alarmNamingInput);
     const alarmNameSuffix = props.alarmNameSuffix;
-    const alarmLabel = this.alarmNamingStrategy.getWidgetLabel(props);
+    const alarmLabel =
+      this.alarmNamingStrategy.getWidgetLabel(alarmNamingInput);
     const alarmDescription = this.generateDescription(
       props.alarmDescription,
       props.alarmDescriptionOverride,
       props.runbookLink,
       props.documentationLink,
     );
-    const dedupeString = this.alarmNamingStrategy.getDedupeString(props);
+    const dedupeString =
+      this.alarmNamingStrategy.getDedupeString(alarmNamingInput);
     const evaluateLowSampleCountPercentile =
       props.evaluateLowSampleCountPercentile ?? true;
 

--- a/lib/common/alarm/IAlarmNamingStrategy.ts
+++ b/lib/common/alarm/IAlarmNamingStrategy.ts
@@ -1,4 +1,8 @@
+import { IAlarmActionStrategy } from "./action";
+
 export interface AlarmNamingInput {
+  // TODO: make this required
+  readonly action?: IAlarmActionStrategy;
   readonly alarmNameSuffix: string;
   readonly alarmNameOverride?: string;
   readonly alarmDedupeStringSuffix?: string;


### PR DESCRIPTION
This can be useful if you want to name the alarm based on properties of the action being applied.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_