### PR TITLE
fix: use latest Node.js runtime for utility Lambda functions

### DIFF
--- a/lib/dashboard/widget/BitmapWidget.ts
+++ b/lib/dashboard/widget/BitmapWidget.ts
@@ -34,7 +34,7 @@ export class BitmapWidgetRenderingSupport extends Construct {
         "Custom Widget Render for Bitmap Widgets (cdk-monitoring-constructs)",
       handler: "index.handler",
       memorySize: 128,
-      runtime: Runtime.NODEJS_18_X,
+      runtime: Runtime.NODEJS_LATEST,
       timeout: Duration.seconds(60),
       logRetention: RetentionDays.ONE_DAY,
     });

--- a/lib/monitoring/aws-secretsmanager/SecretsManagerMetricsPublisher.ts
+++ b/lib/monitoring/aws-secretsmanager/SecretsManagerMetricsPublisher.ts
@@ -34,7 +34,7 @@ export class SecretsManagerMetricsPublisher extends Construct {
         "Custom metrics publisher for SecretsManager Secrets (cdk-monitoring-constructs)",
       handler: "index.handler",
       memorySize: 128,
-      runtime: Runtime.NODEJS_18_X,
+      runtime: Runtime.NODEJS_LATEST,
       timeout: Duration.seconds(60),
       logRetention: RetentionDays.ONE_DAY,
     });

--- a/test/common/alarm/action/LambdaAlarmActionStrategy.test.ts
+++ b/test/common/alarm/action/LambdaAlarmActionStrategy.test.ts
@@ -9,7 +9,7 @@ test("snapshot test: Lambda function", () => {
   const stack = new Stack();
   const onAlarmFunction = new Function(stack, "alarmLambda", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_18_X,
+    runtime: Runtime.NODEJS_LATEST,
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });
@@ -28,7 +28,7 @@ test("snapshot test: Lambda alias", () => {
   const stack = new Stack();
   const onAlarmFunction = new Function(stack, "alarmLambda", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_18_X,
+    runtime: Runtime.NODEJS_LATEST,
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });
@@ -48,7 +48,7 @@ test("snapshot test: Lambda version", () => {
   const stack = new Stack();
   const onAlarmFunction = new Function(stack, "alarmLambda", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_18_X,
+    runtime: Runtime.NODEJS_LATEST,
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });

--- a/test/dashboard/widget/CustomWidget.test.ts
+++ b/test/dashboard/widget/CustomWidget.test.ts
@@ -8,7 +8,7 @@ test("widget", () => {
 
   const handler = new Function(stack, "Function", {
     // execution environment
-    runtime: Runtime.NODEJS_18_X,
+    runtime: Runtime.NODEJS_LATEST,
     // code loaded from "lambda" directory
     code: Code.fromInline(
       'exports.handler = function(event, ctx, cb) { return cb(null, "Hello World!"); }',

--- a/test/monitoring/aws-lambda/LambdaFunctionMonitoring.test.ts
+++ b/test/monitoring/aws-lambda/LambdaFunctionMonitoring.test.ts
@@ -19,7 +19,7 @@ test("snapshot test: default iterator and no alarms", () => {
 
   const lambdaFunction = new Function(stack, "Function", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_18_X,
+    runtime: Runtime.NODEJS_LATEST,
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });
@@ -49,7 +49,7 @@ test("snapshot test: non-iterator and no alarms", () => {
 
   const lambdaFunction = new Function(stack, "Function", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_18_X,
+    runtime: Runtime.NODEJS_LATEST,
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });
@@ -72,7 +72,7 @@ test("snapshot test: all alarms", () => {
 
   const lambdaFunction = new Function(stack, "Function", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_18_X,
+    runtime: Runtime.NODEJS_LATEST,
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });
@@ -190,7 +190,7 @@ test("snapshot test: all alarms", () => {
 
   const lambdaFunction = new Function(stack, "Function", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_18_X,
+    runtime: Runtime.NODEJS_LATEST,
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
     layers: [
@@ -230,7 +230,7 @@ test("snapshot test: all alarms, alarmPrefix on error dedupeString", () => {
 
   const lambdaFunction = new Function(stack, "Function", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_18_X,
+    runtime: Runtime.NODEJS_LATEST,
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });
@@ -376,7 +376,7 @@ test("snapshot test: all alarms, alarmPrefix on latency dedupeString", () => {
 
   const lambdaFunction = new Function(stack, "Function", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_18_X,
+    runtime: Runtime.NODEJS_LATEST,
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });
@@ -519,7 +519,7 @@ test("throws error if attempting to create iterator age alarm if not an iterator
 
   const lambdaFunction = new Function(stack, "Function", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_18_X,
+    runtime: Runtime.NODEJS_LATEST,
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });
@@ -549,7 +549,7 @@ test("throws error if attempting to create offsetLag alarm if not an offsetLag L
 
   const lambdaFunction = new Function(stack, "Function", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_18_X,
+    runtime: Runtime.NODEJS_LATEST,
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });
@@ -578,7 +578,7 @@ test("doesn't create alarms for enhanced Lambda Insights metrics if not enabled"
 
   const lambdaFunction = new Function(stack, "Function", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_18_X,
+    runtime: Runtime.NODEJS_LATEST,
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });

--- a/test/monitoring/aws-step-functions/StepFunctionLambdaIntegrationMonitoring.test.ts
+++ b/test/monitoring/aws-step-functions/StepFunctionLambdaIntegrationMonitoring.test.ts
@@ -16,7 +16,7 @@ test("snapshot test: no alarms", () => {
 
   const lambdaFunction = new Function(stack, "Function", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_18_X,
+    runtime: Runtime.NODEJS_LATEST,
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });
@@ -37,7 +37,7 @@ test("snapshot test: all alarms", () => {
 
   const lambdaFunction = new Function(stack, "Function", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_18_X,
+    runtime: Runtime.NODEJS_LATEST,
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });


### PR DESCRIPTION
Node.js 18 will be blocked later this year.

See https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_