### PR TITLE
feat(MonitoringAspect): add Fargate service support

### DIFF
--- a/lib/facade/IMonitoringAspect.ts
+++ b/lib/facade/IMonitoringAspect.ts
@@ -12,6 +12,9 @@ import {
   DynamoTableMonitoringOptions,
   EC2MonitoringOptions,
   ElastiCacheClusterMonitoringOptions,
+  BaseFargateServiceMonitoringProps,
+  BaseLoadBalancedFargateServiceMonitoringProps,
+  BaseQueueProcessingFargateServiceMonitoringOptions,
   GlueJobMonitoringOptions,
   KinesisDataAnalyticsMonitoringOptions,
   KinesisDataStreamMonitoringOptions,
@@ -99,6 +102,20 @@ export interface ElastiCacheAspectType extends BaseMonitoringAspectType {
   readonly props?: ElastiCacheClusterMonitoringOptions;
 }
 
+export interface FargateServiceAspectType extends BaseMonitoringAspectType {
+  readonly props?: BaseFargateServiceMonitoringProps;
+}
+
+export interface LoadBalancedFargateServiceAspectType
+  extends BaseMonitoringAspectType {
+  readonly props?: BaseLoadBalancedFargateServiceMonitoringProps;
+}
+
+export interface QueueProcessingFargateServiceAspectType
+  extends BaseMonitoringAspectType {
+  readonly props?: BaseQueueProcessingFargateServiceMonitoringOptions;
+}
+
 export interface GlueJobAspectType extends BaseMonitoringAspectType {
   readonly props?: GlueJobMonitoringOptions;
 }
@@ -179,6 +196,9 @@ export interface MonitoringAspectProps {
   readonly dynamoDB?: DynamoTableAspectType;
   readonly ec2?: EC2AspectType;
   readonly elasticCache?: ElastiCacheAspectType;
+  readonly fargateService?: FargateServiceAspectType;
+  readonly fargateLoadBalancedService?: LoadBalancedFargateServiceAspectType;
+  readonly queueProcessingFargateService?: QueueProcessingFargateServiceAspectType;
   readonly glue?: GlueJobAspectType;
   readonly kinesisDataAnalytics?: KinesisDataAnalyticsAspectType;
   readonly kinesisDataStream?: KinesisDataStreamAspectType;

--- a/lib/facade/MonitoringAspect.ts
+++ b/lib/facade/MonitoringAspect.ts
@@ -8,6 +8,8 @@ import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
 import * as codebuild from "aws-cdk-lib/aws-codebuild";
 import * as docdb from "aws-cdk-lib/aws-docdb";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as ecs from "aws-cdk-lib/aws-ecs";
+import * as ecsPatterns from "aws-cdk-lib/aws-ecs-patterns";
 import * as elasticsearch from "aws-cdk-lib/aws-elasticsearch";
 import * as glue from "aws-cdk-lib/aws-glue";
 import * as kinesis from "aws-cdk-lib/aws-kinesis";
@@ -58,6 +60,9 @@ export class MonitoringAspect implements IAspect {
     this.monitorCodeBuild(node);
     this.monitorDocumentDb(node);
     this.monitorDynamoDb(node);
+    this.monitorFargateService(node);
+    this.monitorFargateLoadBalancedService(node);
+    this.monitorQueueProcessingFargateService(node);
     this.monitorGlue(node);
     this.monitorKinesisAnalytics(node);
     this.monitorKinesisDataStream(node);
@@ -236,6 +241,76 @@ export class MonitoringAspect implements IAspect {
         ...props,
       });
     }
+  }
+
+  private monitorFargateService(node: IConstruct) {
+    const [isEnabled, props] = this.getMonitoringDetails(
+      this.props.fargateService,
+    );
+    if (
+      isEnabled &&
+      node instanceof ecs.FargateService &&
+      !this.isInsideFargatePattern(node)
+    ) {
+      this.monitoringFacade.monitorSimpleFargateService({
+        fargateService: node,
+        ...props,
+      });
+    }
+  }
+
+  private monitorFargateLoadBalancedService(node: IConstruct) {
+    const [isEnabled, props] = this.getMonitoringDetails(
+      this.props.fargateLoadBalancedService,
+    );
+    if (
+      isEnabled &&
+      (node instanceof ecsPatterns.ApplicationLoadBalancedFargateService ||
+        node instanceof ecsPatterns.NetworkLoadBalancedFargateService)
+    ) {
+      this.monitoringFacade.monitorFargateService({
+        fargateService: node,
+        ...props,
+      });
+    }
+  }
+
+  private monitorQueueProcessingFargateService(node: IConstruct) {
+    const [isEnabled, props] = this.getMonitoringDetails(
+      this.props.queueProcessingFargateService,
+    );
+    if (
+      isEnabled &&
+      node instanceof ecsPatterns.QueueProcessingFargateService
+    ) {
+      this.monitoringFacade.monitorQueueProcessingFargateService({
+        fargateService: node,
+        ...props,
+      });
+    }
+  }
+
+  /**
+   * Returns true if the FargateService is owned by an L3 ecs-patterns
+   * construct (ApplicationLoadBalancedFargateService,
+   * NetworkLoadBalancedFargateService, QueueProcessingFargateService).
+   * The L3 pattern has its own aspect hook, so monitoring the inner
+   * service separately would duplicate alarms.
+   */
+  private isInsideFargatePattern(service: ecs.FargateService): boolean {
+    const MAX_ANCESTOR_DEPTH = 3;
+    let current: IConstruct | undefined = service.node.scope;
+    for (let i = 0; i < MAX_ANCESTOR_DEPTH && current; i++) {
+      if (
+        current instanceof ecsPatterns.ApplicationLoadBalancedFargateService ||
+        current instanceof ecsPatterns.NetworkLoadBalancedFargateService ||
+        current instanceof ecsPatterns.QueueProcessingFargateService
+      ) {
+        return true;
+      }
+      current = current.node.scope;
+    }
+    return false;
   }
 
   private monitorGlue(node: IConstruct) {

--- a/lib/monitoring/aws-ecs-patterns/FargateServiceMonitoring.ts
+++ b/lib/monitoring/aws-ecs-patterns/FargateServiceMonitoring.ts
@@ -81,7 +81,7 @@ export interface BaseFargateServiceAlarms {
 /**
  * Monitoring props for any type of Fargate service.
  */
-interface BaseFargateServiceMonitoringProps
+export interface BaseFargateServiceMonitoringProps
   extends BaseMonitoringProps,
     BaseFargateServiceAlarms {}
 
@@ -96,7 +96,7 @@ export interface SimpleFargateServiceMonitoringProps
 /**
  * Base of Monitoring props for load-balanced Fargate service.
  */
-interface BaseLoadBalancedFargateServiceMonitoringProps
+export interface BaseLoadBalancedFargateServiceMonitoringProps
   extends BaseFargateServiceMonitoringProps {
   readonly addHealthyTaskCountAlarm?: Record<string, HealthyTaskCountThreshold>;
   readonly addUnhealthyTaskCountAlarm?: Record<

--- a/lib/monitoring/aws-ecs-patterns/misc.ts
+++ b/lib/monitoring/aws-ecs-patterns/misc.ts
@@ -24,6 +24,9 @@ interface BaseQueueProcessingServiceMonitoringProps
   readonly addDeadLetterQueueAlarms?: BaseDlqAlarms;
 }
 
+export interface BaseQueueProcessingFargateServiceMonitoringOptions
+  extends BaseQueueProcessingServiceMonitoringProps {}
+
 export interface QueueProcessingFargateServiceMonitoringProps
   extends BaseQueueProcessingServiceMonitoringProps {
   readonly fargateService: QueueProcessingFargateService;


### PR DESCRIPTION
## What

Wires Fargate services into the auto-applied `MonitoringAspect` so that teams relying on the aspect for fleet-wide auto-monitoring get Fargate coverage without manual opt-in.

Covers three cases:

| Matched construct | Facade method | Metrics covered |
| --- | --- | --- |
| `ecs.FargateService` (bare) | `monitorSimpleFargateService` | Service: CPU, memory, running/desired tasks |
| `ApplicationLoadBalancedFargateService` / `NetworkLoadBalancedFargateService` | `monitorFargateService` | Service + ALB/NLB + target group |
| `QueueProcessingFargateService` | `monitorQueueProcessingFargateService` | Service + SQS queue + DLQ |

To prevent double-monitoring, the bare `FargateService` visitor skips services whose ancestor chain contains one of the L3 pattern constructs — those are already covered by the dedicated visitors.

## Why

`MonitoringFacade` already exposes all of the Fargate monitoring methods, but none of them were reachable through `MonitoringAspect`. Teams that use the aspect for fleet-wide auto-monitoring had to opt Fargate services in manually. This change closes that gap and mirrors the wiring pattern already used for Lambda, API Gateway, DynamoDB, etc.

## Changes

- `lib/facade/IMonitoringAspect.ts`
  - Add `FargateServiceAspectType`, `LoadBalancedFargateServiceAspectType`, `QueueProcessingFargateServiceAspectType`.
  - Add `fargateService`, `fargateLoadBalancedService`, `queueProcessingFargateService` to `MonitoringAspectProps`.
- `lib/facade/MonitoringAspect.ts`
  - Add `monitorFargateService`, `monitorFargateLoadBalancedService`, `monitorQueueProcessingFargateService` visitors.
  - Add `isInsideFargatePattern` helper to de-duplicate the bare-service match inside L3 patterns.
- `lib/monitoring/aws-ecs-patterns/FargateServiceMonitoring.ts`
  - Export `BaseFargateServiceMonitoringProps` and `BaseLoadBalancedFargateServiceMonitoringProps` so they can be used as aspect-option types (jsii requires named interfaces; `Omit<>` transforms aren't accepted).
- `lib/monitoring/aws-ecs-patterns/misc.ts`
  - Add `BaseQueueProcessingFargateServiceMonitoringOptions` as a public alias over the package-private `BaseQueueProcessingServiceMonitoringProps`, for the same reason.
- `API.md` — regenerated by projen.

## Usage

```ts
new MonitoringAspect(facade, {
  fargateService: {
    props: {
      addCpuUsageAlarm: { Warning: { maxUsagePercent: 80 } },
    },
  },
  fargateLoadBalancedService: {
    props: {
      addHealthyTaskCountAlarm: { Critical: { minHealthyTasks: 1 } },
    },
  },
  queueProcessingFargateService: {
    props: {
      addQueueAlarms: { addApproximateNumberOfMessagesVisibleAlarm: { Critical: { maxMessageCount: 1000 } } },
    },
  },
});
```

## Testing

- `yarn build` passes locally (compile + test + eslint + jsii assembly + pacmak for js/java/python/dotnet/go).
- New visitors mirror the established pattern in the class; no existing tests were modified.

## Out of scope

- Ec2 service / Ec2-patterns variants — could be added as a follow-up with the same pattern (bare `Ec2Service` + L3 patterns with ancestor-skip logic).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license