### PR TITLE
feat: use dynamically determined latest Node.js runtime for Lambda handlers instead

### DIFF
--- a/lib/dashboard/widget/BitmapWidget.ts
+++ b/lib/dashboard/widget/BitmapWidget.ts
@@ -3,7 +3,12 @@ import * as path from "path";
 import { Duration, Tags } from "aws-cdk-lib";
 import { IWidget } from "aws-cdk-lib/aws-cloudwatch";
 import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
-import { Code, Function, IFunction, Runtime } from "aws-cdk-lib/aws-lambda";
+import {
+  Code,
+  determineLatestNodeRuntime,
+  Function,
+  IFunction,
+} from "aws-cdk-lib/aws-lambda";
 import { RetentionDays } from "aws-cdk-lib/aws-logs";
 import { Construct } from "constructs";
 
@@ -34,7 +39,7 @@ export class BitmapWidgetRenderingSupport extends Construct {
         "Custom Widget Render for Bitmap Widgets (cdk-monitoring-constructs)",
       handler: "index.handler",
       memorySize: 128,
-      runtime: Runtime.NODEJS_LATEST,
+      runtime: determineLatestNodeRuntime(this),
       timeout: Duration.seconds(60),
       logRetention: RetentionDays.ONE_DAY,
     });

--- a/lib/monitoring/aws-secretsmanager/SecretsManagerMetricsPublisher.ts
+++ b/lib/monitoring/aws-secretsmanager/SecretsManagerMetricsPublisher.ts
@@ -4,7 +4,12 @@ import { Duration, Names } from "aws-cdk-lib";
 import { Rule, RuleTargetInput, Schedule } from "aws-cdk-lib/aws-events";
 import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
 import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
-import { Code, Function, IFunction, Runtime } from "aws-cdk-lib/aws-lambda";
+import {
+  Code,
+  determineLatestNodeRuntime,
+  Function,
+  IFunction,
+} from "aws-cdk-lib/aws-lambda";
 import { RetentionDays } from "aws-cdk-lib/aws-logs";
 import { ISecret } from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from "constructs";
@@ -34,7 +39,7 @@ export class SecretsManagerMetricsPublisher extends Construct {
         "Custom metrics publisher for SecretsManager Secrets (cdk-monitoring-constructs)",
       handler: "index.handler",
       memorySize: 128,
-      runtime: Runtime.NODEJS_LATEST,
+      runtime: determineLatestNodeRuntime(this),
       timeout: Duration.seconds(60),
       logRetention: RetentionDays.ONE_DAY,
     });

--- a/test/common/alarm/action/LambdaAlarmActionStrategy.test.ts
+++ b/test/common/alarm/action/LambdaAlarmActionStrategy.test.ts
@@ -1,7 +1,11 @@
 import { Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
 import { Alarm, Metric } from "aws-cdk-lib/aws-cloudwatch";
-import { Function, InlineCode, Runtime } from "aws-cdk-lib/aws-lambda";
+import {
+  determineLatestNodeRuntime,
+  Function,
+  InlineCode,
+} from "aws-cdk-lib/aws-lambda";
 
 import { LambdaAlarmActionStrategy } from "../../../../lib";
 
@@ -9,7 +13,7 @@ test("snapshot test: Lambda function", () => {
   const stack = new Stack();
   const onAlarmFunction = new Function(stack, "alarmLambda", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_LATEST,
+    runtime: determineLatestNodeRuntime(stack),
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });
@@ -28,7 +32,7 @@ test("snapshot test: Lambda alias", () => {
   const stack = new Stack();
   const onAlarmFunction = new Function(stack, "alarmLambda", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_LATEST,
+    runtime: determineLatestNodeRuntime(stack),
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });
@@ -48,7 +52,7 @@ test("snapshot test: Lambda version", () => {
   const stack = new Stack();
   const onAlarmFunction = new Function(stack, "alarmLambda", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_LATEST,
+    runtime: determineLatestNodeRuntime(stack),
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });

--- a/test/common/alarm/action/__snapshots__/LambdaAlarmActionStrategy.test.ts.snap
+++ b/test/common/alarm/action/__snapshots__/LambdaAlarmActionStrategy.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`snapshot test: Lambda alias 1`] = `
 Object {
+  "Mappings": [MAPPING REMOVED],
   "Parameters": Object {
     "BootstrapVersion": Object {
       "Default": "/cdk-bootstrap/hnb659fds/version",
@@ -43,7 +44,15 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs18.x",
+        "Runtime": Object {
+          "Fn::FindInMap": Array [
+            "LatestNodeRuntimeMap",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            "value",
+          ],
+        },
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -54,7 +63,7 @@ Object {
         },
         "FunctionVersion": Object {
           "Fn::GetAtt": Array [
-            "alarmLambdaCurrentVersionBDCE825C8cbdd693b2754df9b113fa5d7cbd1972",
+            "alarmLambdaCurrentVersionBDCE825C70892026f75c21f8b73d1d91982fbdfc",
             "Version",
           ],
         },
@@ -81,7 +90,7 @@ Object {
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "alarmLambdaCurrentVersionBDCE825C8cbdd693b2754df9b113fa5d7cbd1972": Object {
+    "alarmLambdaCurrentVersionBDCE825C70892026f75c21f8b73d1d91982fbdfc": Object {
       "Properties": Object {
         "FunctionName": Object {
           "Ref": "alarmLambda131DB691",
@@ -153,6 +162,7 @@ Object {
 
 exports[`snapshot test: Lambda function 1`] = `
 Object {
+  "Mappings": [MAPPING REMOVED],
   "Parameters": Object {
     "BootstrapVersion": Object {
       "Default": "/cdk-bootstrap/hnb659fds/version",
@@ -197,7 +207,15 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs18.x",
+        "Runtime": Object {
+          "Fn::FindInMap": Array [
+            "LatestNodeRuntimeMap",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            "value",
+          ],
+        },
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -287,6 +305,7 @@ Object {
 
 exports[`snapshot test: Lambda version 1`] = `
 Object {
+  "Mappings": [MAPPING REMOVED],
   "Parameters": Object {
     "BootstrapVersion": Object {
       "Default": "/cdk-bootstrap/hnb659fds/version",
@@ -299,7 +318,7 @@ Object {
       "Properties": Object {
         "AlarmActions": Array [
           Object {
-            "Ref": "alarmLambdaCurrentVersionBDCE825C8cbdd693b2754df9b113fa5d7cbd1972",
+            "Ref": "alarmLambdaCurrentVersionBDCE825C70892026f75c21f8b73d1d91982fbdfc",
           },
         ],
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
@@ -328,7 +347,15 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs18.x",
+        "Runtime": Object {
+          "Fn::FindInMap": Array [
+            "LatestNodeRuntimeMap",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            "value",
+          ],
+        },
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -336,7 +363,7 @@ Object {
       "Properties": Object {
         "Action": "lambda:InvokeFunction",
         "FunctionName": Object {
-          "Ref": "alarmLambdaCurrentVersionBDCE825C8cbdd693b2754df9b113fa5d7cbd1972",
+          "Ref": "alarmLambdaCurrentVersionBDCE825C70892026f75c21f8b73d1d91982fbdfc",
         },
         "Principal": "lambda.alarms.cloudwatch.amazonaws.com",
         "SourceAccount": Object {
@@ -351,7 +378,7 @@ Object {
       },
       "Type": "AWS::Lambda::Permission",
     },
-    "alarmLambdaCurrentVersionBDCE825C8cbdd693b2754df9b113fa5d7cbd1972": Object {
+    "alarmLambdaCurrentVersionBDCE825C70892026f75c21f8b73d1d91982fbdfc": Object {
       "Properties": Object {
         "FunctionName": Object {
           "Ref": "alarmLambda131DB691",

--- a/test/dashboard/widget/CustomWidget.test.ts
+++ b/test/dashboard/widget/CustomWidget.test.ts
@@ -1,5 +1,9 @@
 import { Stack } from "aws-cdk-lib";
-import { Code, Function, Runtime } from "aws-cdk-lib/aws-lambda";
+import {
+  Code,
+  determineLatestNodeRuntime,
+  Function,
+} from "aws-cdk-lib/aws-lambda";
 
 import { CustomWidget } from "../../../lib/dashboard/widget/CustomWidget";
 
@@ -7,8 +11,7 @@ test("widget", () => {
   const stack = new Stack();
 
   const handler = new Function(stack, "Function", {
-    // execution environment
-    runtime: Runtime.NODEJS_LATEST,
+    runtime: determineLatestNodeRuntime(stack),
     // code loaded from "lambda" directory
     code: Code.fromInline(
       'exports.handler = function(event, ctx, cb) { return cb(null, "Hello World!"); }',

--- a/test/dashboard/widget/__snapshots__/BitmapWidget.test.ts.snap
+++ b/test/dashboard/widget/__snapshots__/BitmapWidget.test.ts.snap
@@ -119,7 +119,15 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs18.x",
+        "Runtime": Object {
+          "Fn::FindInMap": Array [
+            "LatestNodeRuntimeMap",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            "value",
+          ],
+        },
         "Tags": Array [
           Object {
             "Key": "cw-custom-widget",

--- a/test/facade/__snapshots__/MonitoringAspect.test.ts.snap
+++ b/test/facade/__snapshots__/MonitoringAspect.test.ts.snap
@@ -3582,7 +3582,15 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs18.x",
+        "Runtime": Object {
+          "Fn::FindInMap": Array [
+            "LatestNodeRuntimeMap",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            "value",
+          ],
+        },
         "Timeout": 60,
       },
       "Type": "AWS::Lambda::Function",

--- a/test/monitoring/aws-lambda/LambdaFunctionMonitoring.test.ts
+++ b/test/monitoring/aws-lambda/LambdaFunctionMonitoring.test.ts
@@ -2,10 +2,10 @@ import { Duration, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
 import { Color, ComparisonOperator } from "aws-cdk-lib/aws-cloudwatch";
 import {
+  determineLatestNodeRuntime,
   Function,
   InlineCode,
   LayerVersion,
-  Runtime,
 } from "aws-cdk-lib/aws-lambda";
 
 import { AlarmWithAnnotation, LambdaFunctionMonitoring } from "../../../lib";
@@ -19,7 +19,7 @@ test("snapshot test: default iterator and no alarms", () => {
 
   const lambdaFunction = new Function(stack, "Function", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_LATEST,
+    runtime: determineLatestNodeRuntime(stack),
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });
@@ -49,7 +49,7 @@ test("snapshot test: non-iterator and no alarms", () => {
 
   const lambdaFunction = new Function(stack, "Function", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_LATEST,
+    runtime: determineLatestNodeRuntime(stack),
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });
@@ -72,7 +72,7 @@ test("snapshot test: all alarms", () => {
 
   const lambdaFunction = new Function(stack, "Function", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_LATEST,
+    runtime: determineLatestNodeRuntime(stack),
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });
@@ -190,7 +190,7 @@ test("snapshot test: all alarms", () => {
 
   const lambdaFunction = new Function(stack, "Function", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_LATEST,
+    runtime: determineLatestNodeRuntime(stack),
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
     layers: [
@@ -230,7 +230,7 @@ test("snapshot test: all alarms, alarmPrefix on error dedupeString", () => {
 
   const lambdaFunction = new Function(stack, "Function", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_LATEST,
+    runtime: determineLatestNodeRuntime(stack),
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });
@@ -376,7 +376,7 @@ test("snapshot test: all alarms, alarmPrefix on latency dedupeString", () => {
 
   const lambdaFunction = new Function(stack, "Function", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_LATEST,
+    runtime: determineLatestNodeRuntime(stack),
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });
@@ -519,7 +519,7 @@ test("throws error if attempting to create iterator age alarm if not an iterator
 
   const lambdaFunction = new Function(stack, "Function", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_LATEST,
+    runtime: determineLatestNodeRuntime(stack),
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });
@@ -549,7 +549,7 @@ test("throws error if attempting to create offsetLag alarm if not an offsetLag L
 
   const lambdaFunction = new Function(stack, "Function", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_LATEST,
+    runtime: determineLatestNodeRuntime(stack),
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });
@@ -578,7 +578,7 @@ test("doesn't create alarms for enhanced Lambda Insights metrics if not enabled"
 
   const lambdaFunction = new Function(stack, "Function", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_LATEST,
+    runtime: determineLatestNodeRuntime(stack),
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });
@@ -689,7 +689,7 @@ test("snapshot test: latency alarms with percentage of timeout with specific tim
 
   const lambdaFunction = new Function(stack, "Function", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_18_X,
+    runtime: determineLatestNodeRuntime(stack),
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
     timeout: Duration.seconds(100),

--- a/test/monitoring/aws-lambda/__snapshots__/LambdaFunctionMonitoring.test.ts.snap
+++ b/test/monitoring/aws-lambda/__snapshots__/LambdaFunctionMonitoring.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`snapshot test: all alarms 1`] = `
 Object {
+  "Mappings": [MAPPING REMOVED],
   "Parameters": Object {
     "BootstrapVersion": Object {
       "Default": "/cdk-bootstrap/hnb659fds/version",
@@ -204,7 +205,15 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs18.x",
+        "Runtime": Object {
+          "Fn::FindInMap": Array [
+            "LatestNodeRuntimeMap",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            "value",
+          ],
+        },
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -976,6 +985,7 @@ Object {
 
 exports[`snapshot test: all alarms 2`] = `
 Object {
+  "Mappings": [MAPPING REMOVED],
   "Parameters": Object {
     "BootstrapVersion": Object {
       "Default": "/cdk-bootstrap/hnb659fds/version",
@@ -1003,7 +1013,15 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs18.x",
+        "Runtime": Object {
+          "Fn::FindInMap": Array [
+            "LatestNodeRuntimeMap",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            "value",
+          ],
+        },
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -1014,7 +1032,7 @@ Object {
         },
         "FunctionVersion": Object {
           "Fn::GetAtt": Array [
-            "FunctionCurrentVersion4E2B22612881a8e13ea008f06ac95a40e1387c5c",
+            "FunctionCurrentVersion4E2B2261eb172f4d56d10a3af9e0cc449c9db5c1",
             "Version",
           ],
         },
@@ -1025,7 +1043,7 @@ Object {
       },
       "Type": "AWS::Lambda::Alias",
     },
-    "FunctionCurrentVersion4E2B22612881a8e13ea008f06ac95a40e1387c5c": Object {
+    "FunctionCurrentVersion4E2B2261eb172f4d56d10a3af9e0cc449c9db5c1": Object {
       "Properties": Object {
         "FunctionName": Object {
           "Ref": "Function76856677",
@@ -1097,6 +1115,7 @@ Object {
 
 exports[`snapshot test: all alarms, alarmPrefix on error dedupeString 1`] = `
 Object {
+  "Mappings": [MAPPING REMOVED],
   "Parameters": Object {
     "BootstrapVersion": Object {
       "Default": "/cdk-bootstrap/hnb659fds/version",
@@ -1354,7 +1373,15 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs18.x",
+        "Runtime": Object {
+          "Fn::FindInMap": Array [
+            "LatestNodeRuntimeMap",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            "value",
+          ],
+        },
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -2342,6 +2369,7 @@ Object {
 
 exports[`snapshot test: all alarms, alarmPrefix on latency dedupeString 1`] = `
 Object {
+  "Mappings": [MAPPING REMOVED],
   "Parameters": Object {
     "BootstrapVersion": Object {
       "Default": "/cdk-bootstrap/hnb659fds/version",
@@ -2599,7 +2627,15 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs18.x",
+        "Runtime": Object {
+          "Fn::FindInMap": Array [
+            "LatestNodeRuntimeMap",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            "value",
+          ],
+        },
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -3587,6 +3623,7 @@ Object {
 
 exports[`snapshot test: default iterator and no alarms 1`] = `
 Object {
+  "Mappings": [MAPPING REMOVED],
   "Parameters": Object {
     "BootstrapVersion": Object {
       "Default": "/cdk-bootstrap/hnb659fds/version",
@@ -3617,7 +3654,15 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs18.x",
+        "Runtime": Object {
+          "Fn::FindInMap": Array [
+            "LatestNodeRuntimeMap",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            "value",
+          ],
+        },
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -4131,6 +4176,7 @@ Object {
 
 exports[`snapshot test: latency alarms with percentage of timeout with specific timeout 1`] = `
 Object {
+  "Mappings": [MAPPING REMOVED],
   "Parameters": Object {
     "BootstrapVersion": Object {
       "Default": "/cdk-bootstrap/hnb659fds/version",
@@ -4212,7 +4258,15 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs18.x",
+        "Runtime": Object {
+          "Fn::FindInMap": Array [
+            "LatestNodeRuntimeMap",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            "value",
+          ],
+        },
         "Timeout": 100,
       },
       "Type": "AWS::Lambda::Function",
@@ -4571,6 +4625,7 @@ Object {
 
 exports[`snapshot test: non-iterator and no alarms 1`] = `
 Object {
+  "Mappings": [MAPPING REMOVED],
   "Parameters": Object {
     "BootstrapVersion": Object {
       "Default": "/cdk-bootstrap/hnb659fds/version",
@@ -4601,7 +4656,15 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs18.x",
+        "Runtime": Object {
+          "Fn::FindInMap": Array [
+            "LatestNodeRuntimeMap",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            "value",
+          ],
+        },
       },
       "Type": "AWS::Lambda::Function",
     },

--- a/test/monitoring/aws-secretsmanager/__snapshots__/SecretsManagerSecretMonitoring.test.ts.snap
+++ b/test/monitoring/aws-secretsmanager/__snapshots__/SecretsManagerSecretMonitoring.test.ts.snap
@@ -119,7 +119,15 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs18.x",
+        "Runtime": Object {
+          "Fn::FindInMap": Array [
+            "LatestNodeRuntimeMap",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            "value",
+          ],
+        },
         "Timeout": 60,
       },
       "Type": "AWS::Lambda::Function",
@@ -455,7 +463,15 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs18.x",
+        "Runtime": Object {
+          "Fn::FindInMap": Array [
+            "LatestNodeRuntimeMap",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            "value",
+          ],
+        },
         "Timeout": 60,
       },
       "Type": "AWS::Lambda::Function",

--- a/test/monitoring/aws-step-functions/StepFunctionLambdaIntegrationMonitoring.test.ts
+++ b/test/monitoring/aws-step-functions/StepFunctionLambdaIntegrationMonitoring.test.ts
@@ -1,6 +1,10 @@
 import { Duration, Stack } from "aws-cdk-lib";
 import { Template } from "aws-cdk-lib/assertions";
-import { Function, InlineCode, Runtime } from "aws-cdk-lib/aws-lambda";
+import {
+  determineLatestNodeRuntime,
+  Function,
+  InlineCode,
+} from "aws-cdk-lib/aws-lambda";
 
 import {
   AlarmWithAnnotation,
@@ -16,7 +20,7 @@ test("snapshot test: no alarms", () => {
 
   const lambdaFunction = new Function(stack, "Function", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_LATEST,
+    runtime: determineLatestNodeRuntime(stack),
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });
@@ -37,7 +41,7 @@ test("snapshot test: all alarms", () => {
 
   const lambdaFunction = new Function(stack, "Function", {
     functionName: "DummyLambda",
-    runtime: Runtime.NODEJS_LATEST,
+    runtime: determineLatestNodeRuntime(stack),
     code: InlineCode.fromInline("{}"),
     handler: "Dummy::handler",
   });

--- a/test/monitoring/aws-step-functions/__snapshots__/StepFunctionLambdaIntegrationMonitoring.test.ts.snap
+++ b/test/monitoring/aws-step-functions/__snapshots__/StepFunctionLambdaIntegrationMonitoring.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`snapshot test: all alarms 1`] = `
 Object {
+  "Mappings": [MAPPING REMOVED],
   "Parameters": Object {
     "BootstrapVersion": Object {
       "Default": "/cdk-bootstrap/hnb659fds/version",
@@ -105,7 +106,15 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs18.x",
+        "Runtime": Object {
+          "Fn::FindInMap": Array [
+            "LatestNodeRuntimeMap",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            "value",
+          ],
+        },
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -580,6 +589,7 @@ Object {
 
 exports[`snapshot test: no alarms 1`] = `
 Object {
+  "Mappings": [MAPPING REMOVED],
   "Parameters": Object {
     "BootstrapVersion": Object {
       "Default": "/cdk-bootstrap/hnb659fds/version",
@@ -610,7 +620,15 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs18.x",
+        "Runtime": Object {
+          "Fn::FindInMap": Array [
+            "LatestNodeRuntimeMap",
+            Object {
+              "Ref": "AWS::Region",
+            },
+            "value",
+          ],
+        },
       },
       "Type": "AWS::Lambda::Function",
     },


### PR DESCRIPTION
`NODEJS_LATEST` still points to Node.js 18, which is already EOL.

Related upstream issue: https://github.com/aws/aws-cdk/issues/28125

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_