### PR TITLE
feat(lambda): Add widget and alarms on init duration

### DIFF
--- a/API.md
+++ b/API.md
@@ -27212,10 +27212,13 @@ const lambdaFunctionMonitoringOptions: LambdaFunctionMonitoringOptions = { ... }
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.useCreatedAlarms">useCreatedAlarms</a></code> | <code><a href="#cdk-monitoring-constructs.IAlarmConsumer">IAlarmConsumer</a></code> | Calls provided function to process all alarms created. |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addConcurrentExecutionsCountAlarm">addConcurrentExecutionsCountAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.RunningTaskCountThreshold">RunningTaskCountThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addEnhancedMonitoringAvgCpuTotalTimeAlarm">addEnhancedMonitoringAvgCpuTotalTimeAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.DurationThreshold">DurationThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addEnhancedMonitoringAvgInitDurationAlarm">addEnhancedMonitoringAvgInitDurationAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.DurationThreshold">DurationThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addEnhancedMonitoringAvgMemoryUtilizationAlarm">addEnhancedMonitoringAvgMemoryUtilizationAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.UsageThreshold">UsageThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addEnhancedMonitoringMaxCpuTotalTimeAlarm">addEnhancedMonitoringMaxCpuTotalTimeAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.DurationThreshold">DurationThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addEnhancedMonitoringMaxInitDurationAlarm">addEnhancedMonitoringMaxInitDurationAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.DurationThreshold">DurationThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addEnhancedMonitoringMaxMemoryUtilizationAlarm">addEnhancedMonitoringMaxMemoryUtilizationAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.UsageThreshold">UsageThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addEnhancedMonitoringP90CpuTotalTimeAlarm">addEnhancedMonitoringP90CpuTotalTimeAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.DurationThreshold">DurationThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addEnhancedMonitoringP90InitDurationAlarm">addEnhancedMonitoringP90InitDurationAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.DurationThreshold">DurationThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addEnhancedMonitoringP90MemoryUtilizationAlarm">addEnhancedMonitoringP90MemoryUtilizationAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.UsageThreshold">UsageThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addFaultCountAlarm">addFaultCountAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorCountThreshold">ErrorCountThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addFaultRateAlarm">addFaultRateAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorRateThreshold">ErrorRateThreshold</a>}</code> | *No description.* |
@@ -27385,6 +27388,16 @@ public readonly addEnhancedMonitoringAvgCpuTotalTimeAlarm: {[ key: string ]: Dur
 
 ---
 
+##### `addEnhancedMonitoringAvgInitDurationAlarm`<sup>Optional</sup> <a name="addEnhancedMonitoringAvgInitDurationAlarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addEnhancedMonitoringAvgInitDurationAlarm"></a>
+
+```typescript
+public readonly addEnhancedMonitoringAvgInitDurationAlarm: {[ key: string ]: DurationThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.DurationThreshold">DurationThreshold</a>}
+
+---
+
 ##### `addEnhancedMonitoringAvgMemoryUtilizationAlarm`<sup>Optional</sup> <a name="addEnhancedMonitoringAvgMemoryUtilizationAlarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addEnhancedMonitoringAvgMemoryUtilizationAlarm"></a>
 
 ```typescript
@@ -27405,6 +27418,16 @@ public readonly addEnhancedMonitoringMaxCpuTotalTimeAlarm: {[ key: string ]: Dur
 
 ---
 
+##### `addEnhancedMonitoringMaxInitDurationAlarm`<sup>Optional</sup> <a name="addEnhancedMonitoringMaxInitDurationAlarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addEnhancedMonitoringMaxInitDurationAlarm"></a>
+
+```typescript
+public readonly addEnhancedMonitoringMaxInitDurationAlarm: {[ key: string ]: DurationThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.DurationThreshold">DurationThreshold</a>}
+
+---
+
 ##### `addEnhancedMonitoringMaxMemoryUtilizationAlarm`<sup>Optional</sup> <a name="addEnhancedMonitoringMaxMemoryUtilizationAlarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addEnhancedMonitoringMaxMemoryUtilizationAlarm"></a>
 
 ```typescript
@@ -27419,6 +27442,16 @@ public readonly addEnhancedMonitoringMaxMemoryUtilizationAlarm: {[ key: string ]
 
 ```typescript
 public readonly addEnhancedMonitoringP90CpuTotalTimeAlarm: {[ key: string ]: DurationThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.DurationThreshold">DurationThreshold</a>}
+
+---
+
+##### `addEnhancedMonitoringP90InitDurationAlarm`<sup>Optional</sup> <a name="addEnhancedMonitoringP90InitDurationAlarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addEnhancedMonitoringP90InitDurationAlarm"></a>
+
+```typescript
+public readonly addEnhancedMonitoringP90InitDurationAlarm: {[ key: string ]: DurationThreshold};
 ```
 
 - *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.DurationThreshold">DurationThreshold</a>}
@@ -27640,10 +27673,13 @@ const lambdaFunctionMonitoringProps: LambdaFunctionMonitoringProps = { ... }
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.useCreatedAlarms">useCreatedAlarms</a></code> | <code><a href="#cdk-monitoring-constructs.IAlarmConsumer">IAlarmConsumer</a></code> | Calls provided function to process all alarms created. |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addConcurrentExecutionsCountAlarm">addConcurrentExecutionsCountAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.RunningTaskCountThreshold">RunningTaskCountThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addEnhancedMonitoringAvgCpuTotalTimeAlarm">addEnhancedMonitoringAvgCpuTotalTimeAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.DurationThreshold">DurationThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addEnhancedMonitoringAvgInitDurationAlarm">addEnhancedMonitoringAvgInitDurationAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.DurationThreshold">DurationThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addEnhancedMonitoringAvgMemoryUtilizationAlarm">addEnhancedMonitoringAvgMemoryUtilizationAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.UsageThreshold">UsageThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addEnhancedMonitoringMaxCpuTotalTimeAlarm">addEnhancedMonitoringMaxCpuTotalTimeAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.DurationThreshold">DurationThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addEnhancedMonitoringMaxInitDurationAlarm">addEnhancedMonitoringMaxInitDurationAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.DurationThreshold">DurationThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addEnhancedMonitoringMaxMemoryUtilizationAlarm">addEnhancedMonitoringMaxMemoryUtilizationAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.UsageThreshold">UsageThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addEnhancedMonitoringP90CpuTotalTimeAlarm">addEnhancedMonitoringP90CpuTotalTimeAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.DurationThreshold">DurationThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addEnhancedMonitoringP90InitDurationAlarm">addEnhancedMonitoringP90InitDurationAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.DurationThreshold">DurationThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addEnhancedMonitoringP90MemoryUtilizationAlarm">addEnhancedMonitoringP90MemoryUtilizationAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.UsageThreshold">UsageThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addFaultCountAlarm">addFaultCountAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorCountThreshold">ErrorCountThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addFaultRateAlarm">addFaultRateAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorRateThreshold">ErrorRateThreshold</a>}</code> | *No description.* |
@@ -27861,6 +27897,16 @@ public readonly addEnhancedMonitoringAvgCpuTotalTimeAlarm: {[ key: string ]: Dur
 
 ---
 
+##### `addEnhancedMonitoringAvgInitDurationAlarm`<sup>Optional</sup> <a name="addEnhancedMonitoringAvgInitDurationAlarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addEnhancedMonitoringAvgInitDurationAlarm"></a>
+
+```typescript
+public readonly addEnhancedMonitoringAvgInitDurationAlarm: {[ key: string ]: DurationThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.DurationThreshold">DurationThreshold</a>}
+
+---
+
 ##### `addEnhancedMonitoringAvgMemoryUtilizationAlarm`<sup>Optional</sup> <a name="addEnhancedMonitoringAvgMemoryUtilizationAlarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addEnhancedMonitoringAvgMemoryUtilizationAlarm"></a>
 
 ```typescript
@@ -27881,6 +27927,16 @@ public readonly addEnhancedMonitoringMaxCpuTotalTimeAlarm: {[ key: string ]: Dur
 
 ---
 
+##### `addEnhancedMonitoringMaxInitDurationAlarm`<sup>Optional</sup> <a name="addEnhancedMonitoringMaxInitDurationAlarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addEnhancedMonitoringMaxInitDurationAlarm"></a>
+
+```typescript
+public readonly addEnhancedMonitoringMaxInitDurationAlarm: {[ key: string ]: DurationThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.DurationThreshold">DurationThreshold</a>}
+
+---
+
 ##### `addEnhancedMonitoringMaxMemoryUtilizationAlarm`<sup>Optional</sup> <a name="addEnhancedMonitoringMaxMemoryUtilizationAlarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addEnhancedMonitoringMaxMemoryUtilizationAlarm"></a>
 
 ```typescript
@@ -27895,6 +27951,16 @@ public readonly addEnhancedMonitoringMaxMemoryUtilizationAlarm: {[ key: string ]
 
 ```typescript
 public readonly addEnhancedMonitoringP90CpuTotalTimeAlarm: {[ key: string ]: DurationThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.DurationThreshold">DurationThreshold</a>}
+
+---
+
+##### `addEnhancedMonitoringP90InitDurationAlarm`<sup>Optional</sup> <a name="addEnhancedMonitoringP90InitDurationAlarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addEnhancedMonitoringP90InitDurationAlarm"></a>
+
+```typescript
+public readonly addEnhancedMonitoringP90InitDurationAlarm: {[ key: string ]: DurationThreshold};
 ```
 
 - *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.DurationThreshold">DurationThreshold</a>}
@@ -67642,11 +67708,14 @@ new LambdaFunctionEnhancedMetricFactory(metricFactory: MetricFactory, props: Lam
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionEnhancedMetricFactory.enhancedMetricAvgCpuTotalTime">enhancedMetricAvgCpuTotalTime</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionEnhancedMetricFactory.enhancedMetricAvgInitDuration">enhancedMetricAvgInitDuration</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionEnhancedMetricFactory.enhancedMetricAvgMemoryUtilization">enhancedMetricAvgMemoryUtilization</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionEnhancedMetricFactory.enhancedMetricFunctionCost">enhancedMetricFunctionCost</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionEnhancedMetricFactory.enhancedMetricMaxCpuTotalTime">enhancedMetricMaxCpuTotalTime</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionEnhancedMetricFactory.enhancedMetricMaxInitDuration">enhancedMetricMaxInitDuration</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionEnhancedMetricFactory.enhancedMetricMaxMemoryUtilization">enhancedMetricMaxMemoryUtilization</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionEnhancedMetricFactory.enhancedMetricP90CpuTotalTime">enhancedMetricP90CpuTotalTime</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionEnhancedMetricFactory.enhancedMetricP90InitDuration">enhancedMetricP90InitDuration</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionEnhancedMetricFactory.enhancedMetricP90MemoryUtilization">enhancedMetricP90MemoryUtilization</a></code> | *No description.* |
 
 ---
@@ -67655,6 +67724,12 @@ new LambdaFunctionEnhancedMetricFactory(metricFactory: MetricFactory, props: Lam
 
 ```typescript
 public enhancedMetricAvgCpuTotalTime(): Metric | MathExpression
+```
+
+##### `enhancedMetricAvgInitDuration` <a name="enhancedMetricAvgInitDuration" id="cdk-monitoring-constructs.LambdaFunctionEnhancedMetricFactory.enhancedMetricAvgInitDuration"></a>
+
+```typescript
+public enhancedMetricAvgInitDuration(): Metric | MathExpression
 ```
 
 ##### `enhancedMetricAvgMemoryUtilization` <a name="enhancedMetricAvgMemoryUtilization" id="cdk-monitoring-constructs.LambdaFunctionEnhancedMetricFactory.enhancedMetricAvgMemoryUtilization"></a>
@@ -67675,6 +67750,12 @@ public enhancedMetricFunctionCost(): Metric | MathExpression
 public enhancedMetricMaxCpuTotalTime(): Metric | MathExpression
 ```
 
+##### `enhancedMetricMaxInitDuration` <a name="enhancedMetricMaxInitDuration" id="cdk-monitoring-constructs.LambdaFunctionEnhancedMetricFactory.enhancedMetricMaxInitDuration"></a>
+
+```typescript
+public enhancedMetricMaxInitDuration(): Metric | MathExpression
+```
+
 ##### `enhancedMetricMaxMemoryUtilization` <a name="enhancedMetricMaxMemoryUtilization" id="cdk-monitoring-constructs.LambdaFunctionEnhancedMetricFactory.enhancedMetricMaxMemoryUtilization"></a>
 
 ```typescript
@@ -67685,6 +67766,12 @@ public enhancedMetricMaxMemoryUtilization(): Metric | MathExpression
 
 ```typescript
 public enhancedMetricP90CpuTotalTime(): Metric | MathExpression
+```
+
+##### `enhancedMetricP90InitDuration` <a name="enhancedMetricP90InitDuration" id="cdk-monitoring-constructs.LambdaFunctionEnhancedMetricFactory.enhancedMetricP90InitDuration"></a>
+
+```typescript
+public enhancedMetricP90InitDuration(): Metric | MathExpression
 ```
 
 ##### `enhancedMetricP90MemoryUtilization` <a name="enhancedMetricP90MemoryUtilization" id="cdk-monitoring-constructs.LambdaFunctionEnhancedMetricFactory.enhancedMetricP90MemoryUtilization"></a>
@@ -67907,6 +67994,7 @@ new LambdaFunctionMonitoring(scope: MonitoringScope, props: LambdaFunctionMonito
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.createIteratorAgeWidget">createIteratorAgeWidget</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.createLambdaInsightsCpuWidget">createLambdaInsightsCpuWidget</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.createLambdaInsightsFunctionCostWidget">createLambdaInsightsFunctionCostWidget</a></code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.createLambdaInsightsInitDurationWidget">createLambdaInsightsInitDurationWidget</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.createLambdaInsightsMemoryWidget">createLambdaInsightsMemoryWidget</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.createLatencyWidget">createLatencyWidget</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.createOffsetLagWidget">createOffsetLagWidget</a></code> | *No description.* |
@@ -68122,6 +68210,24 @@ public createLambdaInsightsFunctionCostWidget(width: number, height: number): Gr
 
 ---
 
+##### `createLambdaInsightsInitDurationWidget` <a name="createLambdaInsightsInitDurationWidget" id="cdk-monitoring-constructs.LambdaFunctionMonitoring.createLambdaInsightsInitDurationWidget"></a>
+
+```typescript
+public createLambdaInsightsInitDurationWidget(width: number, height: number): GraphWidget
+```
+
+###### `width`<sup>Required</sup> <a name="width" id="cdk-monitoring-constructs.LambdaFunctionMonitoring.createLambdaInsightsInitDurationWidget.parameter.width"></a>
+
+- *Type:* number
+
+---
+
+###### `height`<sup>Required</sup> <a name="height" id="cdk-monitoring-constructs.LambdaFunctionMonitoring.createLambdaInsightsInitDurationWidget.parameter.height"></a>
+
+- *Type:* number
+
+---
+
 ##### `createLambdaInsightsMemoryWidget` <a name="createLambdaInsightsMemoryWidget" id="cdk-monitoring-constructs.LambdaFunctionMonitoring.createLambdaInsightsMemoryWidget"></a>
 
 ```typescript
@@ -68232,6 +68338,7 @@ public createTpsWidget(width: number, height: number): GraphWidget
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.errorRateAnnotations">errorRateAnnotations</a></code> | <code>aws-cdk-lib.aws_cloudwatch.HorizontalAnnotation[]</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.faultCountMetric">faultCountMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.faultRateMetric">faultRateMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.initDurationAnnotations">initDurationAnnotations</a></code> | <code>aws-cdk-lib.aws_cloudwatch.HorizontalAnnotation[]</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.invocationCountAnnotations">invocationCountAnnotations</a></code> | <code>aws-cdk-lib.aws_cloudwatch.HorizontalAnnotation[]</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.invocationCountMetric">invocationCountMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.invocationRateAnnotations">invocationRateAnnotations</a></code> | <code>aws-cdk-lib.aws_cloudwatch.HorizontalAnnotation[]</code> | *No description.* |
@@ -68264,10 +68371,13 @@ public createTpsWidget(width: number, height: number): GraphWidget
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.enhancedMetricFactory">enhancedMetricFactory</a></code> | <code><a href="#cdk-monitoring-constructs.LambdaFunctionEnhancedMetricFactory">LambdaFunctionEnhancedMetricFactory</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.enhancedMetricFunctionCostMetric">enhancedMetricFunctionCostMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.enhancedMonitoringAvgCpuTotalTimeMetric">enhancedMonitoringAvgCpuTotalTimeMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.enhancedMonitoringAvgInitDurationMetric">enhancedMonitoringAvgInitDurationMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.enhancedMonitoringAvgMemoryUtilizationMetric">enhancedMonitoringAvgMemoryUtilizationMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.enhancedMonitoringMaxCpuTotalTimeMetric">enhancedMonitoringMaxCpuTotalTimeMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.enhancedMonitoringMaxInitDurationMetric">enhancedMonitoringMaxInitDurationMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.enhancedMonitoringMaxMemoryUtilizationMetric">enhancedMonitoringMaxMemoryUtilizationMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.enhancedMonitoringP90CpuTotalTimeMetric">enhancedMonitoringP90CpuTotalTimeMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.enhancedMonitoringP90InitDurationMetric">enhancedMonitoringP90InitDurationMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.enhancedMonitoringP90MemoryUtilizationMetric">enhancedMonitoringP90MemoryUtilizationMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.Metric \| aws-cdk-lib.aws_cloudwatch.MathExpression</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.functionUrl">functionUrl</a></code> | <code>string</code> | *No description.* |
 
@@ -68360,6 +68470,16 @@ public readonly faultRateMetric: Metric | MathExpression;
 ```
 
 - *Type:* aws-cdk-lib.aws_cloudwatch.Metric | aws-cdk-lib.aws_cloudwatch.MathExpression
+
+---
+
+##### `initDurationAnnotations`<sup>Required</sup> <a name="initDurationAnnotations" id="cdk-monitoring-constructs.LambdaFunctionMonitoring.property.initDurationAnnotations"></a>
+
+```typescript
+public readonly initDurationAnnotations: HorizontalAnnotation[];
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.HorizontalAnnotation[]
 
 ---
 
@@ -68683,6 +68803,16 @@ public readonly enhancedMonitoringAvgCpuTotalTimeMetric: Metric | MathExpression
 
 ---
 
+##### `enhancedMonitoringAvgInitDurationMetric`<sup>Optional</sup> <a name="enhancedMonitoringAvgInitDurationMetric" id="cdk-monitoring-constructs.LambdaFunctionMonitoring.property.enhancedMonitoringAvgInitDurationMetric"></a>
+
+```typescript
+public readonly enhancedMonitoringAvgInitDurationMetric: Metric | MathExpression;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.Metric | aws-cdk-lib.aws_cloudwatch.MathExpression
+
+---
+
 ##### `enhancedMonitoringAvgMemoryUtilizationMetric`<sup>Optional</sup> <a name="enhancedMonitoringAvgMemoryUtilizationMetric" id="cdk-monitoring-constructs.LambdaFunctionMonitoring.property.enhancedMonitoringAvgMemoryUtilizationMetric"></a>
 
 ```typescript
@@ -68703,6 +68833,16 @@ public readonly enhancedMonitoringMaxCpuTotalTimeMetric: Metric | MathExpression
 
 ---
 
+##### `enhancedMonitoringMaxInitDurationMetric`<sup>Optional</sup> <a name="enhancedMonitoringMaxInitDurationMetric" id="cdk-monitoring-constructs.LambdaFunctionMonitoring.property.enhancedMonitoringMaxInitDurationMetric"></a>
+
+```typescript
+public readonly enhancedMonitoringMaxInitDurationMetric: Metric | MathExpression;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.Metric | aws-cdk-lib.aws_cloudwatch.MathExpression
+
+---
+
 ##### `enhancedMonitoringMaxMemoryUtilizationMetric`<sup>Optional</sup> <a name="enhancedMonitoringMaxMemoryUtilizationMetric" id="cdk-monitoring-constructs.LambdaFunctionMonitoring.property.enhancedMonitoringMaxMemoryUtilizationMetric"></a>
 
 ```typescript
@@ -68717,6 +68857,16 @@ public readonly enhancedMonitoringMaxMemoryUtilizationMetric: Metric | MathExpre
 
 ```typescript
 public readonly enhancedMonitoringP90CpuTotalTimeMetric: Metric | MathExpression;
+```
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.Metric | aws-cdk-lib.aws_cloudwatch.MathExpression
+
+---
+
+##### `enhancedMonitoringP90InitDurationMetric`<sup>Optional</sup> <a name="enhancedMonitoringP90InitDurationMetric" id="cdk-monitoring-constructs.LambdaFunctionMonitoring.property.enhancedMonitoringP90InitDurationMetric"></a>
+
+```typescript
+public readonly enhancedMonitoringP90InitDurationMetric: Metric | MathExpression;
 ```
 
 - *Type:* aws-cdk-lib.aws_cloudwatch.Metric | aws-cdk-lib.aws_cloudwatch.MathExpression
@@ -68770,10 +68920,53 @@ new LatencyAlarmFactory(alarmFactory: AlarmFactory)
 
 | **Name** | **Description** |
 | --- | --- |
+| <code><a href="#cdk-monitoring-constructs.LatencyAlarmFactory.addCustomDurationAlarm">addCustomDurationAlarm</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LatencyAlarmFactory.addDurationAlarm">addDurationAlarm</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LatencyAlarmFactory.addIntegrationLatencyAlarm">addIntegrationLatencyAlarm</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LatencyAlarmFactory.addJvmGarbageCollectionDurationAlarm">addJvmGarbageCollectionDurationAlarm</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LatencyAlarmFactory.addLatencyAlarm">addLatencyAlarm</a></code> | *No description.* |
+
+---
+
+##### `addCustomDurationAlarm` <a name="addCustomDurationAlarm" id="cdk-monitoring-constructs.LatencyAlarmFactory.addCustomDurationAlarm"></a>
+
+```typescript
+public addCustomDurationAlarm(metric: Metric | MathExpression, latencyType: LatencyType, props: DurationThreshold, durationName: string, disambiguator?: string, additionalAlarmNameSuffix?: string): AlarmWithAnnotation
+```
+
+###### `metric`<sup>Required</sup> <a name="metric" id="cdk-monitoring-constructs.LatencyAlarmFactory.addCustomDurationAlarm.parameter.metric"></a>
+
+- *Type:* aws-cdk-lib.aws_cloudwatch.Metric | aws-cdk-lib.aws_cloudwatch.MathExpression
+
+---
+
+###### `latencyType`<sup>Required</sup> <a name="latencyType" id="cdk-monitoring-constructs.LatencyAlarmFactory.addCustomDurationAlarm.parameter.latencyType"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.LatencyType">LatencyType</a>
+
+---
+
+###### `props`<sup>Required</sup> <a name="props" id="cdk-monitoring-constructs.LatencyAlarmFactory.addCustomDurationAlarm.parameter.props"></a>
+
+- *Type:* <a href="#cdk-monitoring-constructs.DurationThreshold">DurationThreshold</a>
+
+---
+
+###### `durationName`<sup>Required</sup> <a name="durationName" id="cdk-monitoring-constructs.LatencyAlarmFactory.addCustomDurationAlarm.parameter.durationName"></a>
+
+- *Type:* string
+
+---
+
+###### `disambiguator`<sup>Optional</sup> <a name="disambiguator" id="cdk-monitoring-constructs.LatencyAlarmFactory.addCustomDurationAlarm.parameter.disambiguator"></a>
+
+- *Type:* string
+
+---
+
+###### `additionalAlarmNameSuffix`<sup>Optional</sup> <a name="additionalAlarmNameSuffix" id="cdk-monitoring-constructs.LatencyAlarmFactory.addCustomDurationAlarm.parameter.additionalAlarmNameSuffix"></a>
+
+- *Type:* string
 
 ---
 

--- a/lib/monitoring/aws-lambda/LambdaFunctionEnhancedMetricFactory.ts
+++ b/lib/monitoring/aws-lambda/LambdaFunctionEnhancedMetricFactory.ts
@@ -74,6 +74,30 @@ export class LambdaFunctionEnhancedMetricFactory extends BaseMetricFactory<Lambd
     );
   }
 
+  enhancedMetricMaxInitDuration() {
+    return this.enhancedMetric(
+      "init_duration",
+      MetricStatistic.MAX,
+      "InitDuration.Max",
+    );
+  }
+
+  enhancedMetricP90InitDuration() {
+    return this.enhancedMetric(
+      "init_duration",
+      MetricStatistic.P90,
+      "InitDuration.P90",
+    );
+  }
+
+  enhancedMetricAvgInitDuration() {
+    return this.enhancedMetric(
+      "init_duration",
+      MetricStatistic.AVERAGE,
+      "InitDuration.Avg",
+    );
+  }
+
   enhancedMetricFunctionCost() {
     return this.metricFactory.createMetricMath(
       "memory_utilization * duration",

--- a/test/monitoring/aws-lambda/LambdaFunctionMonitoring.test.ts
+++ b/test/monitoring/aws-lambda/LambdaFunctionMonitoring.test.ts
@@ -357,6 +357,21 @@ test("snapshot test: all alarms, alarmPrefix on error dedupeString", () => {
         maxUsagePercent: 50,
       },
     },
+    addEnhancedMonitoringMaxInitDurationAlarm: {
+      Warning: {
+        maxDuration: Duration.millis(200),
+      },
+    },
+    addEnhancedMonitoringP90InitDurationAlarm: {
+      Warning: {
+        maxDuration: Duration.millis(150),
+      },
+    },
+    addEnhancedMonitoringAvgInitDurationAlarm: {
+      Warning: {
+        maxDuration: Duration.millis(100),
+      },
+    },
     useCreatedAlarms: {
       consume(alarms: AlarmWithAnnotation[]) {
         numAlarmsCreated = alarms.length;
@@ -365,7 +380,7 @@ test("snapshot test: all alarms, alarmPrefix on error dedupeString", () => {
   });
 
   addMonitoringDashboardsToStack(stack, monitoring);
-  expect(numAlarmsCreated).toStrictEqual(20);
+  expect(numAlarmsCreated).toStrictEqual(23);
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });
 
@@ -500,6 +515,21 @@ test("snapshot test: all alarms, alarmPrefix on latency dedupeString", () => {
         maxUsagePercent: 50,
       },
     },
+    addEnhancedMonitoringMaxInitDurationAlarm: {
+      Warning: {
+        maxDuration: Duration.millis(200),
+      },
+    },
+    addEnhancedMonitoringP90InitDurationAlarm: {
+      Warning: {
+        maxDuration: Duration.millis(150),
+      },
+    },
+    addEnhancedMonitoringAvgInitDurationAlarm: {
+      Warning: {
+        maxDuration: Duration.millis(100),
+      },
+    },
     useCreatedAlarms: {
       consume(alarms: AlarmWithAnnotation[]) {
         numAlarmsCreated = alarms.length;
@@ -508,7 +538,7 @@ test("snapshot test: all alarms, alarmPrefix on latency dedupeString", () => {
   });
 
   addMonitoringDashboardsToStack(stack, monitoring);
-  expect(numAlarmsCreated).toStrictEqual(20);
+  expect(numAlarmsCreated).toStrictEqual(23);
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });
 
@@ -618,6 +648,21 @@ test("doesn't create alarms for enhanced Lambda Insights metrics if not enabled"
     addEnhancedMonitoringAvgMemoryUtilizationAlarm: {
       Warning: {
         maxUsagePercent: 50,
+      },
+    },
+    addEnhancedMonitoringMaxInitDurationAlarm: {
+      Warning: {
+        maxDuration: Duration.millis(200),
+      },
+    },
+    addEnhancedMonitoringP90InitDurationAlarm: {
+      Warning: {
+        maxDuration: Duration.millis(150),
+      },
+    },
+    addEnhancedMonitoringAvgInitDurationAlarm: {
+      Warning: {
+        maxDuration: Duration.millis(100),
       },
     },
     useCreatedAlarms: {

--- a/test/monitoring/aws-lambda/__snapshots__/LambdaFunctionMonitoring.test.ts.snap
+++ b/test/monitoring/aws-lambda/__snapshots__/LambdaFunctionMonitoring.test.ts.snap
@@ -1203,7 +1203,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaLatencyP50WarningE50DF463",
+                  "ScopeTestDummyLambdaInitDurationMaximumWarningC379946D",
                   "Arn",
                 ],
               },
@@ -1214,7 +1214,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaLatencyP90Warning670FFADC",
+                  "ScopeTestDummyLambdaInitDurationP90WarningFCEBF79F",
                   "Arn",
                 ],
               },
@@ -1225,7 +1225,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaLatencyP99WarningDDA8F353",
+                  "ScopeTestDummyLambdaInitDurationAverageWarning0AD3110A",
                   "Arn",
                 ],
               },
@@ -1236,7 +1236,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaLatencyMaximumWarning4C9EF83C",
+                  "ScopeTestDummyLambdaLatencyP50WarningE50DF463",
                   "Arn",
                 ],
               },
@@ -1247,7 +1247,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaFaultCountWarning33B0A193",
+                  "ScopeTestDummyLambdaLatencyP90Warning670FFADC",
                   "Arn",
                 ],
               },
@@ -1258,7 +1258,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaFaultRateWarningE6A1BB2B",
+                  "ScopeTestDummyLambdaLatencyP99WarningDDA8F353",
                   "Arn",
                 ],
               },
@@ -1269,7 +1269,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaMinTPSWarning30EF1FB4",
+                  "ScopeTestDummyLambdaLatencyMaximumWarning4C9EF83C",
                   "Arn",
                 ],
               },
@@ -1280,7 +1280,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaMaxTPSWarning0EC2023E",
+                  "ScopeTestDummyLambdaFaultCountWarning33B0A193",
                   "Arn",
                 ],
               },
@@ -1291,7 +1291,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaThrottledCountWarning946A5E19",
+                  "ScopeTestDummyLambdaFaultRateWarningE6A1BB2B",
                   "Arn",
                 ],
               },
@@ -1302,7 +1302,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaThrottledRateWarning6EB21772",
+                  "ScopeTestDummyLambdaMinTPSWarning30EF1FB4",
                   "Arn",
                 ],
               },
@@ -1313,7 +1313,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaUsageCountWarningFB9A10FB",
+                  "ScopeTestDummyLambdaMaxTPSWarning0EC2023E",
                   "Arn",
                 ],
               },
@@ -1324,7 +1324,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaRunningTasksHighWarning2A06F60A",
+                  "ScopeTestDummyLambdaThrottledCountWarning946A5E19",
                   "Arn",
                 ],
               },
@@ -1335,11 +1335,44 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaRunningTasksHighCritical357223A5",
+                  "ScopeTestDummyLambdaThrottledRateWarning6EB21772",
                   "Arn",
                 ],
               },
               "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":18,\\"y\\":16,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyLambdaUsageCountWarningFB9A10FB",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":0,\\"y\\":20,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyLambdaRunningTasksHighWarning2A06F60A",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":6,\\"y\\":20,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyLambdaRunningTasksHighCritical357223A5",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":12,\\"y\\":20,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -1506,7 +1539,7 @@ Object {
               Object {
                 "Ref": "Function76856677",
               },
-              "\\",{\\"label\\":\\"Iterator Age\\",\\"stat\\":\\"Maximum\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Iterator Age > 1000000 for 3 datapoints within 15 minutes\\",\\"value\\":1000000,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":0,\\"y\\":16,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CPU Total Time\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Iterator Age\\",\\"stat\\":\\"Maximum\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Iterator Age > 1000000 for 3 datapoints within 15 minutes\\",\\"value\\":1000000,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":16,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CPU Total Time\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -1522,7 +1555,7 @@ Object {
               Object {
                 "Ref": "Function76856677",
               },
-              "\\",{\\"label\\":\\"CPUTotalTime.Avg\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"CPUTotalTime.Max > 100 for 3 datapoints within 15 minutes\\",\\"value\\":100,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"CPUTotalTime.P90 > 100 for 3 datapoints within 15 minutes\\",\\"value\\":100,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"CPUTotalTime.Avg > 100 for 3 datapoints within 15 minutes\\",\\"value\\":100,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":8,\\"y\\":16,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Memory Utilization\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"CPUTotalTime.Avg\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"CPUTotalTime.Max > 100 for 3 datapoints within 15 minutes\\",\\"value\\":100,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"CPUTotalTime.P90 > 100 for 3 datapoints within 15 minutes\\",\\"value\\":100,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"CPUTotalTime.Avg > 100 for 3 datapoints within 15 minutes\\",\\"value\\":100,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":16,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Memory Utilization\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -1538,7 +1571,23 @@ Object {
               Object {
                 "Ref": "Function76856677",
               },
-              "\\",{\\"label\\":\\"MemoryUtilization.Avg\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"MemoryUtilization.Max > 50 for 3 datapoints within 15 minutes\\",\\"value\\":50,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"MemoryUtilization.P90 > 50 for 3 datapoints within 15 minutes\\",\\"value\\":50,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"MemoryUtilization.Avg > 50 for 3 datapoints within 15 minutes\\",\\"value\\":50,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":100,\\"label\\":\\"%\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":16,\\"y\\":16,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Cost\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"MemoryUtilization.Avg\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"MemoryUtilization.Max > 50 for 3 datapoints within 15 minutes\\",\\"value\\":50,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"MemoryUtilization.P90 > 50 for 3 datapoints within 15 minutes\\",\\"value\\":50,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"MemoryUtilization.Avg > 50 for 3 datapoints within 15 minutes\\",\\"value\\":50,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":100,\\"label\\":\\"%\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":16,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Init Duration\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"LambdaInsights\\",\\"init_duration\\",\\"function_name\\",\\"",
+              Object {
+                "Ref": "Function76856677",
+              },
+              "\\",{\\"label\\":\\"InitDuration.Max\\",\\"stat\\":\\"Maximum\\"}],[\\"LambdaInsights\\",\\"init_duration\\",\\"function_name\\",\\"",
+              Object {
+                "Ref": "Function76856677",
+              },
+              "\\",{\\"label\\":\\"InitDuration.P90\\",\\"stat\\":\\"p90\\"}],[\\"LambdaInsights\\",\\"init_duration\\",\\"function_name\\",\\"",
+              Object {
+                "Ref": "Function76856677",
+              },
+              "\\",{\\"label\\":\\"InitDuration.Avg\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"InitDuration.Max > 200 for 3 datapoints within 15 minutes\\",\\"value\\":200,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"InitDuration.P90 > 150 for 3 datapoints within 15 minutes\\",\\"value\\":150,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"InitDuration.Avg > 100 for 3 datapoints within 15 minutes\\",\\"value\\":100,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":16,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Cost\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -1769,6 +1818,114 @@ Object {
           },
         ],
         "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyLambdaInitDurationAverageWarning0AD3110A": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Average InitDuration is too long.",
+        "AlarmName": "Test-DummyLambda-InitDuration-Average-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "InitDuration.Avg",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "function_name",
+                    "Value": Object {
+                      "Ref": "Function76856677",
+                    },
+                  },
+                ],
+                "MetricName": "init_duration",
+                "Namespace": "LambdaInsights",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 100,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyLambdaInitDurationMaximumWarningC379946D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Maximum InitDuration is too long.",
+        "AlarmName": "Test-DummyLambda-InitDuration-Maximum-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "InitDuration.Max",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "function_name",
+                    "Value": Object {
+                      "Ref": "Function76856677",
+                    },
+                  },
+                ],
+                "MetricName": "init_duration",
+                "Namespace": "LambdaInsights",
+              },
+              "Period": 300,
+              "Stat": "Maximum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 200,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyLambdaInitDurationP90WarningFCEBF79F": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P90 InitDuration is too long.",
+        "AlarmName": "Test-DummyLambda-InitDuration-P90-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "InitDuration.P90",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "function_name",
+                    "Value": Object {
+                      "Ref": "Function76856677",
+                    },
+                  },
+                ],
+                "MetricName": "init_duration",
+                "Namespace": "LambdaInsights",
+              },
+              "Period": 300,
+              "Stat": "p90",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 150,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
@@ -2457,7 +2614,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaLatencyP50WarningE50DF463",
+                  "ScopeTestDummyLambdaInitDurationMaximumWarningC379946D",
                   "Arn",
                 ],
               },
@@ -2468,7 +2625,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaLatencyP90Warning670FFADC",
+                  "ScopeTestDummyLambdaInitDurationP90WarningFCEBF79F",
                   "Arn",
                 ],
               },
@@ -2479,7 +2636,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaLatencyP99WarningDDA8F353",
+                  "ScopeTestDummyLambdaInitDurationAverageWarning0AD3110A",
                   "Arn",
                 ],
               },
@@ -2490,7 +2647,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaLatencyMaximumWarning4C9EF83C",
+                  "ScopeTestDummyLambdaLatencyP50WarningE50DF463",
                   "Arn",
                 ],
               },
@@ -2501,7 +2658,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaFaultCountWarning33B0A193",
+                  "ScopeTestDummyLambdaLatencyP90Warning670FFADC",
                   "Arn",
                 ],
               },
@@ -2512,7 +2669,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaFaultRateWarningE6A1BB2B",
+                  "ScopeTestDummyLambdaLatencyP99WarningDDA8F353",
                   "Arn",
                 ],
               },
@@ -2523,7 +2680,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaMinTPSWarning30EF1FB4",
+                  "ScopeTestDummyLambdaLatencyMaximumWarning4C9EF83C",
                   "Arn",
                 ],
               },
@@ -2534,7 +2691,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaMaxTPSWarning0EC2023E",
+                  "ScopeTestDummyLambdaFaultCountWarning33B0A193",
                   "Arn",
                 ],
               },
@@ -2545,7 +2702,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaThrottledCountWarning946A5E19",
+                  "ScopeTestDummyLambdaFaultRateWarningE6A1BB2B",
                   "Arn",
                 ],
               },
@@ -2556,7 +2713,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaThrottledRateWarning6EB21772",
+                  "ScopeTestDummyLambdaMinTPSWarning30EF1FB4",
                   "Arn",
                 ],
               },
@@ -2567,7 +2724,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaUsageCountWarningFB9A10FB",
+                  "ScopeTestDummyLambdaMaxTPSWarning0EC2023E",
                   "Arn",
                 ],
               },
@@ -2578,7 +2735,7 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaRunningTasksHighWarning2A06F60A",
+                  "ScopeTestDummyLambdaThrottledCountWarning946A5E19",
                   "Arn",
                 ],
               },
@@ -2589,11 +2746,44 @@ Object {
               "\\",\\"annotations\\":{\\"alarms\\":[\\"",
               Object {
                 "Fn::GetAtt": Array [
-                  "ScopeTestDummyLambdaRunningTasksHighCritical357223A5",
+                  "ScopeTestDummyLambdaThrottledRateWarning6EB21772",
                   "Arn",
                 ],
               },
               "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":18,\\"y\\":16,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyLambdaUsageCountWarningFB9A10FB",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":0,\\"y\\":20,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyLambdaRunningTasksHighWarning2A06F60A",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":6,\\"y\\":20,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyLambdaRunningTasksHighCritical357223A5",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":12,\\"y\\":20,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -2760,7 +2950,7 @@ Object {
               Object {
                 "Ref": "Function76856677",
               },
-              "\\",{\\"label\\":\\"Iterator Age\\",\\"stat\\":\\"Maximum\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Iterator Age > 1000000 for 3 datapoints within 15 minutes\\",\\"value\\":1000000,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":0,\\"y\\":16,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CPU Total Time\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Iterator Age\\",\\"stat\\":\\"Maximum\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"Iterator Age > 1000000 for 3 datapoints within 15 minutes\\",\\"value\\":1000000,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":16,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"CPU Total Time\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -2776,7 +2966,7 @@ Object {
               Object {
                 "Ref": "Function76856677",
               },
-              "\\",{\\"label\\":\\"CPUTotalTime.Avg\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"CPUTotalTime.Max > 100 for 3 datapoints within 15 minutes\\",\\"value\\":100,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"CPUTotalTime.P90 > 100 for 3 datapoints within 15 minutes\\",\\"value\\":100,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"CPUTotalTime.Avg > 100 for 3 datapoints within 15 minutes\\",\\"value\\":100,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":8,\\"y\\":16,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Memory Utilization\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"CPUTotalTime.Avg\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"CPUTotalTime.Max > 100 for 3 datapoints within 15 minutes\\",\\"value\\":100,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"CPUTotalTime.P90 > 100 for 3 datapoints within 15 minutes\\",\\"value\\":100,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"CPUTotalTime.Avg > 100 for 3 datapoints within 15 minutes\\",\\"value\\":100,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":16,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Memory Utilization\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -2792,7 +2982,23 @@ Object {
               Object {
                 "Ref": "Function76856677",
               },
-              "\\",{\\"label\\":\\"MemoryUtilization.Avg\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"MemoryUtilization.Max > 50 for 3 datapoints within 15 minutes\\",\\"value\\":50,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"MemoryUtilization.P90 > 50 for 3 datapoints within 15 minutes\\",\\"value\\":50,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"MemoryUtilization.Avg > 50 for 3 datapoints within 15 minutes\\",\\"value\\":50,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":100,\\"label\\":\\"%\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":16,\\"y\\":16,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Cost\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"MemoryUtilization.Avg\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"MemoryUtilization.Max > 50 for 3 datapoints within 15 minutes\\",\\"value\\":50,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"MemoryUtilization.P90 > 50 for 3 datapoints within 15 minutes\\",\\"value\\":50,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"MemoryUtilization.Avg > 50 for 3 datapoints within 15 minutes\\",\\"value\\":50,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"max\\":100,\\"label\\":\\"%\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":16,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Init Duration\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"LambdaInsights\\",\\"init_duration\\",\\"function_name\\",\\"",
+              Object {
+                "Ref": "Function76856677",
+              },
+              "\\",{\\"label\\":\\"InitDuration.Max\\",\\"stat\\":\\"Maximum\\"}],[\\"LambdaInsights\\",\\"init_duration\\",\\"function_name\\",\\"",
+              Object {
+                "Ref": "Function76856677",
+              },
+              "\\",{\\"label\\":\\"InitDuration.P90\\",\\"stat\\":\\"p90\\"}],[\\"LambdaInsights\\",\\"init_duration\\",\\"function_name\\",\\"",
+              Object {
+                "Ref": "Function76856677",
+              },
+              "\\",{\\"label\\":\\"InitDuration.Avg\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"InitDuration.Max > 200 for 3 datapoints within 15 minutes\\",\\"value\\":200,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"InitDuration.P90 > 150 for 3 datapoints within 15 minutes\\",\\"value\\":150,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"InitDuration.Avg > 100 for 3 datapoints within 15 minutes\\",\\"value\\":100,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":16,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Function Cost\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -3023,6 +3229,114 @@ Object {
           },
         ],
         "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyLambdaInitDurationAverageWarning0AD3110A": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Average InitDuration is too long.",
+        "AlarmName": "Test-DummyLambda-InitDuration-Average-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "InitDuration.Avg",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "function_name",
+                    "Value": Object {
+                      "Ref": "Function76856677",
+                    },
+                  },
+                ],
+                "MetricName": "init_duration",
+                "Namespace": "LambdaInsights",
+              },
+              "Period": 300,
+              "Stat": "Average",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 100,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyLambdaInitDurationMaximumWarningC379946D": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "Maximum InitDuration is too long.",
+        "AlarmName": "Test-DummyLambda-InitDuration-Maximum-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "InitDuration.Max",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "function_name",
+                    "Value": Object {
+                      "Ref": "Function76856677",
+                    },
+                  },
+                ],
+                "MetricName": "init_duration",
+                "Namespace": "LambdaInsights",
+              },
+              "Period": 300,
+              "Stat": "Maximum",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 200,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyLambdaInitDurationP90WarningFCEBF79F": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "P90 InitDuration is too long.",
+        "AlarmName": "Test-DummyLambda-InitDuration-P90-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "InitDuration.P90",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "function_name",
+                    "Value": Object {
+                      "Ref": "Function76856677",
+                    },
+                  },
+                ],
+                "MetricName": "init_duration",
+                "Namespace": "LambdaInsights",
+              },
+              "Period": 300,
+              "Stat": "p90",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 150,
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",


### PR DESCRIPTION
Fixes https://github.com/cdklabs/cdk-monitoring-constructs/issues/462

Add `init_duration` to `LambdaFunctionMonitoring`. Monitoring INIT has become increasingly important due to:

1. Lambda now bills for the INIT phase. [Blog](https://aws.amazon.com/blogs/compute/aws-lambda-standardizes-billing-for-init-phase/).
2. With the growing adoption of Provisioned Concurrency and SnapStart, people want visibility into INIT durations.

While making changes for the PR, I noticed an issue with how the function cost is calculated (https://github.com/cdklabs/cdk-monitoring-constructs/issues/645). I’ll fix that next and also include INIT as part of the cost calculation.

<img width="1458" alt="image" src="https://github.com/user-attachments/assets/5e0b53ce-304c-4ae6-94ff-e2d1e30b05ad" />
---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_