### PR TITLE
feat(dashboard): add support for dashboard variables

### DIFF
--- a/API.md
+++ b/API.md
@@ -16751,6 +16751,7 @@ const dynamicDashboardConfiguration: DynamicDashboardConfiguration = { ... }
 | <code><a href="#cdk-monitoring-constructs.DynamicDashboardConfiguration.property.periodOverride">periodOverride</a></code> | <code>aws-cdk-lib.aws_cloudwatch.PeriodOverride</code> | Period override for the dashboard. |
 | <code><a href="#cdk-monitoring-constructs.DynamicDashboardConfiguration.property.range">range</a></code> | <code>aws-cdk-lib.Duration</code> | Range of the dashboard. |
 | <code><a href="#cdk-monitoring-constructs.DynamicDashboardConfiguration.property.renderingPreference">renderingPreference</a></code> | <code><a href="#cdk-monitoring-constructs.DashboardRenderingPreference">DashboardRenderingPreference</a></code> | Dashboard rendering preference. |
+| <code><a href="#cdk-monitoring-constructs.DynamicDashboardConfiguration.property.variables">variables</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IVariable[]</code> | Dashboard variables to include in the dashboards. |
 
 ---
 
@@ -16805,6 +16806,19 @@ public readonly renderingPreference: DashboardRenderingPreference;
 - *Default:* DashboardRenderingPreference.INTERACTIVE_ONLY
 
 Dashboard rendering preference.
+
+---
+
+##### `variables`<sup>Optional</sup> <a name="variables" id="cdk-monitoring-constructs.DynamicDashboardConfiguration.property.variables"></a>
+
+```typescript
+public readonly variables: IVariable[];
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IVariable[]
+- *Default:* No variables
+
+Dashboard variables to include in the dashboards.
 
 ---
 
@@ -38720,6 +38734,7 @@ const monitoringDashboardsProps: MonitoringDashboardsProps = { ... }
 | <code><a href="#cdk-monitoring-constructs.MonitoringDashboardsProps.property.renderingPreference">renderingPreference</a></code> | <code><a href="#cdk-monitoring-constructs.DashboardRenderingPreference">DashboardRenderingPreference</a></code> | Dashboard rendering preference. |
 | <code><a href="#cdk-monitoring-constructs.MonitoringDashboardsProps.property.summaryDashboardPeriodOverride">summaryDashboardPeriodOverride</a></code> | <code>aws-cdk-lib.aws_cloudwatch.PeriodOverride</code> | Period override for the summary dashboard. |
 | <code><a href="#cdk-monitoring-constructs.MonitoringDashboardsProps.property.summaryDashboardRange">summaryDashboardRange</a></code> | <code>aws-cdk-lib.Duration</code> | Range of the summary dashboard. |
+| <code><a href="#cdk-monitoring-constructs.MonitoringDashboardsProps.property.variables">variables</a></code> | <code>aws-cdk-lib.aws_cloudwatch.IVariable[]</code> | Dashboard variables to include in the dashboards. |
 
 ---
 
@@ -38846,6 +38861,19 @@ public readonly summaryDashboardRange: Duration;
 - *Default:* 14 days
 
 Range of the summary dashboard.
+
+---
+
+##### `variables`<sup>Optional</sup> <a name="variables" id="cdk-monitoring-constructs.MonitoringDashboardsProps.property.variables"></a>
+
+```typescript
+public readonly variables: IVariable[];
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.IVariable[]
+- *Default:* No variables
+
+Dashboard variables to include in the dashboards.
 
 ---
 

--- a/lib/dashboard/DefaultDashboardFactory.ts
+++ b/lib/dashboard/DefaultDashboardFactory.ts
@@ -3,6 +3,7 @@ import {
   Dashboard,
   DashboardProps,
   PeriodOverride,
+  IVariable,
 } from "aws-cdk-lib/aws-cloudwatch";
 import { Construct } from "constructs";
 import { BitmapDashboard } from "./BitmapDashboard";
@@ -66,6 +67,12 @@ export interface MonitoringDashboardsProps {
    * @default - DashboardRenderingPreference.INTERACTIVE_ONLY
    */
   readonly renderingPreference?: DashboardRenderingPreference;
+  /**
+   * Dashboard variables to include in the dashboards.
+   *
+   * @default - No variables
+   */
+  readonly variables?: IVariable[];
 }
 
 export enum DefaultDashboards {
@@ -118,6 +125,7 @@ export class DefaultDashboardFactory
         start: detailStart,
         periodOverride:
           props.detailDashboardPeriodOverride ?? PeriodOverride.INHERIT,
+        variables: props.variables,
       });
       this.dashboards[DefaultDashboards.DETAIL] = this.dashboard;
     }
@@ -131,6 +139,7 @@ export class DefaultDashboardFactory
           start: summaryStart,
           periodOverride:
             props.summaryDashboardPeriodOverride ?? PeriodOverride.INHERIT,
+          variables: props.variables,
         },
       );
       this.dashboards[DefaultDashboards.SUMMARY] = this.summaryDashboard;
@@ -145,6 +154,7 @@ export class DefaultDashboardFactory
           start: detailStart,
           periodOverride:
             props.detailDashboardPeriodOverride ?? PeriodOverride.INHERIT,
+          variables: props.variables,
         },
       );
       this.dashboards[DefaultDashboards.ALARMS] = this.alarmDashboard;

--- a/lib/dashboard/DynamicDashboardFactory.ts
+++ b/lib/dashboard/DynamicDashboardFactory.ts
@@ -3,6 +3,7 @@ import {
   Dashboard,
   DashboardProps,
   PeriodOverride,
+  IVariable,
 } from "aws-cdk-lib/aws-cloudwatch";
 import { Construct } from "constructs";
 
@@ -41,6 +42,13 @@ export interface DynamicDashboardConfiguration {
    * @default - respect individual graphs (PeriodOverride.INHERIT)
    */
   readonly periodOverride?: PeriodOverride;
+
+  /**
+   * Dashboard variables to include in the dashboards.
+   *
+   * @default - No variables
+   */
+  readonly variables?: IVariable[];
 }
 
 export interface MonitoringDynamicDashboardsProps {
@@ -100,6 +108,7 @@ export class DynamicDashboardFactory
           start,
           periodOverride:
             dashboardConfig.periodOverride ?? PeriodOverride.INHERIT,
+          variables: dashboardConfig.variables,
         },
       );
 


### PR DESCRIPTION
Fixes https://github.com/cdklabs/cdk-monitoring-constructs/issues/391

Not sure if this change is really needed — I’ve been creating dashboards with variables by just grabbing the underlying dashboards and attaching variables that way. That said, it’s a nice cleanup and does make the code a bit cleaner. Totally fine to close the PR if you don’t think it’s worth it.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_