### PR TITLE
fix(MetricFactory): Metric Search with multiple namespaces are wrongly wrapped

### DIFF
--- a/lib/common/metric/MetricFactory.ts
+++ b/lib/common/metric/MetricFactory.ts
@@ -149,11 +149,14 @@ export class MetricFactory {
     const finalPeriod =
       period ?? this.globalDefaults.period ?? DefaultMetricPeriod;
     const searchNamespace = this.getNamespaceWithFallback(namespace);
+    const namespacesWithQuotations = searchNamespace
+      .split(",")
+      .map((namespace) => `"${namespace.trim()}"`);
     const keysWithQuotations = Object.keys(dimensionsMap).map(
       (key) => `"${key}"`,
     );
     const namespacePlusDimensionKeys = [
-      `"${searchNamespace}"`,
+      namespacesWithQuotations,
       ...keysWithQuotations,
     ].join(",");
     const metricSchema = `{${namespacePlusDimensionKeys}}`;

--- a/test/common/metric/MetricFactory.test.ts
+++ b/test/common/metric/MetricFactory.test.ts
@@ -328,6 +328,15 @@ test("snapshot test: createMetricSearch", () => {
   );
 
   expect(metricWithEmptyDimensions).toMatchSnapshot();
+
+  const metricWithMultipleNamespaces = metricFactory.createMetricSearch(
+    "MyMetricPrefix-",
+    { DummyDimension: "DummyDimensionValue" },
+    MetricStatistic.SUM,
+    "DummyNamespaceOverride1, DummyNamespaceOverride2 ,DummyNamespaceOverride3",
+  );
+
+  expect(metricWithMultipleNamespaces).toMatchSnapshot();
 });
 
 test("snapshot test: createMetricAnomalyDetection", () => {

--- a/test/common/metric/__snapshots__/MetricFactory.test.ts.snap
+++ b/test/common/metric/__snapshots__/MetricFactory.test.ts.snap
@@ -387,6 +387,25 @@ MathExpression {
 }
 `;
 
+exports[`snapshot test: createMetricSearch 5`] = `
+MathExpression {
+  "color": undefined,
+  "expression": "SEARCH('{\\"DummyNamespaceOverride1\\",\\"DummyNamespaceOverride2\\",\\"DummyNamespaceOverride3\\",\\"DummyDimension\\"} \\"DummyDimension\\"=\\"DummyDimensionValue\\" MyMetricPrefix-', 'Sum', 300)",
+  "label": " ",
+  "period": Duration {
+    "amount": 5,
+    "unit": TimeUnit {
+      "inMillis": 60000,
+      "isoLabel": "M",
+      "label": "minutes",
+    },
+  },
+  "searchAccount": undefined,
+  "searchRegion": undefined,
+  "usingMetrics": Object {},
+}
+`;
+
 exports[`snapshot test: global defaults with account 1`] = `
 Object {
   "metric": Metric {


### PR DESCRIPTION
This change splits the namespaces to wrap them individually.

Fixes #623

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_