### PR TITLE
feat(KinesisFirehoseMonitoring): add isDataFormatConversionEnabled prop

### DIFF
--- a/API.md
+++ b/API.md
@@ -26440,6 +26440,7 @@ const kinesisFirehoseMonitoringOptions: KinesisFirehoseMonitoringOptions = { ...
 | <code><a href="#cdk-monitoring-constructs.KinesisFirehoseMonitoringOptions.property.addIncomingPutRequestsExceedThresholdAlarm">addIncomingPutRequestsExceedThresholdAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.FirehoseStreamLimitThreshold">FirehoseStreamLimitThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisFirehoseMonitoringOptions.property.addIncomingRecordsExceedThresholdAlarm">addIncomingRecordsExceedThresholdAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.FirehoseStreamLimitThreshold">FirehoseStreamLimitThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisFirehoseMonitoringOptions.property.addRecordsThrottledAlarm">addRecordsThrottledAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.RecordsThrottledThreshold">RecordsThrottledThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.KinesisFirehoseMonitoringOptions.property.isDataFormatConversionEnabled">isDataFormatConversionEnabled</a></code> | <code>boolean</code> | Indicates that the Kinesis Firehose has record format conversion enabled. |
 
 ---
 
@@ -26611,6 +26612,23 @@ public readonly addRecordsThrottledAlarm: {[ key: string ]: RecordsThrottledThre
 
 ---
 
+##### `isDataFormatConversionEnabled`<sup>Optional</sup> <a name="isDataFormatConversionEnabled" id="cdk-monitoring-constructs.KinesisFirehoseMonitoringOptions.property.isDataFormatConversionEnabled"></a>
+
+```typescript
+public readonly isDataFormatConversionEnabled: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Indicates that the Kinesis Firehose has record format conversion enabled.
+
+This impacts what widgets are shown.
+
+> [https://docs.aws.amazon.com/firehose/latest/dev/enable-record-format-conversion.html](https://docs.aws.amazon.com/firehose/latest/dev/enable-record-format-conversion.html)
+
+---
+
 ### KinesisFirehoseMonitoringProps <a name="KinesisFirehoseMonitoringProps" id="cdk-monitoring-constructs.KinesisFirehoseMonitoringProps"></a>
 
 #### Initializer <a name="Initializer" id="cdk-monitoring-constructs.KinesisFirehoseMonitoringProps.Initializer"></a>
@@ -26639,6 +26657,7 @@ const kinesisFirehoseMonitoringProps: KinesisFirehoseMonitoringProps = { ... }
 | <code><a href="#cdk-monitoring-constructs.KinesisFirehoseMonitoringProps.property.addIncomingPutRequestsExceedThresholdAlarm">addIncomingPutRequestsExceedThresholdAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.FirehoseStreamLimitThreshold">FirehoseStreamLimitThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisFirehoseMonitoringProps.property.addIncomingRecordsExceedThresholdAlarm">addIncomingRecordsExceedThresholdAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.FirehoseStreamLimitThreshold">FirehoseStreamLimitThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisFirehoseMonitoringProps.property.addRecordsThrottledAlarm">addRecordsThrottledAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.RecordsThrottledThreshold">RecordsThrottledThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.KinesisFirehoseMonitoringProps.property.isDataFormatConversionEnabled">isDataFormatConversionEnabled</a></code> | <code>boolean</code> | Indicates that the Kinesis Firehose has record format conversion enabled. |
 
 ---
 
@@ -26817,6 +26836,23 @@ public readonly addRecordsThrottledAlarm: {[ key: string ]: RecordsThrottledThre
 ```
 
 - *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.RecordsThrottledThreshold">RecordsThrottledThreshold</a>}
+
+---
+
+##### `isDataFormatConversionEnabled`<sup>Optional</sup> <a name="isDataFormatConversionEnabled" id="cdk-monitoring-constructs.KinesisFirehoseMonitoringProps.property.isDataFormatConversionEnabled"></a>
+
+```typescript
+public readonly isDataFormatConversionEnabled: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Indicates that the Kinesis Firehose has record format conversion enabled.
+
+This impacts what widgets are shown.
+
+> [https://docs.aws.amazon.com/firehose/latest/dev/enable-record-format-conversion.html](https://docs.aws.amazon.com/firehose/latest/dev/enable-record-format-conversion.html)
 
 ---
 
@@ -66691,6 +66727,7 @@ public createTitleWidget(): MonitoringHeaderWidget
 | <code><a href="#cdk-monitoring-constructs.KinesisFirehoseMonitoring.property.incomingPutRequestsToLimitRate">incomingPutRequestsToLimitRate</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisFirehoseMonitoring.property.incomingRecordsMetric">incomingRecordsMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisFirehoseMonitoring.property.incomingRecordsToLimitRate">incomingRecordsToLimitRate</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.KinesisFirehoseMonitoring.property.isDataFormatConversionEnabled">isDataFormatConversionEnabled</a></code> | <code>boolean</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisFirehoseMonitoring.property.kinesisAlarmFactory">kinesisAlarmFactory</a></code> | <code><a href="#cdk-monitoring-constructs.KinesisAlarmFactory">KinesisAlarmFactory</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisFirehoseMonitoring.property.putRecordBatchLatency">putRecordBatchLatency</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.KinesisFirehoseMonitoring.property.putRecordLatency">putRecordLatency</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
@@ -66769,6 +66806,16 @@ public readonly incomingRecordsToLimitRate: Metric | MathExpression;
 ```
 
 - *Type:* aws-cdk-lib.aws_cloudwatch.Metric | aws-cdk-lib.aws_cloudwatch.MathExpression
+
+---
+
+##### `isDataFormatConversionEnabled`<sup>Required</sup> <a name="isDataFormatConversionEnabled" id="cdk-monitoring-constructs.KinesisFirehoseMonitoring.property.isDataFormatConversionEnabled"></a>
+
+```typescript
+public readonly isDataFormatConversionEnabled: boolean;
+```
+
+- *Type:* boolean
 
 ---
 

--- a/test/monitoring/aws-kinesis/KinesisFirehoseMonitoring.test.ts
+++ b/test/monitoring/aws-kinesis/KinesisFirehoseMonitoring.test.ts
@@ -59,6 +59,20 @@ test("snapshot test: all alarms", () => {
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });
 
+test("snapshot test: data format conversion disabled", () => {
+  const stack = new Stack();
+
+  const scope = new TestMonitoringScope(stack, "Scope");
+
+  const monitoring = new KinesisFirehoseMonitoring(scope, {
+    deliveryStreamName: "my-firehose-delivery-stream",
+    isDataFormatConversionEnabled: false,
+  });
+
+  addMonitoringDashboardsToStack(stack, monitoring);
+  expect(Template.fromStack(stack)).toMatchSnapshot();
+});
+
 test("test: validation error if incoming traffic usage alarm threshold equal to 1", () => {
   const stack = new Stack();
 

--- a/test/monitoring/aws-kinesis/__snapshots__/KinesisFirehoseMonitoring.test.ts.snap
+++ b/test/monitoring/aws-kinesis/__snapshots__/KinesisFirehoseMonitoring.test.ts.snap
@@ -356,6 +356,95 @@ Object {
 }
 `;
 
+exports[`snapshot test: data format conversion disabled 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "Alarm7103F465": Object {
+      "Properties": Object {
+        "DashboardBody": "{\\"widgets\\":[]}",
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "Resource": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Firehose Delivery Stream **[my-firehose-delivery-stream](https://eu-west-1.console.aws.amazon.com/firehose/home?region=eu-west-1#/details/my-firehose-delivery-stream/monitoring)**\\"}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Records\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Firehose\\",\\"IncomingRecords\\",\\"DeliveryStreamName\\",\\"my-firehose-delivery-stream\\",{\\"label\\":\\"Incoming (Records)\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/Firehose\\",\\"ThrottledRecords\\",\\"DeliveryStreamName\\",\\"my-firehose-delivery-stream\\",{\\"label\\":\\"Throttled\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":8,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency (P90)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Firehose\\",\\"PutRecord.Latency\\",\\"DeliveryStreamName\\",\\"my-firehose-delivery-stream\\",{\\"label\\":\\"PutRecord P90\\",\\"stat\\":\\"p90\\"}],[\\"AWS/Firehose\\",\\"PutRecordBatch.Latency\\",\\"DeliveryStreamName\\",\\"my-firehose-delivery-stream\\",{\\"label\\":\\"PutRecordBatch P90\\",\\"stat\\":\\"p90\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":16,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Limits (rate)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Bytes\\",\\"expression\\":\\"(bytes_in / PERIOD(bytes_in)) / bytes_max\\"}],[\\"AWS/Firehose\\",\\"IncomingBytes\\",\\"DeliveryStreamName\\",\\"my-firehose-delivery-stream\\",{\\"label\\":\\"Incoming (bytes)\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"bytes_in\\"}],[\\"AWS/Firehose\\",\\"BytesPerSecondLimit\\",\\"DeliveryStreamName\\",\\"my-firehose-delivery-stream\\",{\\"label\\":\\"Incoming Bytes/s Limit\\",\\"visible\\":false,\\"id\\":\\"bytes_max\\"}],[{\\"label\\":\\"Records\\",\\"expression\\":\\"(records_in / PERIOD(records_in)) / records_max\\"}],[\\"AWS/Firehose\\",\\"IncomingRecords\\",\\"DeliveryStreamName\\",\\"my-firehose-delivery-stream\\",{\\"label\\":\\"Incoming (Records)\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"records_in\\"}],[\\"AWS/Firehose\\",\\"RecordsPerSecondLimit\\",\\"DeliveryStreamName\\",\\"my-firehose-delivery-stream\\",{\\"label\\":\\"Records/s Limit\\",\\"visible\\":false,\\"id\\":\\"records_max\\"}],[{\\"label\\":\\"PutRequests\\",\\"expression\\":\\"(requests_in / PERIOD(requests_in)) / requests_max\\"}],[\\"AWS/Firehose\\",\\"IncomingPutRequests\\",\\"DeliveryStreamName\\",\\"my-firehose-delivery-stream\\",{\\"label\\":\\"Incoming (PutRequest)\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests_in\\"}],[\\"AWS/Firehose\\",\\"PutRequestsPerSecondLimit\\",\\"DeliveryStreamName\\",\\"my-firehose-delivery-stream\\",{\\"label\\":\\"PutRequests/s Limit\\",\\"visible\\":false,\\"id\\":\\"requests_max\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"value\\":1,\\"label\\":\\"100% usage\\",\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "Summary68521F81": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Firehose Delivery Stream **[my-firehose-delivery-stream](https://eu-west-1.console.aws.amazon.com/firehose/home?region=eu-west-1#/details/my-firehose-delivery-stream/monitoring)**\\"}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Records\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Firehose\\",\\"IncomingRecords\\",\\"DeliveryStreamName\\",\\"my-firehose-delivery-stream\\",{\\"label\\":\\"Incoming (Records)\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/Firehose\\",\\"ThrottledRecords\\",\\"DeliveryStreamName\\",\\"my-firehose-delivery-stream\\",{\\"label\\":\\"Throttled\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`snapshot test: no alarms 1`] = `
 Object {
   "Parameters": Object {


### PR DESCRIPTION
The conversions widget is useless for any Firehose which doesn't have data format conversions enabled.

Default is true for backwards compatability.

Implementation is based on the similar `isIterator` parameter for Lambda Functions. 

Note that the AWS docs are not consistent about what they call this feature, [sometimes calling it data format conversion, sometimes calling it record format conversion](https://docs.aws.amazon.com/firehose/latest/dev/enable-record-format-conversion.html). CDK calls it [data format conversion](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_kinesisfirehose.CfnDeliveryStream.DataFormatConversionConfigurationProperty.html), hence my choice to use that terminology for the parameter too.

The library doesn't currently support enabling alarms on any of the data format conversion metrics, so we don't need additional checks there.

I've not written any new tests validating if this widget is shown based on the param, since the similar `isIterator` parameter also has no tests for this; happy to add some if you wish, but if so I'd appreciate a pointer to a similar existing test to help me understand this repo's testing approach.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_