### PR TITLE
feat: add ability to clone monitors

### DIFF
--- a/API.md
+++ b/API.md
@@ -1054,13 +1054,16 @@ new MonitoringFacade(scope: Construct, id: string, props?: MonitoringFacadeProps
 | <code><a href="#cdk-monitoring-constructs.MonitoringFacade.addSegment">addSegment</a></code> | Adds a dashboard segment to go on one of the {@link DefaultDashboards}. |
 | <code><a href="#cdk-monitoring-constructs.MonitoringFacade.addSmallHeader">addSmallHeader</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.MonitoringFacade.addWidget">addWidget</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.MonitoringFacade.cloneAlarms">cloneAlarms</a></code> | Applies a cloning function to each of the given alarms, creating a new collection of alarms that are adjusted by the function. |
 | <code><a href="#cdk-monitoring-constructs.MonitoringFacade.createCompositeAlarmUsingDisambiguator">createCompositeAlarmUsingDisambiguator</a></code> | Finds a subset of created alarms that are marked by a specific disambiguator and creates a composite alarm. |
 | <code><a href="#cdk-monitoring-constructs.MonitoringFacade.createCompositeAlarmUsingTag">createCompositeAlarmUsingTag</a></code> | Finds a subset of created alarms that are marked by a specific custom tag and creates a composite alarm. |
 | <code><a href="#cdk-monitoring-constructs.MonitoringFacade.createdAlarmDashboard">createdAlarmDashboard</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.MonitoringFacade.createdAlarms">createdAlarms</a></code> | Returns the created alarms across all added segments that subclass {@link Monitoring} added up until now. |
 | <code><a href="#cdk-monitoring-constructs.MonitoringFacade.createdAlarmsWithDisambiguator">createdAlarmsWithDisambiguator</a></code> | Returns a subset of created alarms that are marked by a specific disambiguator. |
 | <code><a href="#cdk-monitoring-constructs.MonitoringFacade.createdAlarmsWithTag">createdAlarmsWithTag</a></code> | Returns a subset of created alarms that are marked by a specific custom tag. |
+| <code><a href="#cdk-monitoring-constructs.MonitoringFacade.createdCompositeAlarms">createdCompositeAlarms</a></code> | Returns the added composite alarms. |
 | <code><a href="#cdk-monitoring-constructs.MonitoringFacade.createdDashboard">createdDashboard</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.MonitoringFacade.createdDashboardSegments">createdDashboardSegments</a></code> | Returns all the added segments. |
 | <code><a href="#cdk-monitoring-constructs.MonitoringFacade.createdMonitorings">createdMonitorings</a></code> | Returns the added segments that subclass {@link Monitoring}. |
 | <code><a href="#cdk-monitoring-constructs.MonitoringFacade.createdSummaryDashboard">createdSummaryDashboard</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.MonitoringFacade.monitorApiGateway">monitorApiGateway</a></code> | *No description.* |
@@ -1301,6 +1304,30 @@ public addWidget(widget: IWidget, addToSummary?: boolean, addToAlarm?: boolean):
 
 ---
 
+##### `cloneAlarms` <a name="cloneAlarms" id="cdk-monitoring-constructs.MonitoringFacade.cloneAlarms"></a>
+
+```typescript
+public cloneAlarms(sourceAlarms: AlarmWithAnnotation[], cloneFunction: AlarmCloneFunction): AlarmWithAnnotation[]
+```
+
+Applies a cloning function to each of the given alarms, creating a new collection of alarms that are adjusted by the function.
+
+###### `sourceAlarms`<sup>Required</sup> <a name="sourceAlarms" id="cdk-monitoring-constructs.MonitoringFacade.cloneAlarms.parameter.sourceAlarms"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.AlarmWithAnnotation">AlarmWithAnnotation</a>[]
+
+The alarms that should be used as sources for the clones.
+
+---
+
+###### `cloneFunction`<sup>Required</sup> <a name="cloneFunction" id="cdk-monitoring-constructs.MonitoringFacade.cloneAlarms.parameter.cloneFunction"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.AlarmCloneFunction">AlarmCloneFunction</a>
+
+A function that will accept a source alarm and determine whether and how a new alarm should be cloned from it.
+
+---
+
 ##### `createCompositeAlarmUsingDisambiguator` <a name="createCompositeAlarmUsingDisambiguator" id="cdk-monitoring-constructs.MonitoringFacade.createCompositeAlarmUsingDisambiguator"></a>
 
 ```typescript
@@ -1401,11 +1428,27 @@ tag to filter alarms by.
 
 ---
 
+##### `createdCompositeAlarms` <a name="createdCompositeAlarms" id="cdk-monitoring-constructs.MonitoringFacade.createdCompositeAlarms"></a>
+
+```typescript
+public createdCompositeAlarms(): CompositeAlarm[]
+```
+
+Returns the added composite alarms.
+
 ##### ~~`createdDashboard`~~ <a name="createdDashboard" id="cdk-monitoring-constructs.MonitoringFacade.createdDashboard"></a>
 
 ```typescript
 public createdDashboard(): Dashboard
 ```
+
+##### `createdDashboardSegments` <a name="createdDashboardSegments" id="cdk-monitoring-constructs.MonitoringFacade.createdDashboardSegments"></a>
+
+```typescript
+public createdDashboardSegments(): IDashboardSegment | IDynamicDashboardSegment[]
+```
+
+Returns all the added segments.
 
 ##### `createdMonitorings` <a name="createdMonitorings" id="cdk-monitoring-constructs.MonitoringFacade.createdMonitorings"></a>
 
@@ -3366,6 +3409,108 @@ public readonly overrideAnnotationVisibility: boolean;
 
 ---
 
+### AlarmCloneFunction <a name="AlarmCloneFunction" id="cdk-monitoring-constructs.AlarmCloneFunction"></a>
+
+A function that, when given an alarm, returns modified inputs that can be used to create additional alarms, slightly adjusted from the original one.
+
+The function can be used to clone alarms.
+
+Implementers of this function can use the original alarm configuration to specify a new alarm,
+or they can return undefined to skip the creation of an alarm.
+
+#### Initializer <a name="Initializer" id="cdk-monitoring-constructs.AlarmCloneFunction.Initializer"></a>
+
+```typescript
+import { AlarmCloneFunction } from 'cdk-monitoring-constructs'
+
+const alarmCloneFunction: AlarmCloneFunction = { ... }
+```
+
+
+### AlarmCreateDefinition <a name="AlarmCreateDefinition" id="cdk-monitoring-constructs.AlarmCreateDefinition"></a>
+
+Describes the inputs to a single alarm's creation and configuration.
+
+#### Initializer <a name="Initializer" id="cdk-monitoring-constructs.AlarmCreateDefinition.Initializer"></a>
+
+```typescript
+import { AlarmCreateDefinition } from 'cdk-monitoring-constructs'
+
+const alarmCreateDefinition: AlarmCreateDefinition = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#cdk-monitoring-constructs.AlarmCreateDefinition.property.addAlarmProps">addAlarmProps</a></code> | <code><a href="#cdk-monitoring-constructs.AddAlarmProps">AddAlarmProps</a></code> | The requested configuration for the alarm. |
+| <code><a href="#cdk-monitoring-constructs.AlarmCreateDefinition.property.alarmFactory">alarmFactory</a></code> | <code><a href="#cdk-monitoring-constructs.AlarmFactory">AlarmFactory</a></code> | The alarm factory that created the alarm. |
+| <code><a href="#cdk-monitoring-constructs.AlarmCreateDefinition.property.datapointsToAlarm">datapointsToAlarm</a></code> | <code>number</code> | Number of breaches required to transition into an ALARM state. |
+| <code><a href="#cdk-monitoring-constructs.AlarmCreateDefinition.property.evaluationPeriods">evaluationPeriods</a></code> | <code>number</code> | Number of periods to consider when checking the number of breaching datapoints. |
+| <code><a href="#cdk-monitoring-constructs.AlarmCreateDefinition.property.metric">metric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | The original, unadjusted metric on which the alarm was created. |
+
+---
+
+##### `addAlarmProps`<sup>Required</sup> <a name="addAlarmProps" id="cdk-monitoring-constructs.AlarmCreateDefinition.property.addAlarmProps"></a>
+
+```typescript
+public readonly addAlarmProps: AddAlarmProps;
+```
+
+- *Type:* <a href="#cdk-monitoring-constructs.AddAlarmProps">AddAlarmProps</a>
+
+The requested configuration for the alarm.
+
+---
+
+##### `alarmFactory`<sup>Required</sup> <a name="alarmFactory" id="cdk-monitoring-constructs.AlarmCreateDefinition.property.alarmFactory"></a>
+
+```typescript
+public readonly alarmFactory: AlarmFactory;
+```
+
+- *Type:* <a href="#cdk-monitoring-constructs.AlarmFactory">AlarmFactory</a>
+
+The alarm factory that created the alarm.
+
+---
+
+##### `datapointsToAlarm`<sup>Required</sup> <a name="datapointsToAlarm" id="cdk-monitoring-constructs.AlarmCreateDefinition.property.datapointsToAlarm"></a>
+
+```typescript
+public readonly datapointsToAlarm: number;
+```
+
+- *Type:* number
+
+Number of breaches required to transition into an ALARM state.
+
+---
+
+##### `evaluationPeriods`<sup>Required</sup> <a name="evaluationPeriods" id="cdk-monitoring-constructs.AlarmCreateDefinition.property.evaluationPeriods"></a>
+
+```typescript
+public readonly evaluationPeriods: number;
+```
+
+- *Type:* number
+
+Number of periods to consider when checking the number of breaching datapoints.
+
+---
+
+##### `metric`<sup>Required</sup> <a name="metric" id="cdk-monitoring-constructs.AlarmCreateDefinition.property.metric"></a>
+
+```typescript
+public readonly metric: Metric | MathExpression;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.Metric | aws-cdk-lib.aws_cloudwatch.MathExpression
+
+The original, unadjusted metric on which the alarm was created.
+
+---
+
 ### AlarmFactoryDefaults <a name="AlarmFactoryDefaults" id="cdk-monitoring-constructs.AlarmFactoryDefaults"></a>
 
 #### Initializer <a name="Initializer" id="cdk-monitoring-constructs.AlarmFactoryDefaults.Initializer"></a>
@@ -3978,6 +4123,7 @@ const alarmWithAnnotation: AlarmWithAnnotation = { ... }
 | <code><a href="#cdk-monitoring-constructs.AlarmWithAnnotation.property.dedupeString">dedupeString</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.AlarmWithAnnotation.property.disambiguator">disambiguator</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.AlarmWithAnnotation.property.alarm">alarm</a></code> | <code>aws-cdk-lib.aws_cloudwatch.AlarmBase</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.AlarmWithAnnotation.property.alarmDefinition">alarmDefinition</a></code> | <code><a href="#cdk-monitoring-constructs.AlarmCreateDefinition">AlarmCreateDefinition</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.AlarmWithAnnotation.property.alarmDescription">alarmDescription</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.AlarmWithAnnotation.property.alarmLabel">alarmLabel</a></code> | <code>string</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.AlarmWithAnnotation.property.alarmName">alarmName</a></code> | <code>string</code> | *No description.* |
@@ -4046,6 +4192,16 @@ public readonly alarm: AlarmBase;
 ```
 
 - *Type:* aws-cdk-lib.aws_cloudwatch.AlarmBase
+
+---
+
+##### `alarmDefinition`<sup>Required</sup> <a name="alarmDefinition" id="cdk-monitoring-constructs.AlarmWithAnnotation.property.alarmDefinition"></a>
+
+```typescript
+public readonly alarmDefinition: AlarmCreateDefinition;
+```
+
+- *Type:* <a href="#cdk-monitoring-constructs.AlarmCreateDefinition">AlarmCreateDefinition</a>
 
 ---
 
@@ -46679,6 +46835,88 @@ public readonly useCreatedAlarms: IAlarmConsumer;
 - *Type:* <a href="#cdk-monitoring-constructs.IAlarmConsumer">IAlarmConsumer</a>
 
 Calls provided function to process all alarms created.
+
+---
+
+### ScaleAlarmsProps <a name="ScaleAlarmsProps" id="cdk-monitoring-constructs.ScaleAlarmsProps"></a>
+
+Properties for configuring a function that clones alarms to be scaled by multiplication factors.
+
+#### Initializer <a name="Initializer" id="cdk-monitoring-constructs.ScaleAlarmsProps.Initializer"></a>
+
+```typescript
+import { ScaleAlarmsProps } from 'cdk-monitoring-constructs'
+
+const scaleAlarmsProps: ScaleAlarmsProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#cdk-monitoring-constructs.ScaleAlarmsProps.property.disambiguator">disambiguator</a></code> | <code>string</code> | The disambiguator to assign to the alarms cloned by the function. |
+| <code><a href="#cdk-monitoring-constructs.ScaleAlarmsProps.property.datapointsToAlarmMultiplier">datapointsToAlarmMultiplier</a></code> | <code>number</code> | A multiplication factor to apply to the datapointsToAlarm property of the cloned alarms. |
+| <code><a href="#cdk-monitoring-constructs.ScaleAlarmsProps.property.evaluationPeriodsMultiplier">evaluationPeriodsMultiplier</a></code> | <code>number</code> | A multiplication factor to apply to the `evaluationPeriods` property of the cloned alarms. |
+| <code><a href="#cdk-monitoring-constructs.ScaleAlarmsProps.property.thresholdMultiplier">thresholdMultiplier</a></code> | <code>number</code> | A multiplication factor to apply to the threshold of the cloned alarms. |
+
+---
+
+##### `disambiguator`<sup>Required</sup> <a name="disambiguator" id="cdk-monitoring-constructs.ScaleAlarmsProps.property.disambiguator"></a>
+
+```typescript
+public readonly disambiguator: string;
+```
+
+- *Type:* string
+
+The disambiguator to assign to the alarms cloned by the function.
+
+---
+
+##### `datapointsToAlarmMultiplier`<sup>Optional</sup> <a name="datapointsToAlarmMultiplier" id="cdk-monitoring-constructs.ScaleAlarmsProps.property.datapointsToAlarmMultiplier"></a>
+
+```typescript
+public readonly datapointsToAlarmMultiplier: number;
+```
+
+- *Type:* number
+- *Default:* 1.0
+
+A multiplication factor to apply to the datapointsToAlarm property of the cloned alarms.
+
+When configured with a value less that 1.0, the cloned alarm *may* use a metric with a more
+granular period so that the result will use a reasonable number of datapoints. In this case,
+the `datapointsToAlarm` and `evaluationPeriods` are increased by the same factor that the
+period is decreased. It will also scale `threshold` for metrics using the SUM or SAMPLE_COUNT
+stats.
+
+---
+
+##### `evaluationPeriodsMultiplier`<sup>Optional</sup> <a name="evaluationPeriodsMultiplier" id="cdk-monitoring-constructs.ScaleAlarmsProps.property.evaluationPeriodsMultiplier"></a>
+
+```typescript
+public readonly evaluationPeriodsMultiplier: number;
+```
+
+- *Type:* number
+- *Default:* Same as datapointsToAlarmMultiplier.
+
+A multiplication factor to apply to the `evaluationPeriods` property of the cloned alarms.
+
+---
+
+##### `thresholdMultiplier`<sup>Optional</sup> <a name="thresholdMultiplier" id="cdk-monitoring-constructs.ScaleAlarmsProps.property.thresholdMultiplier"></a>
+
+```typescript
+public readonly thresholdMultiplier: number;
+```
+
+- *Type:* number
+- *Default:* 1.0
+
+A multiplication factor to apply to the threshold of the cloned alarms.
+
+Threshold scaling does not apply to thresholds on anomaly detection alarms.
 
 ---
 

--- a/lib/common/alarm/AlarmFactory.ts
+++ b/lib/common/alarm/AlarmFactory.ts
@@ -62,6 +62,7 @@ export interface AlarmWithAnnotation extends AlarmMetadata {
   readonly alarmNameSuffix: string;
   readonly alarmLabel: string;
   readonly alarmDescription: string;
+  readonly alarmDefinition: AlarmCreateDefinition;
   readonly alarmRuleWhenOk: IAlarmRule;
   readonly alarmRuleWhenAlarming: IAlarmRule;
   readonly alarmRuleWhenInsufficientData: IAlarmRule;
@@ -279,6 +280,36 @@ export interface AddAlarmProps {
    * @default - no adjuster
    */
   readonly metricAdjuster?: IMetricAdjuster;
+}
+
+/**
+ * Describes the inputs to a single alarm's creation and configuration.
+ */
+export interface AlarmCreateDefinition {
+  /**
+   * The original, unadjusted metric on which the alarm was created.
+   */
+  readonly metric: MetricWithAlarmSupport;
+
+  /**
+   * The requested configuration for the alarm.
+   */
+  readonly addAlarmProps: AddAlarmProps;
+
+  /**
+   * Number of breaches required to transition into an ALARM state.
+   */
+  readonly datapointsToAlarm: number;
+
+  /**
+   * Number of periods to consider when checking the number of breaching datapoints.
+   */
+  readonly evaluationPeriods: number;
+
+  /**
+   * The alarm factory that created the alarm.
+   */
+  readonly alarmFactory: AlarmFactory;
 }
 
 /**
@@ -769,6 +800,13 @@ export class AlarmFactory {
       alarmNameSuffix,
       alarmLabel,
       alarmDescription,
+      alarmDefinition: {
+        metric,
+        addAlarmProps: props,
+        datapointsToAlarm,
+        evaluationPeriods,
+        alarmFactory: this,
+      },
       customTags: props.customTags,
       customParams: props.customParams,
       alarmRuleWhenOk: AlarmRule.fromAlarm(alarm, AlarmState.OK),

--- a/lib/common/alarm/ScaleAlarms.ts
+++ b/lib/common/alarm/ScaleAlarms.ts
@@ -1,0 +1,157 @@
+import { Duration } from "aws-cdk-lib";
+import { ComparisonOperator, Stats } from "aws-cdk-lib/aws-cloudwatch";
+import { AlarmCloneFunction, AlarmWithAnnotation } from "../..";
+
+const SupportedMetricPeriods = [
+  Duration.minutes(1),
+  Duration.minutes(5),
+  Duration.minutes(15),
+  Duration.hours(1),
+  Duration.hours(6),
+  Duration.days(1),
+  Duration.days(7),
+];
+
+/**
+ * Properties for configuring a function that clones alarms to be scaled by multiplication factors.
+ */
+export interface ScaleAlarmsProps {
+  /**
+   * The disambiguator to assign to the alarms cloned by the function.
+   */
+  readonly disambiguator: string;
+
+  /**
+   * A multiplication factor to apply to the threshold of the cloned alarms.
+   *
+   * Threshold scaling does not apply to thresholds on anomaly detection alarms.
+   *
+   * @default - 1.0
+   */
+  readonly thresholdMultiplier?: number;
+
+  /**
+   * A multiplication factor to apply to the datapointsToAlarm property of the cloned alarms.
+   *
+   * When configured with a value less that 1.0, the cloned alarm *may* use a metric with a more
+   * granular period so that the result will use a reasonable number of datapoints. In this case,
+   * the `datapointsToAlarm` and `evaluationPeriods` are increased by the same factor that the
+   * period is decreased. It will also scale `threshold` for metrics using the SUM or SAMPLE_COUNT
+   * stats.
+   *
+   * @default - 1.0
+   */
+  readonly datapointsToAlarmMultiplier?: number;
+
+  /**
+   * A multiplication factor to apply to the `evaluationPeriods` property of the cloned alarms.
+   * @default - Same as datapointsToAlarmMultiplier.
+   */
+  readonly evaluationPeriodsMultiplier?: number;
+}
+
+/**
+ * Creates a function that clones alarms to be more scaled using the multiplication factors
+ * provided. This function can be provided to the `cloneAlarms` method of
+ * {@link MonitoringFacade}.
+ *
+ * This can be used with scaling factors less than 1.0 to create more aggressive alarms, which
+ * can be useful to provide early detection and trigger change rollbacks.
+ *
+ * If the datapoints to alarm would be scaled to such a small number that it can't effectively be
+ * alarmed, the metric period will be reduced to the next smallest duration and the required
+ * datapoint count will scale up accordingly.
+ *
+ * @param props The properties for configuring the function.
+ * @returns A function that clones alarms and applies scaling factors.
+ */
+export function ScaleAlarms(props: ScaleAlarmsProps): AlarmCloneFunction {
+  return function (alarm: AlarmWithAnnotation) {
+    let thresholdMultiplierToUse: number = 1;
+    if (props.thresholdMultiplier) {
+      const comparisonOperator =
+        alarm.alarmDefinition.addAlarmProps.comparisonOperator;
+      switch (comparisonOperator) {
+        case ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD:
+        case ComparisonOperator.GREATER_THAN_THRESHOLD:
+          thresholdMultiplierToUse = props.thresholdMultiplier;
+          break;
+        case ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD:
+        case ComparisonOperator.LESS_THAN_THRESHOLD:
+          thresholdMultiplierToUse = 1.0 / props.thresholdMultiplier;
+          break;
+        case ComparisonOperator.GREATER_THAN_UPPER_THRESHOLD:
+        case ComparisonOperator.LESS_THAN_LOWER_THRESHOLD:
+        case ComparisonOperator.LESS_THAN_LOWER_OR_GREATER_THAN_UPPER_THRESHOLD:
+          // Don't modify thresholds for anomaly detection models.
+          thresholdMultiplierToUse = 1;
+          break;
+        default:
+          throw new Error(
+            `Comparison operator ${comparisonOperator} is not supported by ScaleAlarms.`,
+          );
+      }
+    }
+    let cloneThreshold =
+      alarm.alarmDefinition.addAlarmProps.threshold * thresholdMultiplierToUse;
+
+    let cloneEvaluationPeriods =
+      alarm.alarmDefinition.evaluationPeriods *
+      (props.evaluationPeriodsMultiplier ??
+        props.datapointsToAlarmMultiplier ??
+        1);
+    let cloneDatapointsToAlarm =
+      alarm.alarmDefinition.datapointsToAlarm *
+      (props.datapointsToAlarmMultiplier ?? 1);
+
+    // If the tightened datapoints to alarm is now so small that we can't effectively alarm on it,
+    // reduce the metric period to the next smallest duration and scale up the datapoint count accordingly.
+    let clonePeriod = alarm.alarmDefinition.addAlarmProps.period;
+    if (cloneEvaluationPeriods < 2 || cloneDatapointsToAlarm < 2) {
+      const originalPeriod =
+        alarm.alarmDefinition.addAlarmProps.period ??
+        alarm.alarmDefinition.metric.period;
+
+      const nextSmallestPeriod = findNextSmallestPeriod(originalPeriod);
+      if (nextSmallestPeriod) {
+        clonePeriod = nextSmallestPeriod;
+        const datapointScaleFactor =
+          originalPeriod.toSeconds() / nextSmallestPeriod.toSeconds();
+        cloneEvaluationPeriods = cloneEvaluationPeriods * datapointScaleFactor;
+        cloneDatapointsToAlarm = cloneDatapointsToAlarm * datapointScaleFactor;
+
+        // If the metric uses SUM or N, we also need to scale the threshold down.
+        if ("statistic" in alarm.alarmDefinition.metric) {
+          if (
+            alarm.alarmDefinition.metric.statistic === Stats.SUM ||
+            alarm.alarmDefinition.metric.statistic === Stats.SAMPLE_COUNT
+          ) {
+            cloneThreshold = cloneThreshold / datapointScaleFactor;
+          }
+        }
+      }
+    }
+
+    cloneEvaluationPeriods = Math.max(1, Math.round(cloneEvaluationPeriods));
+    cloneDatapointsToAlarm = Math.max(1, Math.round(cloneDatapointsToAlarm));
+
+    return {
+      ...alarm.alarmDefinition.addAlarmProps,
+      disambiguator: props.disambiguator,
+      threshold: cloneThreshold,
+      evaluationPeriods: cloneEvaluationPeriods,
+      datapointsToAlarm: cloneDatapointsToAlarm,
+      period: clonePeriod,
+    };
+  };
+}
+
+function findNextSmallestPeriod(originalPeriod: Duration) {
+  for (let index = SupportedMetricPeriods.length - 1; index >= 0; index--) {
+    const current = SupportedMetricPeriods[index];
+    if (current.toSeconds() < originalPeriod.toSeconds()) {
+      return current;
+    }
+  }
+  return undefined;
+}

--- a/lib/common/alarm/index.ts
+++ b/lib/common/alarm/index.ts
@@ -6,3 +6,4 @@ export * from "./CustomAlarmThreshold";
 export * from "./IAlarmAnnotationStrategy";
 export * from "./IAlarmDedupeStringProcessor";
 export * from "./IAlarmNamingStrategy";
+export * from "./ScaleAlarms";

--- a/test/common/alarm/ScaleAlarms.test.ts
+++ b/test/common/alarm/ScaleAlarms.test.ts
@@ -1,0 +1,397 @@
+import { Duration, Stack } from "aws-cdk-lib";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { RestApi } from "aws-cdk-lib/aws-apigateway";
+import { Topic } from "aws-cdk-lib/aws-sns";
+import {
+  AlarmWithAnnotation,
+  ElastiCacheClusterType,
+  MonitoringFacade,
+  ScaleAlarms,
+  ScaleAlarmsProps,
+  noopAction,
+  notifySns,
+} from "../../../lib";
+
+test("Given threshold multiplier, creates cloned monitors with more aggressive thresholds.", () => {
+  const resources = makeFacade();
+
+  addMonitors(resources);
+  const clonedAlarms = resources.facade.cloneAlarms(
+    resources.facade.createdAlarmsWithDisambiguator("Critical"),
+    ScaleAlarms({
+      disambiguator: "Rollback",
+      thresholdMultiplier: 0.9,
+    }),
+  );
+
+  verify(resources, clonedAlarms, {
+    disambiguator: "Rollback",
+    thresholdMultiplier: 0.9,
+  });
+});
+
+test("Given threshold multiplier greater than 1.0, creates cloned monitors with more lax thresholds.", () => {
+  const resources = makeFacade();
+
+  addMonitors(resources);
+  const clonedAlarms = resources.facade.cloneAlarms(
+    resources.facade.createdAlarmsWithDisambiguator("Critical"),
+    ScaleAlarms({
+      disambiguator: "Rollback",
+      thresholdMultiplier: 1.5,
+    }),
+  );
+
+  verify(resources, clonedAlarms, {
+    disambiguator: "Rollback",
+    thresholdMultiplier: 1.5,
+  });
+});
+
+test("Given datapointsToAlarm multiplier, creates cloned monitors with more aggressive datapoints to alarm and evaluation periods.", () => {
+  const resources = makeFacade();
+
+  addMonitors(resources);
+  const clonedAlarms = resources.facade.cloneAlarms(
+    resources.facade.createdAlarmsWithDisambiguator("Critical"),
+    ScaleAlarms({
+      disambiguator: "Rollback",
+      datapointsToAlarmMultiplier: 0.3,
+    }),
+  );
+
+  verify(resources, clonedAlarms, {
+    disambiguator: "Rollback",
+    datapointsToAlarmMultiplier: 0.3,
+  });
+});
+
+test("Given datapointsToAlarm and evaluationPeriods multiplier, creates cloned monitors with more aggressive datapoints to alarm and evaluation periods.", () => {
+  const resources = makeFacade();
+
+  addMonitors(resources);
+  const clonedAlarms = resources.facade.cloneAlarms(
+    resources.facade.createdAlarmsWithDisambiguator("Critical"),
+    ScaleAlarms({
+      disambiguator: "Rollback",
+      datapointsToAlarmMultiplier: 0.3,
+      evaluationPeriodsMultiplier: 0.5,
+    }),
+  );
+
+  verify(resources, clonedAlarms, {
+    disambiguator: "Rollback",
+    datapointsToAlarmMultiplier: 0.3,
+    evaluationPeriodsMultiplier: 0.5,
+  });
+});
+
+test("Given all inputs, creates cloned monitors with more aggressive properties.", () => {
+  const resources = makeFacade();
+
+  addMonitors(resources);
+  const clonedAlarms = resources.facade.cloneAlarms(
+    resources.facade.createdAlarmsWithDisambiguator("Critical"),
+    ScaleAlarms({
+      disambiguator: "Rollback",
+      thresholdMultiplier: 0.8,
+      datapointsToAlarmMultiplier: 0.3,
+      evaluationPeriodsMultiplier: 0.5,
+    }),
+  );
+
+  verify(resources, clonedAlarms, {
+    disambiguator: "Rollback",
+    thresholdMultiplier: 0.8,
+    datapointsToAlarmMultiplier: 0.3,
+    evaluationPeriodsMultiplier: 0.5,
+  });
+});
+
+interface TestResources {
+  readonly stack: Stack;
+  readonly facade: MonitoringFacade;
+  readonly onCriticalTopic: Topic;
+  readonly onWarningTopic: Topic;
+}
+
+function makeFacade(): TestResources {
+  const stack = new Stack();
+  const onCriticalTopic = new Topic(stack, "OnCriticalTopic", {
+    topicName: "Criticals",
+  });
+  const onWarningTopic = new Topic(stack, "OnWarningTopic", {
+    topicName: "Warnings",
+  });
+  const facade = new MonitoringFacade(stack, "MonitoringFacade", {
+    metricFactoryDefaults: {
+      namespace: "MyNamespace",
+    },
+    alarmFactoryDefaults: {
+      actionsEnabled: true,
+      alarmNamePrefix: "MyApp",
+      datapointsToAlarm: 5,
+      disambiguatorAction: {
+        Critical: notifySns(onCriticalTopic),
+        Warning: notifySns(onWarningTopic),
+      },
+    },
+  });
+
+  return {
+    stack,
+    facade,
+    onCriticalTopic,
+    onWarningTopic,
+  };
+}
+
+function addMonitors(resources: TestResources) {
+  resources.facade
+    .addLargeHeader("My App Dashboard")
+    .monitorApiGateway({
+      api: RestApi.fromRestApiId(
+        resources.stack,
+        "ImportedRestApi",
+        "MyRestApiId",
+      ),
+      add5XXFaultCountAlarm: {
+        Critical: {
+          maxErrorCount: 10,
+        },
+      },
+      addLowTpsAlarm: {
+        Critical: {
+          minTps: 100,
+        },
+      },
+      addLatencyP90Alarm: {
+        Critical: {
+          maxLatency: Duration.millis(750),
+        },
+      },
+      addHighTpsAlarm: {
+        Critical: {
+          maxTps: 1000,
+          period: Duration.minutes(60),
+          datapointsToAlarm: 2,
+        },
+      },
+    })
+    .monitorElastiCacheCluster({
+      clusterType: ElastiCacheClusterType.REDIS,
+      addRedisEngineCpuUsageAlarm: {
+        Critical: {
+          maxUsagePercent: 0.85,
+        },
+        Warning: {
+          maxUsagePercent: 0.7,
+        },
+      },
+      addMaxEvictedItemsCountAlarm: {
+        Warning: {
+          maxItemsCount: 100,
+        },
+      },
+    });
+}
+
+function verify(
+  resources: TestResources,
+  actualClonedAlarms: AlarmWithAnnotation[],
+  expectedCloneConfiguration: ScaleAlarmsProps,
+) {
+  const facade = resources.facade;
+  // Verify the requested monitors are created.
+  expect(new Set(facade.createdAlarms().map((a) => a.disambiguator))).toEqual(
+    new Set(["Critical", "Warning", "Rollback"]),
+  );
+  const criticalAlarms = facade.createdAlarmsWithDisambiguator("Critical");
+  const expectedNumberOfCriticalAlarms = 5;
+  expect(criticalAlarms.length).toBe(expectedNumberOfCriticalAlarms);
+  expect(criticalAlarms.map((a) => a.action)).toEqual(
+    expect.arrayContaining(
+      Array(expectedNumberOfCriticalAlarms).fill(
+        notifySns(resources.onCriticalTopic),
+      ),
+    ),
+  );
+  const warningAlarms = facade.createdAlarmsWithDisambiguator("Warning");
+  const expectedNumberOfWarningAlarms = 2;
+  expect(warningAlarms.length).toBe(expectedNumberOfWarningAlarms);
+  expect(warningAlarms.map((a) => a.action)).toEqual(
+    expect.arrayContaining(
+      Array(expectedNumberOfWarningAlarms).fill(
+        notifySns(resources.onWarningTopic),
+      ),
+    ),
+  );
+
+  // Verify the cloned monitors are also created.
+  expect(actualClonedAlarms.length).toBe(expectedNumberOfCriticalAlarms);
+  expect(actualClonedAlarms.map((a) => a.action)).toEqual(
+    expect.arrayContaining(
+      Array(expectedNumberOfCriticalAlarms).fill(noopAction()),
+    ),
+  );
+  expect(actualClonedAlarms.map((a) => a.disambiguator)).toEqual(
+    expect.arrayContaining(
+      Array(expectedNumberOfCriticalAlarms).fill("Rollback"),
+    ),
+  );
+  expect(facade.createdAlarmsWithDisambiguator("Rollback")).toEqual(
+    actualClonedAlarms,
+  );
+
+  // Verify the templated alarms have the expected number of evaluation periods,
+  // datapoints to alarm, and thresholds for both the requested alarms and their
+  // clones (adjusted as configured).
+  const template = Template.fromStack(resources.stack);
+
+  const templateCriticalAlarms = template.findResources(
+    "AWS::CloudWatch::Alarm",
+    {
+      Properties: {
+        AlarmName: Match.stringLikeRegexp("-Critical$"),
+        ActionsEnabled: true,
+        AlarmActions: Match.anyValue(),
+        AlarmDescription: Match.anyValue(),
+        ComparisonOperator: Match.anyValue(),
+        DatapointsToAlarm: Match.anyValue(),
+        EvaluationPeriods: Match.anyValue(),
+        Metrics: Match.anyValue(),
+        Threshold: Match.anyValue(),
+        TreatMissingData: Match.anyValue(),
+      },
+    },
+  );
+
+  // Expect cloned alarms to match the requested alarms in all ways
+  // except for the configured variations.
+  // Loop through each requested alarm and verify that a corresponding
+  // clone exists with the expected properties.
+  Object.values(templateCriticalAlarms).forEach((requestedAlarmCfn) => {
+    const correspondingClones = template.findResources(
+      "AWS::CloudWatch::Alarm",
+      {
+        Properties: {
+          AlarmName: requestedAlarmCfn.Properties.AlarmName.replace(
+            /-Critical$/,
+            "-Rollback",
+          ),
+        },
+      },
+    );
+    expect(Object.values(correspondingClones).length).toBe(1);
+    const clonedAlarmCfn = Object.values(correspondingClones)[0];
+
+    expect(clonedAlarmCfn.Properties.AlarmActions).toBe(undefined);
+
+    const requestedPeriod = getMetricPeriod(
+      requestedAlarmCfn.Properties.Metrics,
+    );
+    const clonedPeriod = getMetricPeriod(clonedAlarmCfn.Properties.Metrics);
+    expect(clonedPeriod).toBeLessThanOrEqual(requestedPeriod);
+
+    const scalingFactor = requestedPeriod / clonedPeriod;
+
+    const expectedEvaluationPeriodMultiplier =
+      expectedCloneConfiguration.evaluationPeriodsMultiplier ??
+      expectedCloneConfiguration.datapointsToAlarmMultiplier ??
+      1;
+    const expectedEvaluationPeriods =
+      requestedAlarmCfn.Properties.EvaluationPeriods *
+      expectedEvaluationPeriodMultiplier *
+      scalingFactor;
+    expect(clonedAlarmCfn.Properties.EvaluationPeriods).toEqual(
+      Math.round(expectedEvaluationPeriods),
+    );
+
+    const expectedDatapointsToAlarmMultiplier =
+      expectedCloneConfiguration.datapointsToAlarmMultiplier ?? 1;
+    const expectedDatapointsToAlarm =
+      requestedAlarmCfn.Properties.DatapointsToAlarm *
+      expectedDatapointsToAlarmMultiplier *
+      scalingFactor;
+    expect(clonedAlarmCfn.Properties.DatapointsToAlarm).toEqual(
+      Math.round(expectedDatapointsToAlarm),
+    );
+
+    const thresholdMultiplierToUse =
+      getThresholdMultiplierForTightening(
+        requestedAlarmCfn.Properties.ComparisonOperator,
+        expectedCloneConfiguration.thresholdMultiplier,
+      ) *
+      getThresholdMultiplierForPeriodScaling(
+        requestedAlarmCfn.Properties.Metrics,
+        scalingFactor,
+      );
+    const expectedThreshold =
+      requestedAlarmCfn.Properties.Threshold * thresholdMultiplierToUse;
+    expect(clonedAlarmCfn.Properties.Threshold).toBeCloseTo(expectedThreshold);
+
+    expect(clonedAlarmCfn.Properties.Metrics).toEqual(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      requestedAlarmCfn.Properties.Metrics.map((mCfn: any) => {
+        if (mCfn.MetricStat) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+          return {
+            ...mCfn,
+            MetricStat: {
+              ...mCfn.MetricStat,
+              Period: clonedPeriod,
+            },
+          };
+        } else {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+          return mCfn;
+        }
+      }),
+    );
+  });
+
+  // Snapshot verification
+  expect(template).toMatchSnapshot();
+}
+
+function getMetricPeriod(metricsCfn: any[]): number {
+  const metricsWithPeriod = metricsCfn.filter((m) => m.MetricStat?.Period);
+  // Assert that all these metrics are using the same period.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-non-null-assertion
+  expect(new Set(metricsWithPeriod.map((m) => m.MetricStat!.Period)).size).toBe(
+    1,
+  );
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return metricsWithPeriod[0].MetricStat.Period;
+}
+
+function getThresholdMultiplierForTightening(
+  monitorComparisonOperatorCfn: string,
+  configuredThresholdMultiplier?: number,
+) {
+  if (!configuredThresholdMultiplier) {
+    return 1;
+  } else if (
+    monitorComparisonOperatorCfn.includes("LessThanLower") ||
+    monitorComparisonOperatorCfn.includes("GreaterThanUpper")
+  ) {
+    return 1;
+  } else if (monitorComparisonOperatorCfn.startsWith("LessThan")) {
+    return 1 / configuredThresholdMultiplier;
+  } else {
+    return configuredThresholdMultiplier;
+  }
+}
+
+function getThresholdMultiplierForPeriodScaling(
+  metricsCfn: any[],
+  scalingFactor: number,
+) {
+  if (metricsCfn.length === 1) {
+    const metricStat = metricsCfn[0].MetricStat.Stat;
+    if (metricStat === "Sum" || metricStat === "SampleCount") {
+      return 1 / scalingFactor;
+    }
+  }
+  return 1;
+}

--- a/test/common/alarm/__snapshots__/ScaleAlarms.test.ts.snap
+++ b/test/common/alarm/__snapshots__/ScaleAlarms.test.ts.snap
@@ -1,0 +1,2871 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Given all inputs, creates cloned monitors with more aggressive properties. 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "MonitoringFacadeMonitoringFacadeDashboardsDashboardBE67AB47": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"# My App Dashboard\\"}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"markdown\\":\\"### API Gateway Endpoint **ImportedRestApi prod**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":2,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Count/s\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\"}],[\\"AWS/ApiGateway\\",\\"Count\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"Count\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Count/s < 100 for 5 datapoints within 25 minutes\\",\\"value\\":100,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Count/s > 1000 for 2 datapoints within 120 minutes\\",\\"value\\":1000,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":2,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"stat\\":\\"p50\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P90 (avg: \${AVG})\\",\\"stat\\":\\"p90\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P99 (avg: \${AVG})\\",\\"stat\\":\\"p99\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"P90 > 750 for 5 datapoints within 25 minutes\\",\\"value\\":750,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":2,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"4XXError\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"4XX Error\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/ApiGateway\\",\\"5XXError\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"5XX Fault\\",\\"stat\\":\\"Sum\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"5XX Fault > 10 for 5 datapoints within 25 minutes\\",\\"value\\":10,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":2,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"4XXError\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"4XX Error (avg)\\"}],[\\"AWS/ApiGateway\\",\\"5XXError\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"5XX Fault (avg)\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":7,\\"properties\\":{\\"markdown\\":\\"### ElastiCache Cluster **Redis-ALL**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":3,\\"x\\":0,\\"y\\":8,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CPU Utilization\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"CPUUtilization\\",{\\"label\\":\\"Cluster CPU Utilization\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":100,\\"label\\":\\"%\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":3,\\"x\\":0,\\"y\\":11,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Engine CPU Utilization\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"EngineCPUUtilization\\",{\\"label\\":\\"Cluster Engine CPU Utilization\\",\\"stat\\":\\"Maximum\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Cluster Engine CPU Utilization > 0.85 for 5 datapoints within 25 minutes\\",\\"value\\":0.85,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Cluster Engine CPU Utilization > 0.7 for 5 datapoints within 25 minutes\\",\\"value\\":0.7,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":100,\\"label\\":\\"%\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":8,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Memory Utilization\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"FreeableMemory\\",{\\"label\\":\\"Freeable\\"}],[\\"AWS/ElastiCache\\",\\"UnusedMemory\\",{\\"label\\":\\"Unused\\"}],[\\"AWS/ElastiCache\\",\\"SwapUsage\\",{\\"label\\":\\"Swap\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"bytes\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":8,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Connections\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"CurrConnections\\",{\\"label\\":\\"Current\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":8,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Items\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"CurrItems\\",{\\"label\\":\\"Count\\",\\"stat\\":\\"Maximum\\"}],[\\"AWS/ElastiCache\\",\\"Evictions\\",{\\"label\\":\\"Evictions\\",\\"stat\\":\\"Sum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Evictions > 100 for 5 datapoints within 25 minutes\\",\\"value\\":100,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+        "DashboardName": "MonitoringFacade",
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodFaultCountCriticalC1971DC4": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "Fault count is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-Fault-Count-Critical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "5XX Fault",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodFaultCountRollback155ED76E": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Fault count is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-Fault-Count-Rollback",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 8,
+        "EvaluationPeriods": 13,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "5XX Fault",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 1.6,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodLatencyP90CriticalDA6F10BC": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "P90 latency is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-Latency-P90-Critical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P90",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p90",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 750,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodLatencyP90RollbackD3CE89CE": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P90 latency is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-Latency-P90-Rollback",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 8,
+        "EvaluationPeriods": 13,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P90",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "p90",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 600,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodMaxTPSCritical49F44A12": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "TPS is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-MaxTPS-Critical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 2,
+        "EvaluationPeriods": 2,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Count/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Count",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 3600,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 1000,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodMaxTPSRollback7F44299D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TPS is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-MaxTPS-Rollback",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 2,
+        "EvaluationPeriods": 4,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Count/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Count",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 900,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 800,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodMinTPSCriticalF6FF9D38": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "TPS is too low.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-MinTPS-Critical",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Count/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Count",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 100,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodMinTPSRollbackF6B051A7": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TPS is too low.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-MinTPS-Rollback",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 8,
+        "EvaluationPeriods": 13,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Count/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Count",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 125,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppRedisALLCPUUsageRedisEngineCritical4D8650C6": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "The CPU usage is too high.",
+        "AlarmName": "MyApp-Redis-ALL-CPU-Usage-RedisEngine-Critical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Cluster Engine CPU Utilization",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "EngineCPUUtilization",
+                "Namespace": "AWS/ElastiCache",
+              },
+              "Period": 300,
+              "Stat": "Maximum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.85,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppRedisALLCPUUsageRedisEngineRollback83AD3009": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "The CPU usage is too high.",
+        "AlarmName": "MyApp-Redis-ALL-CPU-Usage-RedisEngine-Rollback",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 8,
+        "EvaluationPeriods": 13,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Cluster Engine CPU Utilization",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "EngineCPUUtilization",
+                "Namespace": "AWS/ElastiCache",
+              },
+              "Period": 60,
+              "Stat": "Maximum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.68,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppRedisALLCPUUsageRedisEngineWarningCA7F3F65": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnWarningTopic4697DA2F",
+          },
+        ],
+        "AlarmDescription": "The CPU usage is too high.",
+        "AlarmName": "MyApp-Redis-ALL-CPU-Usage-RedisEngine-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Cluster Engine CPU Utilization",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "EngineCPUUtilization",
+                "Namespace": "AWS/ElastiCache",
+              },
+              "Period": 300,
+              "Stat": "Maximum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.7,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppRedisALLItemsEvictedWarning3BF10FA1": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnWarningTopic4697DA2F",
+          },
+        ],
+        "AlarmDescription": "The number of items evicted by the cache is too high.",
+        "AlarmName": "MyApp-Redis-ALL-Items-Evicted-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Evictions",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "Evictions",
+                "Namespace": "AWS/ElastiCache",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 100,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "OnCriticalTopic29118B55": Object {
+      "Properties": Object {
+        "TopicName": "Criticals",
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "OnWarningTopic4697DA2F": Object {
+      "Properties": Object {
+        "TopicName": "Warnings",
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`Given datapointsToAlarm and evaluationPeriods multiplier, creates cloned monitors with more aggressive datapoints to alarm and evaluation periods. 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "MonitoringFacadeMonitoringFacadeDashboardsDashboardBE67AB47": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"# My App Dashboard\\"}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"markdown\\":\\"### API Gateway Endpoint **ImportedRestApi prod**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":2,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Count/s\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\"}],[\\"AWS/ApiGateway\\",\\"Count\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"Count\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Count/s < 100 for 5 datapoints within 25 minutes\\",\\"value\\":100,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Count/s > 1000 for 2 datapoints within 120 minutes\\",\\"value\\":1000,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":2,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"stat\\":\\"p50\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P90 (avg: \${AVG})\\",\\"stat\\":\\"p90\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P99 (avg: \${AVG})\\",\\"stat\\":\\"p99\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"P90 > 750 for 5 datapoints within 25 minutes\\",\\"value\\":750,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":2,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"4XXError\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"4XX Error\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/ApiGateway\\",\\"5XXError\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"5XX Fault\\",\\"stat\\":\\"Sum\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"5XX Fault > 10 for 5 datapoints within 25 minutes\\",\\"value\\":10,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":2,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"4XXError\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"4XX Error (avg)\\"}],[\\"AWS/ApiGateway\\",\\"5XXError\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"5XX Fault (avg)\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":7,\\"properties\\":{\\"markdown\\":\\"### ElastiCache Cluster **Redis-ALL**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":3,\\"x\\":0,\\"y\\":8,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CPU Utilization\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"CPUUtilization\\",{\\"label\\":\\"Cluster CPU Utilization\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":100,\\"label\\":\\"%\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":3,\\"x\\":0,\\"y\\":11,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Engine CPU Utilization\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"EngineCPUUtilization\\",{\\"label\\":\\"Cluster Engine CPU Utilization\\",\\"stat\\":\\"Maximum\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Cluster Engine CPU Utilization > 0.85 for 5 datapoints within 25 minutes\\",\\"value\\":0.85,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Cluster Engine CPU Utilization > 0.7 for 5 datapoints within 25 minutes\\",\\"value\\":0.7,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":100,\\"label\\":\\"%\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":8,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Memory Utilization\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"FreeableMemory\\",{\\"label\\":\\"Freeable\\"}],[\\"AWS/ElastiCache\\",\\"UnusedMemory\\",{\\"label\\":\\"Unused\\"}],[\\"AWS/ElastiCache\\",\\"SwapUsage\\",{\\"label\\":\\"Swap\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"bytes\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":8,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Connections\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"CurrConnections\\",{\\"label\\":\\"Current\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":8,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Items\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"CurrItems\\",{\\"label\\":\\"Count\\",\\"stat\\":\\"Maximum\\"}],[\\"AWS/ElastiCache\\",\\"Evictions\\",{\\"label\\":\\"Evictions\\",\\"stat\\":\\"Sum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Evictions > 100 for 5 datapoints within 25 minutes\\",\\"value\\":100,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+        "DashboardName": "MonitoringFacade",
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodFaultCountCriticalC1971DC4": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "Fault count is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-Fault-Count-Critical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "5XX Fault",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodFaultCountRollback155ED76E": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Fault count is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-Fault-Count-Rollback",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 8,
+        "EvaluationPeriods": 13,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "5XX Fault",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 2,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodLatencyP90CriticalDA6F10BC": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "P90 latency is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-Latency-P90-Critical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P90",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p90",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 750,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodLatencyP90RollbackD3CE89CE": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P90 latency is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-Latency-P90-Rollback",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 8,
+        "EvaluationPeriods": 13,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P90",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "p90",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 750,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodMaxTPSCritical49F44A12": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "TPS is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-MaxTPS-Critical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 2,
+        "EvaluationPeriods": 2,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Count/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Count",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 3600,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 1000,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodMaxTPSRollback7F44299D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TPS is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-MaxTPS-Rollback",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 2,
+        "EvaluationPeriods": 4,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Count/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Count",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 900,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 1000,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodMinTPSCriticalF6FF9D38": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "TPS is too low.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-MinTPS-Critical",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Count/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Count",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 100,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodMinTPSRollbackF6B051A7": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TPS is too low.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-MinTPS-Rollback",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 8,
+        "EvaluationPeriods": 13,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Count/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Count",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 100,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppRedisALLCPUUsageRedisEngineCritical4D8650C6": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "The CPU usage is too high.",
+        "AlarmName": "MyApp-Redis-ALL-CPU-Usage-RedisEngine-Critical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Cluster Engine CPU Utilization",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "EngineCPUUtilization",
+                "Namespace": "AWS/ElastiCache",
+              },
+              "Period": 300,
+              "Stat": "Maximum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.85,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppRedisALLCPUUsageRedisEngineRollback83AD3009": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "The CPU usage is too high.",
+        "AlarmName": "MyApp-Redis-ALL-CPU-Usage-RedisEngine-Rollback",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 8,
+        "EvaluationPeriods": 13,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Cluster Engine CPU Utilization",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "EngineCPUUtilization",
+                "Namespace": "AWS/ElastiCache",
+              },
+              "Period": 60,
+              "Stat": "Maximum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.85,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppRedisALLCPUUsageRedisEngineWarningCA7F3F65": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnWarningTopic4697DA2F",
+          },
+        ],
+        "AlarmDescription": "The CPU usage is too high.",
+        "AlarmName": "MyApp-Redis-ALL-CPU-Usage-RedisEngine-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Cluster Engine CPU Utilization",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "EngineCPUUtilization",
+                "Namespace": "AWS/ElastiCache",
+              },
+              "Period": 300,
+              "Stat": "Maximum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.7,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppRedisALLItemsEvictedWarning3BF10FA1": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnWarningTopic4697DA2F",
+          },
+        ],
+        "AlarmDescription": "The number of items evicted by the cache is too high.",
+        "AlarmName": "MyApp-Redis-ALL-Items-Evicted-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Evictions",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "Evictions",
+                "Namespace": "AWS/ElastiCache",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 100,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "OnCriticalTopic29118B55": Object {
+      "Properties": Object {
+        "TopicName": "Criticals",
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "OnWarningTopic4697DA2F": Object {
+      "Properties": Object {
+        "TopicName": "Warnings",
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`Given datapointsToAlarm multiplier, creates cloned monitors with more aggressive datapoints to alarm and evaluation periods. 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "MonitoringFacadeMonitoringFacadeDashboardsDashboardBE67AB47": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"# My App Dashboard\\"}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"markdown\\":\\"### API Gateway Endpoint **ImportedRestApi prod**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":2,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Count/s\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\"}],[\\"AWS/ApiGateway\\",\\"Count\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"Count\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Count/s < 100 for 5 datapoints within 25 minutes\\",\\"value\\":100,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Count/s > 1000 for 2 datapoints within 120 minutes\\",\\"value\\":1000,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":2,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"stat\\":\\"p50\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P90 (avg: \${AVG})\\",\\"stat\\":\\"p90\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P99 (avg: \${AVG})\\",\\"stat\\":\\"p99\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"P90 > 750 for 5 datapoints within 25 minutes\\",\\"value\\":750,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":2,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"4XXError\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"4XX Error\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/ApiGateway\\",\\"5XXError\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"5XX Fault\\",\\"stat\\":\\"Sum\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"5XX Fault > 10 for 5 datapoints within 25 minutes\\",\\"value\\":10,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":2,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"4XXError\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"4XX Error (avg)\\"}],[\\"AWS/ApiGateway\\",\\"5XXError\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"5XX Fault (avg)\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":7,\\"properties\\":{\\"markdown\\":\\"### ElastiCache Cluster **Redis-ALL**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":3,\\"x\\":0,\\"y\\":8,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CPU Utilization\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"CPUUtilization\\",{\\"label\\":\\"Cluster CPU Utilization\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":100,\\"label\\":\\"%\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":3,\\"x\\":0,\\"y\\":11,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Engine CPU Utilization\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"EngineCPUUtilization\\",{\\"label\\":\\"Cluster Engine CPU Utilization\\",\\"stat\\":\\"Maximum\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Cluster Engine CPU Utilization > 0.85 for 5 datapoints within 25 minutes\\",\\"value\\":0.85,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Cluster Engine CPU Utilization > 0.7 for 5 datapoints within 25 minutes\\",\\"value\\":0.7,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":100,\\"label\\":\\"%\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":8,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Memory Utilization\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"FreeableMemory\\",{\\"label\\":\\"Freeable\\"}],[\\"AWS/ElastiCache\\",\\"UnusedMemory\\",{\\"label\\":\\"Unused\\"}],[\\"AWS/ElastiCache\\",\\"SwapUsage\\",{\\"label\\":\\"Swap\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"bytes\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":8,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Connections\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"CurrConnections\\",{\\"label\\":\\"Current\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":8,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Items\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"CurrItems\\",{\\"label\\":\\"Count\\",\\"stat\\":\\"Maximum\\"}],[\\"AWS/ElastiCache\\",\\"Evictions\\",{\\"label\\":\\"Evictions\\",\\"stat\\":\\"Sum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Evictions > 100 for 5 datapoints within 25 minutes\\",\\"value\\":100,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+        "DashboardName": "MonitoringFacade",
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodFaultCountCriticalC1971DC4": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "Fault count is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-Fault-Count-Critical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "5XX Fault",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodFaultCountRollback155ED76E": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Fault count is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-Fault-Count-Rollback",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 8,
+        "EvaluationPeriods": 8,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "5XX Fault",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 2,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodLatencyP90CriticalDA6F10BC": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "P90 latency is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-Latency-P90-Critical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P90",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p90",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 750,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodLatencyP90RollbackD3CE89CE": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P90 latency is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-Latency-P90-Rollback",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 8,
+        "EvaluationPeriods": 8,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P90",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "p90",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 750,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodMaxTPSCritical49F44A12": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "TPS is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-MaxTPS-Critical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 2,
+        "EvaluationPeriods": 2,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Count/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Count",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 3600,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 1000,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodMaxTPSRollback7F44299D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TPS is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-MaxTPS-Rollback",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 2,
+        "EvaluationPeriods": 2,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Count/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Count",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 900,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 1000,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodMinTPSCriticalF6FF9D38": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "TPS is too low.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-MinTPS-Critical",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Count/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Count",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 100,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodMinTPSRollbackF6B051A7": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TPS is too low.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-MinTPS-Rollback",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 8,
+        "EvaluationPeriods": 8,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Count/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Count",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 100,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppRedisALLCPUUsageRedisEngineCritical4D8650C6": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "The CPU usage is too high.",
+        "AlarmName": "MyApp-Redis-ALL-CPU-Usage-RedisEngine-Critical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Cluster Engine CPU Utilization",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "EngineCPUUtilization",
+                "Namespace": "AWS/ElastiCache",
+              },
+              "Period": 300,
+              "Stat": "Maximum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.85,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppRedisALLCPUUsageRedisEngineRollback83AD3009": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "The CPU usage is too high.",
+        "AlarmName": "MyApp-Redis-ALL-CPU-Usage-RedisEngine-Rollback",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 8,
+        "EvaluationPeriods": 8,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Cluster Engine CPU Utilization",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "EngineCPUUtilization",
+                "Namespace": "AWS/ElastiCache",
+              },
+              "Period": 60,
+              "Stat": "Maximum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.85,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppRedisALLCPUUsageRedisEngineWarningCA7F3F65": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnWarningTopic4697DA2F",
+          },
+        ],
+        "AlarmDescription": "The CPU usage is too high.",
+        "AlarmName": "MyApp-Redis-ALL-CPU-Usage-RedisEngine-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Cluster Engine CPU Utilization",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "EngineCPUUtilization",
+                "Namespace": "AWS/ElastiCache",
+              },
+              "Period": 300,
+              "Stat": "Maximum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.7,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppRedisALLItemsEvictedWarning3BF10FA1": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnWarningTopic4697DA2F",
+          },
+        ],
+        "AlarmDescription": "The number of items evicted by the cache is too high.",
+        "AlarmName": "MyApp-Redis-ALL-Items-Evicted-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Evictions",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "Evictions",
+                "Namespace": "AWS/ElastiCache",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 100,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "OnCriticalTopic29118B55": Object {
+      "Properties": Object {
+        "TopicName": "Criticals",
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "OnWarningTopic4697DA2F": Object {
+      "Properties": Object {
+        "TopicName": "Warnings",
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`Given threshold multiplier greater than 1.0, creates cloned monitors with more lax thresholds. 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "MonitoringFacadeMonitoringFacadeDashboardsDashboardBE67AB47": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"# My App Dashboard\\"}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"markdown\\":\\"### API Gateway Endpoint **ImportedRestApi prod**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":2,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Count/s\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\"}],[\\"AWS/ApiGateway\\",\\"Count\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"Count\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Count/s < 100 for 5 datapoints within 25 minutes\\",\\"value\\":100,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Count/s > 1000 for 2 datapoints within 120 minutes\\",\\"value\\":1000,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":2,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"stat\\":\\"p50\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P90 (avg: \${AVG})\\",\\"stat\\":\\"p90\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P99 (avg: \${AVG})\\",\\"stat\\":\\"p99\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"P90 > 750 for 5 datapoints within 25 minutes\\",\\"value\\":750,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":2,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"4XXError\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"4XX Error\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/ApiGateway\\",\\"5XXError\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"5XX Fault\\",\\"stat\\":\\"Sum\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"5XX Fault > 10 for 5 datapoints within 25 minutes\\",\\"value\\":10,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":2,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"4XXError\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"4XX Error (avg)\\"}],[\\"AWS/ApiGateway\\",\\"5XXError\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"5XX Fault (avg)\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":7,\\"properties\\":{\\"markdown\\":\\"### ElastiCache Cluster **Redis-ALL**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":3,\\"x\\":0,\\"y\\":8,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CPU Utilization\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"CPUUtilization\\",{\\"label\\":\\"Cluster CPU Utilization\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":100,\\"label\\":\\"%\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":3,\\"x\\":0,\\"y\\":11,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Engine CPU Utilization\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"EngineCPUUtilization\\",{\\"label\\":\\"Cluster Engine CPU Utilization\\",\\"stat\\":\\"Maximum\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Cluster Engine CPU Utilization > 0.85 for 5 datapoints within 25 minutes\\",\\"value\\":0.85,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Cluster Engine CPU Utilization > 0.7 for 5 datapoints within 25 minutes\\",\\"value\\":0.7,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":100,\\"label\\":\\"%\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":8,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Memory Utilization\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"FreeableMemory\\",{\\"label\\":\\"Freeable\\"}],[\\"AWS/ElastiCache\\",\\"UnusedMemory\\",{\\"label\\":\\"Unused\\"}],[\\"AWS/ElastiCache\\",\\"SwapUsage\\",{\\"label\\":\\"Swap\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"bytes\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":8,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Connections\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"CurrConnections\\",{\\"label\\":\\"Current\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":8,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Items\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"CurrItems\\",{\\"label\\":\\"Count\\",\\"stat\\":\\"Maximum\\"}],[\\"AWS/ElastiCache\\",\\"Evictions\\",{\\"label\\":\\"Evictions\\",\\"stat\\":\\"Sum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Evictions > 100 for 5 datapoints within 25 minutes\\",\\"value\\":100,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+        "DashboardName": "MonitoringFacade",
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodFaultCountCriticalC1971DC4": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "Fault count is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-Fault-Count-Critical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "5XX Fault",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodFaultCountRollback155ED76E": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Fault count is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-Fault-Count-Rollback",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "5XX Fault",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 15,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodLatencyP90CriticalDA6F10BC": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "P90 latency is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-Latency-P90-Critical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P90",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p90",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 750,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodLatencyP90RollbackD3CE89CE": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P90 latency is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-Latency-P90-Rollback",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P90",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p90",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 1125,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodMaxTPSCritical49F44A12": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "TPS is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-MaxTPS-Critical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 2,
+        "EvaluationPeriods": 2,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Count/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Count",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 3600,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 1000,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodMaxTPSRollback7F44299D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TPS is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-MaxTPS-Rollback",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 2,
+        "EvaluationPeriods": 2,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Count/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Count",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 3600,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 1500,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodMinTPSCriticalF6FF9D38": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "TPS is too low.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-MinTPS-Critical",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Count/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Count",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 100,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodMinTPSRollbackF6B051A7": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TPS is too low.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-MinTPS-Rollback",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Count/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Count",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 66.66666666666666,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppRedisALLCPUUsageRedisEngineCritical4D8650C6": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "The CPU usage is too high.",
+        "AlarmName": "MyApp-Redis-ALL-CPU-Usage-RedisEngine-Critical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Cluster Engine CPU Utilization",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "EngineCPUUtilization",
+                "Namespace": "AWS/ElastiCache",
+              },
+              "Period": 300,
+              "Stat": "Maximum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.85,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppRedisALLCPUUsageRedisEngineRollback83AD3009": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "The CPU usage is too high.",
+        "AlarmName": "MyApp-Redis-ALL-CPU-Usage-RedisEngine-Rollback",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Cluster Engine CPU Utilization",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "EngineCPUUtilization",
+                "Namespace": "AWS/ElastiCache",
+              },
+              "Period": 300,
+              "Stat": "Maximum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 1.275,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppRedisALLCPUUsageRedisEngineWarningCA7F3F65": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnWarningTopic4697DA2F",
+          },
+        ],
+        "AlarmDescription": "The CPU usage is too high.",
+        "AlarmName": "MyApp-Redis-ALL-CPU-Usage-RedisEngine-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Cluster Engine CPU Utilization",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "EngineCPUUtilization",
+                "Namespace": "AWS/ElastiCache",
+              },
+              "Period": 300,
+              "Stat": "Maximum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.7,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppRedisALLItemsEvictedWarning3BF10FA1": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnWarningTopic4697DA2F",
+          },
+        ],
+        "AlarmDescription": "The number of items evicted by the cache is too high.",
+        "AlarmName": "MyApp-Redis-ALL-Items-Evicted-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Evictions",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "Evictions",
+                "Namespace": "AWS/ElastiCache",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 100,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "OnCriticalTopic29118B55": Object {
+      "Properties": Object {
+        "TopicName": "Criticals",
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "OnWarningTopic4697DA2F": Object {
+      "Properties": Object {
+        "TopicName": "Warnings",
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`Given threshold multiplier, creates cloned monitors with more aggressive thresholds. 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "MonitoringFacadeMonitoringFacadeDashboardsDashboardBE67AB47": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"# My App Dashboard\\"}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"markdown\\":\\"### API Gateway Endpoint **ImportedRestApi prod**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":2,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Count/s\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\"}],[\\"AWS/ApiGateway\\",\\"Count\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"Count\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Count/s < 100 for 5 datapoints within 25 minutes\\",\\"value\\":100,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Count/s > 1000 for 2 datapoints within 120 minutes\\",\\"value\\":1000,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":2,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"stat\\":\\"p50\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P90 (avg: \${AVG})\\",\\"stat\\":\\"p90\\"}],[\\"AWS/ApiGateway\\",\\"Latency\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"P99 (avg: \${AVG})\\",\\"stat\\":\\"p99\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"P90 > 750 for 5 datapoints within 25 minutes\\",\\"value\\":750,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":2,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"4XXError\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"4XX Error\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/ApiGateway\\",\\"5XXError\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"5XX Fault\\",\\"stat\\":\\"Sum\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"5XX Fault > 10 for 5 datapoints within 25 minutes\\",\\"value\\":10,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":2,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ApiGateway\\",\\"4XXError\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"4XX Error (avg)\\"}],[\\"AWS/ApiGateway\\",\\"5XXError\\",\\"ApiName\\",\\"ImportedRestApi\\",\\"Stage\\",\\"prod\\",{\\"label\\":\\"5XX Fault (avg)\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":7,\\"properties\\":{\\"markdown\\":\\"### ElastiCache Cluster **Redis-ALL**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":3,\\"x\\":0,\\"y\\":8,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CPU Utilization\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"CPUUtilization\\",{\\"label\\":\\"Cluster CPU Utilization\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":100,\\"label\\":\\"%\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":3,\\"x\\":0,\\"y\\":11,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Engine CPU Utilization\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"EngineCPUUtilization\\",{\\"label\\":\\"Cluster Engine CPU Utilization\\",\\"stat\\":\\"Maximum\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Cluster Engine CPU Utilization > 0.85 for 5 datapoints within 25 minutes\\",\\"value\\":0.85,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Cluster Engine CPU Utilization > 0.7 for 5 datapoints within 25 minutes\\",\\"value\\":0.7,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":100,\\"label\\":\\"%\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":8,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Memory Utilization\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"FreeableMemory\\",{\\"label\\":\\"Freeable\\"}],[\\"AWS/ElastiCache\\",\\"UnusedMemory\\",{\\"label\\":\\"Unused\\"}],[\\"AWS/ElastiCache\\",\\"SwapUsage\\",{\\"label\\":\\"Swap\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"bytes\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":8,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Connections\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"CurrConnections\\",{\\"label\\":\\"Current\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":8,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Items\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/ElastiCache\\",\\"CurrItems\\",{\\"label\\":\\"Count\\",\\"stat\\":\\"Maximum\\"}],[\\"AWS/ElastiCache\\",\\"Evictions\\",{\\"label\\":\\"Evictions\\",\\"stat\\":\\"Sum\\",\\"yAxis\\":\\"right\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Evictions > 100 for 5 datapoints within 25 minutes\\",\\"value\\":100,\\"yAxis\\":\\"right\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+        "DashboardName": "MonitoringFacade",
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodFaultCountCriticalC1971DC4": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "Fault count is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-Fault-Count-Critical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "5XX Fault",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 10,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodFaultCountRollback155ED76E": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Fault count is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-Fault-Count-Rollback",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "5XX Fault",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "5XXError",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 9,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodLatencyP90CriticalDA6F10BC": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "P90 latency is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-Latency-P90-Critical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P90",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p90",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 750,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodLatencyP90RollbackD3CE89CE": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P90 latency is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-Latency-P90-Rollback",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "P90",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Latency",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "p90",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 675,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodMaxTPSCritical49F44A12": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "TPS is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-MaxTPS-Critical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 2,
+        "EvaluationPeriods": 2,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Count/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Count",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 3600,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 1000,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodMaxTPSRollback7F44299D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TPS is too high.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-MaxTPS-Rollback",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 2,
+        "EvaluationPeriods": 2,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Count/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Count",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 3600,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 900,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodMinTPSCriticalF6FF9D38": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "TPS is too low.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-MinTPS-Critical",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Count/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Count",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 100,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppImportedRestApiprodMinTPSRollbackF6B051A7": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TPS is too low.",
+        "AlarmName": "MyApp-ImportedRestApi-prod-MinTPS-Rollback",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "Count/s",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Count",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "ApiName",
+                    "Value": "ImportedRestApi",
+                  },
+                  Object {
+                    "Name": "Stage",
+                    "Value": "prod",
+                  },
+                ],
+                "MetricName": "Count",
+                "Namespace": "AWS/ApiGateway",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 111.11111111111111,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppRedisALLCPUUsageRedisEngineCritical4D8650C6": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnCriticalTopic29118B55",
+          },
+        ],
+        "AlarmDescription": "The CPU usage is too high.",
+        "AlarmName": "MyApp-Redis-ALL-CPU-Usage-RedisEngine-Critical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Cluster Engine CPU Utilization",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "EngineCPUUtilization",
+                "Namespace": "AWS/ElastiCache",
+              },
+              "Period": 300,
+              "Stat": "Maximum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.85,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppRedisALLCPUUsageRedisEngineRollback83AD3009": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "The CPU usage is too high.",
+        "AlarmName": "MyApp-Redis-ALL-CPU-Usage-RedisEngine-Rollback",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Cluster Engine CPU Utilization",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "EngineCPUUtilization",
+                "Namespace": "AWS/ElastiCache",
+              },
+              "Period": 300,
+              "Stat": "Maximum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.765,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppRedisALLCPUUsageRedisEngineWarningCA7F3F65": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnWarningTopic4697DA2F",
+          },
+        ],
+        "AlarmDescription": "The CPU usage is too high.",
+        "AlarmName": "MyApp-Redis-ALL-CPU-Usage-RedisEngine-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Cluster Engine CPU Utilization",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "EngineCPUUtilization",
+                "Namespace": "AWS/ElastiCache",
+              },
+              "Period": 300,
+              "Stat": "Maximum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.7,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MonitoringFacadeMyAppRedisALLItemsEvictedWarning3BF10FA1": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnWarningTopic4697DA2F",
+          },
+        ],
+        "AlarmDescription": "The number of items evicted by the cache is too high.",
+        "AlarmName": "MyApp-Redis-ALL-Items-Evicted-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Evictions",
+            "MetricStat": Object {
+              "Metric": Object {
+                "MetricName": "Evictions",
+                "Namespace": "AWS/ElastiCache",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 100,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "OnCriticalTopic29118B55": Object {
+      "Properties": Object {
+        "TopicName": "Criticals",
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+    "OnWarningTopic4697DA2F": Object {
+      "Properties": Object {
+        "TopicName": "Warnings",
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;

--- a/test/facade/MonitoringFacade.test.ts
+++ b/test/facade/MonitoringFacade.test.ts
@@ -1,6 +1,6 @@
 import { Duration, Stack } from "aws-cdk-lib";
-import { Capture, Template } from "aws-cdk-lib/assertions";
-import { TextWidget } from "aws-cdk-lib/aws-cloudwatch";
+import { Capture, Template, Match } from "aws-cdk-lib/assertions";
+import { TextWidget, ComparisonOperator } from "aws-cdk-lib/aws-cloudwatch";
 import { Table } from "aws-cdk-lib/aws-dynamodb";
 import { Function } from "aws-cdk-lib/aws-lambda";
 import { Topic } from "aws-cdk-lib/aws-sns";
@@ -9,6 +9,7 @@ import {
   DynamicDashboardFactory,
   MonitoringFacade,
   SingleWidgetDashboardSegment,
+  noopAction,
   notifySns,
 } from "../../lib";
 
@@ -171,5 +172,225 @@ describe("test of defaults", () => {
       const dashboardBody = JSON.parse(dashboardCapture.asString());
       expect(dashboardBody.widgets).toHaveLength(0);
     } while (dashboardCapture.next());
+  });
+
+  test("Given clone function, creates cloned monitors and returns them.", () => {
+    const stack = new Stack();
+    const onAlarmTopic = new Topic(stack, "OnAlarmTopic", {
+      topicName: "Alarm",
+    });
+    const facade = new MonitoringFacade(stack, "MyAppFacade", {
+      metricFactoryDefaults: {
+        namespace: "MyNamespace",
+      },
+      alarmFactoryDefaults: {
+        alarmNamePrefix: "MyApp",
+        actionsEnabled: true,
+        datapointsToAlarm: 5,
+        disambiguatorAction: {
+          Critical: notifySns(onAlarmTopic),
+        },
+      },
+    });
+
+    facade
+      .addLargeHeader("My App Dashboard")
+      .monitorDynamoTable({
+        table: Table.fromTableName(stack, "ImportedTable", "MyTableName"),
+        addAverageSuccessfulGetItemLatencyAlarm: {
+          Critical: {
+            maxLatency: Duration.seconds(10),
+          },
+          Warning: {
+            maxLatency: Duration.seconds(5),
+          },
+        },
+        addReadThrottledEventsCountAlarm: {
+          Critical: {
+            maxThrottledEventsThreshold: 100,
+          },
+        },
+      })
+      .monitorLambdaFunction({
+        lambdaFunction: Function.fromFunctionAttributes(
+          stack,
+          "XaXrImportedFunction",
+          {
+            functionArn: `arn:aws:lambda:us-west-2:01234567890:function:MyFunction`,
+            sameEnvironment: true,
+          },
+        ),
+        addLowTpsAlarm: {
+          Critical: {
+            minTps: 1,
+          },
+          Warning: {
+            minTps: 5,
+          },
+        },
+        addFaultRateAlarm: {
+          Critical: {
+            maxErrorRate: 0.5,
+          },
+          Warning: {
+            maxErrorRate: 0.25,
+          },
+        },
+      });
+
+    const criticalAlarms = facade.createdAlarmsWithDisambiguator("Critical");
+    const clones = facade.cloneAlarms(criticalAlarms, (a) => {
+      // Arbitrary user-supplied function to create new alarms based off other ones.
+      if (
+        a.alarmDefinition.addAlarmProps.comparisonOperator ==
+        ComparisonOperator.GREATER_THAN_THRESHOLD
+      ) {
+        // Clone alarms that have an upper bound
+        return {
+          ...a.alarmDefinition.addAlarmProps,
+          actionsEnabled: false,
+          disambiguator: "UpperBoundCritical",
+          alarmDescription: "Cloned alarm of " + a.alarmDescription,
+          // Bump the threshold a bit
+          threshold: a.alarmDefinition.addAlarmProps.threshold * 1.1,
+          // Tighten the number of datapoints a bit
+          datapointsToAlarm: a.alarmDefinition.datapointsToAlarm - 1,
+          // Keep the same number of evaluation periods
+          evaluationPeriods: a.alarmDefinition.evaluationPeriods,
+        };
+      } else {
+        // Don't clone alarms that have a lower bound
+        return undefined;
+      }
+    });
+
+    const expectedNumberOfCriticalAlarms = 4;
+    expect(criticalAlarms.length).toBe(expectedNumberOfCriticalAlarms);
+
+    const expectedNumberOfWarningAlarms = 3;
+    const warningAlarms = facade.createdAlarmsWithDisambiguator("Warning");
+    expect(warningAlarms.length).toBe(expectedNumberOfWarningAlarms);
+
+    const expectedNumberOfClonedAlarms = 3;
+    expect(clones.length).toBe(expectedNumberOfClonedAlarms);
+    clones.forEach((a) => expect(a.action).toEqual(noopAction()));
+    clones.forEach((a) =>
+      expect(a.disambiguator).toEqual("UpperBoundCritical"),
+    );
+    clones.forEach((cloneAlarm) => {
+      const sourceAlarm = criticalAlarms.find(
+        (a) => a.alarmDefinition.metric === cloneAlarm.alarmDefinition.metric,
+      )!;
+      expect(cloneAlarm.alarmDefinition.addAlarmProps.threshold).toBeCloseTo(
+        sourceAlarm.alarmDefinition.addAlarmProps.threshold * 1.1,
+      );
+      expect(cloneAlarm.alarmDefinition.datapointsToAlarm).toEqual(
+        sourceAlarm.alarmDefinition.datapointsToAlarm - 1,
+      );
+    });
+
+    // Verify the templated alarms have the expected number of evaluation periods,
+    // datapoints to alarm, and thresholds for both the requested alarms and their
+    // clones (adjusted as configured).
+    const template = Template.fromStack(stack);
+
+    const templateAllAlarms = template.findResources("AWS::CloudWatch::Alarm");
+    expect(Object.keys(templateAllAlarms).length).toBe(
+      expectedNumberOfCriticalAlarms +
+        expectedNumberOfWarningAlarms +
+        expectedNumberOfClonedAlarms,
+    );
+    const templateCriticalAlarms = template.findResources(
+      "AWS::CloudWatch::Alarm",
+      {
+        Properties: {
+          AlarmName: Match.stringLikeRegexp("-Critical$"),
+          ActionsEnabled: true,
+          AlarmActions: Match.anyValue(),
+          AlarmDescription: Match.anyValue(),
+          ComparisonOperator: Match.anyValue(),
+          DatapointsToAlarm: 5,
+          EvaluationPeriods: 5,
+          Metrics: Match.anyValue(),
+          Threshold: Match.anyValue(),
+          TreatMissingData: Match.anyValue(),
+        },
+      },
+    );
+    expect(Object.keys(templateCriticalAlarms).length).toBe(
+      expectedNumberOfCriticalAlarms,
+    );
+    const templateWarningAlarms = template.findResources(
+      "AWS::CloudWatch::Alarm",
+      Match.objectLike({
+        Properties: {
+          AlarmName: Match.stringLikeRegexp("-Warning$"),
+          ActionsEnabled: true,
+          AlarmActions: Match.absent(),
+          AlarmDescription: Match.anyValue(),
+          ComparisonOperator: Match.anyValue(),
+          DatapointsToAlarm: 5,
+          EvaluationPeriods: 5,
+          Metrics: Match.anyValue(),
+          Threshold: Match.anyValue(),
+          TreatMissingData: Match.anyValue(),
+        },
+      }),
+    );
+    expect(Object.keys(templateWarningAlarms).length).toBe(
+      expectedNumberOfWarningAlarms,
+    );
+    const templateCloneAlarms = template.findResources(
+      "AWS::CloudWatch::Alarm",
+      Match.objectLike({
+        Properties: {
+          AlarmName: Match.stringLikeRegexp("-UpperBoundCritical$"),
+          ActionsEnabled: false,
+          AlarmActions: Match.absent(),
+          AlarmDescription: Match.stringLikeRegexp("^Cloned alarm of "),
+          ComparisonOperator: "GreaterThanThreshold",
+          DatapointsToAlarm: 4,
+          EvaluationPeriods: 5,
+          Metrics: Match.anyValue(),
+          Threshold: Match.anyValue(),
+          TreatMissingData: Match.anyValue(),
+        },
+      }),
+    );
+    expect(Object.keys(templateCloneAlarms).length).toBe(
+      expectedNumberOfClonedAlarms,
+    );
+    // Expect cloned alarms to match the requested alarms in all ways
+    // except for the configured variations.
+    expect(Object.values(templateCloneAlarms)).toEqual(
+      Object.values(templateCriticalAlarms)
+        .filter(
+          (resource) =>
+            resource.Properties.ComparisonOperator === "GreaterThanThreshold",
+        )
+        .map((resource) => {
+          return {
+            ...resource,
+            Properties: {
+              ...resource.Properties,
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+              AlarmName: resource.Properties.AlarmName.replace(
+                /-Critical$/,
+                "-UpperBoundCritical",
+              ),
+              ActionsEnabled: false,
+              AlarmActions: undefined,
+              AlarmDescription:
+                "Cloned alarm of " + resource.Properties.AlarmDescription,
+              Threshold: resource.Properties.Threshold * 1.1,
+              DatapointsToAlarm: resource.Properties.DatapointsToAlarm - 1,
+              EvaluationPeriods: resource.Properties.EvaluationPeriods,
+            },
+          };
+        }),
+    );
+
+    // Snapshot verification
+    expect(template).toMatchSnapshot();
   });
 });

--- a/test/facade/__snapshots__/MonitoringFacade.test.ts.snap
+++ b/test/facade/__snapshots__/MonitoringFacade.test.ts.snap
@@ -1,5 +1,522 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`test of defaults Given clone function, creates cloned monitors and returns them. 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "MyAppFacadeMyAppFacadeDashboardsDashboard951173E0": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"start\\":\\"-PT8H\\",\\"periodOverride\\":\\"inherit\\",\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"# My App Dashboard\\"}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"markdown\\":\\"### Dynamo Table **[ImportedTable](https://",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ".console.aws.amazon.com/dynamodb/home?region=",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "#tables:selected=MyTableName)**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":3,\\"x\\":0,\\"y\\":2,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Read Usage\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Consumed\\",\\"expression\\":\\"consumed_rcu_sum/PERIOD(consumed_rcu_sum)\\",\\"id\\":\\"consumed_read_cap\\"}],[\\"AWS/DynamoDB\\",\\"ConsumedReadCapacityUnits\\",\\"TableName\\",\\"MyTableName\\",{\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"consumed_rcu_sum\\"}],[\\"AWS/DynamoDB\\",\\"ProvisionedReadCapacityUnits\\",\\"TableName\\",\\"MyTableName\\",{\\"label\\":\\"Provisioned\\",\\"id\\":\\"provisioned_read_cap\\"}],[{\\"label\\":\\"Utilization\\",\\"expression\\":\\"100*(consumed_read_cap/provisioned_read_cap)\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"max\\":100,\\"label\\":\\"%\\",\\"showUnits\\":false}},\\"legend\\":{\\"position\\":\\"right\\"}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":3,\\"x\\":0,\\"y\\":5,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Write Usage\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Consumed\\",\\"expression\\":\\"consumed_wcu_sum/PERIOD(consumed_wcu_sum)\\",\\"id\\":\\"consumed_write_cap\\"}],[\\"AWS/DynamoDB\\",\\"ConsumedWriteCapacityUnits\\",\\"TableName\\",\\"MyTableName\\",{\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"consumed_wcu_sum\\"}],[\\"AWS/DynamoDB\\",\\"ProvisionedWriteCapacityUnits\\",\\"TableName\\",\\"MyTableName\\",{\\"label\\":\\"Provisioned\\",\\"id\\":\\"provisioned_write_cap\\"}],[{\\"label\\":\\"Utilization\\",\\"expression\\":\\"100*(consumed_write_cap/provisioned_write_cap)\\",\\"yAxis\\":\\"right\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false},\\"right\\":{\\"min\\":0,\\"max\\":100,\\"label\\":\\"%\\",\\"showUnits\\":false}},\\"legend\\":{\\"position\\":\\"right\\"}}},{\\"type\\":\\"metric\\",\\"width\\":9,\\"height\\":6,\\"x\\":6,\\"y\\":2,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency (Average)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\" \\",\\"expression\\":\\"SEARCH('{\\\\\\"AWS/DynamoDB\\\\\\",\\\\\\"TableName\\\\\\",\\\\\\"Operation\\\\\\"} \\\\\\"TableName\\\\\\"=\\\\\\"MyTableName\\\\\\" MetricName=\\\\\\"SuccessfulRequestLatency\\\\\\"', 'Average', 300)\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"GetItem > 10000 for 5 datapoints within 25 minutes\\",\\"value\\":10000,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"GetItem > 5000 for 5 datapoints within 25 minutes\\",\\"value\\":5000,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}},\\"legend\\":{\\"position\\":\\"right\\"}}},{\\"type\\":\\"metric\\",\\"width\\":3,\\"height\\":6,\\"x\\":15,\\"y\\":2,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Throttles\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"Read\\",\\"expression\\":\\"FILL(readThrottles,0)\\"}],[\\"AWS/DynamoDB\\",\\"ReadThrottleEvents\\",\\"TableName\\",\\"MyTableName\\",{\\"label\\":\\"Read\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"readThrottles\\"}],[{\\"label\\":\\"Write\\",\\"expression\\":\\"FILL(writeThrottles,0)\\"}],[\\"AWS/DynamoDB\\",\\"WriteThrottleEvents\\",\\"TableName\\",\\"MyTableName\\",{\\"label\\":\\"Write\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"writeThrottles\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Read > 100 for 5 datapoints within 25 minutes\\",\\"value\\":100,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":6,\\"x\\":18,\\"y\\":2,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"System Errors\\",\\"expression\\":\\"systemErrorGetItem+systemErrorBatchGetItem+systemErrorScan+systemErrorQuery+systemErrorGetRecords+systemErrorPutItem+systemErrorDeleteItem+systemErrorUpdateItem+systemErrorBatchWriteItem\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"GetItem\\",\\"TableName\\",\\"MyTableName\\",{\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorGetItem\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"BatchGetItem\\",\\"TableName\\",\\"MyTableName\\",{\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorBatchGetItem\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"Scan\\",\\"TableName\\",\\"MyTableName\\",{\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorScan\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"Query\\",\\"TableName\\",\\"MyTableName\\",{\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorQuery\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"GetRecords\\",\\"TableName\\",\\"MyTableName\\",{\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorGetRecords\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"PutItem\\",\\"TableName\\",\\"MyTableName\\",{\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorPutItem\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"DeleteItem\\",\\"TableName\\",\\"MyTableName\\",{\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorDeleteItem\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"UpdateItem\\",\\"TableName\\",\\"MyTableName\\",{\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorUpdateItem\\"}],[\\"AWS/DynamoDB\\",\\"SystemErrors\\",\\"Operation\\",\\"BatchWriteItem\\",\\"TableName\\",\\"MyTableName\\",{\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"systemErrorBatchWriteItem\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":8,\\"properties\\":{\\"markdown\\":\\"### Lambda Function **[XaXrImportedFunction](https://",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              ".console.aws.amazon.com/lambda/home?region=",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "#/functions/MyFunction)**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":9,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"TPS\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\"}],[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"Invocations\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"TPS < 1 for 5 datapoints within 25 minutes\\",\\"value\\":1,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TPS < 5 for 5 datapoints within 25 minutes\\",\\"value\\":5,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":9,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"stat\\":\\"p50\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"P90 (avg: \${AVG})\\",\\"stat\\":\\"p90\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"P99 (avg: \${AVG})\\",\\"stat\\":\\"p99\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":9,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"Faults (avg)\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Faults (avg) > 0.5 for 5 datapoints within 25 minutes\\",\\"value\\":0.5,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Faults (avg) > 0.25 for 5 datapoints within 25 minutes\\",\\"value\\":0.25,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":9,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Rates\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"Throttles (avg)\\"}],[\\"AWS/Lambda\\",\\"ProvisionedConcurrencySpilloverInvocations\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"Provisioned Concurrency Spillovers (avg)\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":0,\\"y\\":14,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Invocations\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"Invocations\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"Throttles\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"ConcurrentExecutions\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"Concurrent\\",\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"ProvisionedConcurrencySpilloverInvocations\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"Provisioned Concurrency Spillovers\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":8,\\"y\\":14,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"Faults\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":16,\\"y\\":19,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Iterator\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"IteratorAge\\",\\"FunctionName\\",\\"MyFunction\\",{\\"label\\":\\"Iterator Age\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+        "DashboardName": "MyAppFacade",
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "MyAppFacadeMyAppImportedTableLatencyAverageGetItemCriticalCE2E24AD": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnAlarmTopicF22649A2",
+          },
+        ],
+        "AlarmDescription": "Average latency is too high.",
+        "AlarmName": "MyApp-ImportedTable-Latency-Average-GetItem-Critical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "GetItem",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "Operation",
+                    "Value": "GetItem",
+                  },
+                  Object {
+                    "Name": "TableName",
+                    "Value": "MyTableName",
+                  },
+                ],
+                "MetricName": "SuccessfulRequestLatency",
+                "Namespace": "AWS/DynamoDB",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 10000,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MyAppFacadeMyAppImportedTableLatencyAverageGetItemUpperBoundCriticalD9F38439": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmDescription": "Cloned alarm of Average latency is too high.",
+        "AlarmName": "MyApp-ImportedTable-Latency-Average-GetItem-UpperBoundCritical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 4,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "GetItem",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "Operation",
+                    "Value": "GetItem",
+                  },
+                  Object {
+                    "Name": "TableName",
+                    "Value": "MyTableName",
+                  },
+                ],
+                "MetricName": "SuccessfulRequestLatency",
+                "Namespace": "AWS/DynamoDB",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 11000,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MyAppFacadeMyAppImportedTableLatencyAverageGetItemWarning6B092EC9": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Average latency is too high.",
+        "AlarmName": "MyApp-ImportedTable-Latency-Average-GetItem-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "GetItem",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "Operation",
+                    "Value": "GetItem",
+                  },
+                  Object {
+                    "Name": "TableName",
+                    "Value": "MyTableName",
+                  },
+                ],
+                "MetricName": "SuccessfulRequestLatency",
+                "Namespace": "AWS/DynamoDB",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 5000,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MyAppFacadeMyAppImportedTableReadThrottledEventsCritical1A15FCE5": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnAlarmTopicF22649A2",
+          },
+        ],
+        "AlarmDescription": "Read throttled events above threshold.",
+        "AlarmName": "MyApp-ImportedTable-Read-Throttled-Events-Critical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(readThrottles,0)",
+            "Id": "expr_1",
+            "Label": "Read",
+          },
+          Object {
+            "Id": "readThrottles",
+            "Label": "Read",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "TableName",
+                    "Value": "MyTableName",
+                  },
+                ],
+                "MetricName": "ReadThrottleEvents",
+                "Namespace": "AWS/DynamoDB",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 100,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MyAppFacadeMyAppImportedTableReadThrottledEventsUpperBoundCritical2562AD69": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmDescription": "Cloned alarm of Read throttled events above threshold.",
+        "AlarmName": "MyApp-ImportedTable-Read-Throttled-Events-UpperBoundCritical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 4,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(readThrottles,0)",
+            "Id": "expr_1",
+            "Label": "Read",
+          },
+          Object {
+            "Id": "readThrottles",
+            "Label": "Read",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "TableName",
+                    "Value": "MyTableName",
+                  },
+                ],
+                "MetricName": "ReadThrottleEvents",
+                "Namespace": "AWS/DynamoDB",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 110.00000000000001,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MyAppFacadeMyAppXaXrImportedFunctionFaultRateCritical7D4BE91C": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnAlarmTopicF22649A2",
+          },
+        ],
+        "AlarmDescription": "Fault rate is too high.",
+        "AlarmName": "MyApp-XaXrImportedFunction-Fault-Rate-Critical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Faults (avg)",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": "MyFunction",
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.5,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MyAppFacadeMyAppXaXrImportedFunctionFaultRateUpperBoundCriticalC439FCAA": Object {
+      "Properties": Object {
+        "ActionsEnabled": false,
+        "AlarmDescription": "Cloned alarm of Fault rate is too high.",
+        "AlarmName": "MyApp-XaXrImportedFunction-Fault-Rate-UpperBoundCritical",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 4,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Faults (avg)",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": "MyFunction",
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.55,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MyAppFacadeMyAppXaXrImportedFunctionFaultRateWarning46056A2E": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Fault rate is too high.",
+        "AlarmName": "MyApp-XaXrImportedFunction-Fault-Rate-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "Faults (avg)",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": "MyFunction",
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 0.25,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MyAppFacadeMyAppXaXrImportedFunctionMinTPSCritical73D97A1A": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "OnAlarmTopicF22649A2",
+          },
+        ],
+        "AlarmDescription": "TPS is too low.",
+        "AlarmName": "MyApp-XaXrImportedFunction-MinTPS-Critical",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "TPS",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Invocations",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": "MyFunction",
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "MyAppFacadeMyAppXaXrImportedFunctionMinTPSWarning04AB2576": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TPS is too low.",
+        "AlarmName": "MyApp-XaXrImportedFunction-MinTPS-Warning",
+        "ComparisonOperator": "LessThanThreshold",
+        "DatapointsToAlarm": 5,
+        "EvaluationPeriods": 5,
+        "Metrics": Array [
+          Object {
+            "Expression": "FILL(requests,0) / PERIOD(requests)",
+            "Id": "expr_1",
+            "Label": "TPS",
+          },
+          Object {
+            "Id": "requests",
+            "Label": "Invocations",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": "MyFunction",
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 300,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "Threshold": 5,
+        "TreatMissingData": "missing",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "OnAlarmTopicF22649A2": Object {
+      "Properties": Object {
+        "TopicName": "Alarm",
+      },
+      "Type": "AWS::SNS::Topic",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`test of defaults typical usage 1`] = `
 Object {
   "Parameters": Object {


### PR DESCRIPTION
Closes #631

---

### Summary

The changes in this pull request implement [a feature to clone conservative ticketing alarms to be more aggressive for rollback alarms](https://github.com/cdklabs/cdk-monitoring-constructs/issues/631). `MonitoringFacade` introduces the capability to specify that all monitors belonging to a given disambiguator (e.g. "Critical") should be cloned to new monitors with a new different disambiguator (e.g. "Rollback") and mutated to a smaller number of datapoints to alarm.

There are two parts to this feature.

The `MonitoringFacade` class now has a `cloneAlarms()` method. When given a list of `AlarmWithAnnotation` objects and a TypeScript function, the `cloneAlarms()` method applies the function on each alarm in the list. The clone function itself takes an `AlarmWithAnnotation` instance and returns a new `AddAlarmProps` instance that describes a new alarm to create. Once the function generates a new list of `AddAlarmProps` objects, the `cloneAlarms()` method then invokes the alarm factory to create those alarms and return them to the consumer.

To easily enable the use case describe in #631 of creating aggressive rollback alarms by cloning more-conservative ticketing alarms, the PR includes an implementation of the alarm cloning function. The function can be customized by consumers with scaling factors for `threshold`, `datapointsToAlarm`, and `evaluationPeriods`; scaling factors between 0.0 and 1.0 will result in more aggressive alarms.

### Implementation Details

In order for the new `cloneAlarms()` method to create new alarms, it needs to obtain information about the original alarm that currently is not stored. Specifically, it needs all the inputs to `AlarmFactory`'s `addAlarm()` method: a `MetricWithAlarmSupport` and an `AddAlarmProps` instance. It also needs the original `AlamFactory` instance itself.

Currently, the `AlarmFactory` and its inputs are discarded after alarms are originally created. Therefore, this CR creates a place to hold onto those objects for later use. A new type called `AlarmCreateDefinition` stores the factory, the metric, and the source alarm props, and an instance of this object is added to `AlarmWithAnnotation`. Whenever an alarm is created in `AlarmFactory`, the creation definition is stored on the resulting alarm object. That way, an alarm clone function can access these original values.

We also create the `ScaleAlarms` clone function implementation. This code can perform the following scaling operations when cloning:
* **threshold scaling** - When a threshold is specified with a "greater than" comparison operator, the scaling factor is multiplied against the original threshold. For example, a scaling factor of 0.5 would half the source threshold value, creating a more aggressive threshold. For "less than" comparison operators, we subtract the scaling factor from 1 so that we make the lower-bound threshold more aggressive too.
* **datapointsToAlarm and evaluationPeriods scaling** - Scaling factors will be multiplied by the source alarm's datapoint values. When the scaling factor is less than 1, this causes the alarm to trigger sooner. In the case where the original alarm has a low number of datapoints such that scaling it down would be problematic, we attempt to reduce the period duration so that we can still alarm sooner.

### Testing

This PR includes new unit test cases for both a user-supplied custom clone function and the common case of using the alarm-scaling clone function. The unit test performs both fine-grained assertions and also a snapshot verification.

I also deployed a CloudFormation stack with this feature to a personal account and manually verified it created the expected alarms.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_