### PR TITLE
feat(aws-lambda): support trimmed mean latency alarms

### DIFF
--- a/API.md
+++ b/API.md
@@ -30896,6 +30896,13 @@ const lambdaFunctionMonitoringOptions: LambdaFunctionMonitoringOptions = { ... }
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addLatencyP50Alarm">addLatencyP50Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> \| <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addLatencyP90Alarm">addLatencyP90Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> \| <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addLatencyP99Alarm">addLatencyP99Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> \| <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addLatencyTM50Alarm">addLatencyTM50Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> \| <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addLatencyTM70Alarm">addLatencyTM70Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> \| <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addLatencyTM90Alarm">addLatencyTM90Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> \| <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addLatencyTM95Alarm">addLatencyTM95Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> \| <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addLatencyTM9999Alarm">addLatencyTM9999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> \| <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addLatencyTM999Alarm">addLatencyTM999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> \| <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addLatencyTM99Alarm">addLatencyTM99Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> \| <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addLowTpsAlarm">addLowTpsAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LowTpsThreshold">LowTpsThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addMaxIteratorAgeAlarm">addMaxIteratorAgeAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.MaxAgeThreshold">MaxAgeThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addMaxLatencyAlarm">addMaxLatencyAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> \| <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}</code> | *No description.* |
@@ -30907,6 +30914,7 @@ const lambdaFunctionMonitoringOptions: LambdaFunctionMonitoringOptions = { ... }
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addThrottlesRateAlarm">addThrottlesRateAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorRateThreshold">ErrorRateThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.isIterator">isIterator</a></code> | <code>boolean</code> | Indicates that the Lambda function handles an event source (e.g. DynamoDB event stream). This impacts what widgets are shown, as well as validates the ability to use addMaxIteratorAgeAlarm. |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.isOffsetLag">isOffsetLag</a></code> | <code>boolean</code> | Indicates that the Lambda function handles an event source which uses offsets for records (e.g. Kafka streams). This impacts what widgets are shown, as well as validates the ability to use addMaxOffsetLagAlarm. |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.latencyTypesToRender">latencyTypesToRender</a></code> | <code><a href="#cdk-monitoring-constructs.LatencyType">LatencyType</a>[]</code> | You can specify what latency types you want to be rendered in the dashboards. |
 
 ---
 
@@ -31198,6 +31206,76 @@ public readonly addLatencyP99Alarm: {[ key: string ]: LatencyThreshold | Latency
 
 ---
 
+##### `addLatencyTM50Alarm`<sup>Optional</sup> <a name="addLatencyTM50Alarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addLatencyTM50Alarm"></a>
+
+```typescript
+public readonly addLatencyTM50Alarm: {[ key: string ]: LatencyThreshold | LatencyTimeoutPercentageThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> | <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}
+
+---
+
+##### `addLatencyTM70Alarm`<sup>Optional</sup> <a name="addLatencyTM70Alarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addLatencyTM70Alarm"></a>
+
+```typescript
+public readonly addLatencyTM70Alarm: {[ key: string ]: LatencyThreshold | LatencyTimeoutPercentageThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> | <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}
+
+---
+
+##### `addLatencyTM90Alarm`<sup>Optional</sup> <a name="addLatencyTM90Alarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addLatencyTM90Alarm"></a>
+
+```typescript
+public readonly addLatencyTM90Alarm: {[ key: string ]: LatencyThreshold | LatencyTimeoutPercentageThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> | <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}
+
+---
+
+##### `addLatencyTM95Alarm`<sup>Optional</sup> <a name="addLatencyTM95Alarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addLatencyTM95Alarm"></a>
+
+```typescript
+public readonly addLatencyTM95Alarm: {[ key: string ]: LatencyThreshold | LatencyTimeoutPercentageThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> | <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}
+
+---
+
+##### `addLatencyTM9999Alarm`<sup>Optional</sup> <a name="addLatencyTM9999Alarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addLatencyTM9999Alarm"></a>
+
+```typescript
+public readonly addLatencyTM9999Alarm: {[ key: string ]: LatencyThreshold | LatencyTimeoutPercentageThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> | <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}
+
+---
+
+##### `addLatencyTM999Alarm`<sup>Optional</sup> <a name="addLatencyTM999Alarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addLatencyTM999Alarm"></a>
+
+```typescript
+public readonly addLatencyTM999Alarm: {[ key: string ]: LatencyThreshold | LatencyTimeoutPercentageThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> | <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}
+
+---
+
+##### `addLatencyTM99Alarm`<sup>Optional</sup> <a name="addLatencyTM99Alarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addLatencyTM99Alarm"></a>
+
+```typescript
+public readonly addLatencyTM99Alarm: {[ key: string ]: LatencyThreshold | LatencyTimeoutPercentageThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> | <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}
+
+---
+
 ##### `addLowTpsAlarm`<sup>Optional</sup> <a name="addLowTpsAlarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.addLowTpsAlarm"></a>
 
 ```typescript
@@ -31314,6 +31392,23 @@ Indicates that the Lambda function handles an event source which uses offsets fo
 
 ---
 
+##### `latencyTypesToRender`<sup>Optional</sup> <a name="latencyTypesToRender" id="cdk-monitoring-constructs.LambdaFunctionMonitoringOptions.property.latencyTypesToRender"></a>
+
+```typescript
+public readonly latencyTypesToRender: LatencyType[];
+```
+
+- *Type:* <a href="#cdk-monitoring-constructs.LatencyType">LatencyType</a>[]
+- *Default:* p50, p90, p99 (@see DefaultLatencyTypesToRender)
+
+You can specify what latency types you want to be rendered in the dashboards.
+
+Note: any latency type with an alarm will be also added automatically.
+If the list is undefined, default values will be shown.
+If the list is empty, only the latency types with an alarm will be shown (if any).
+
+---
+
 ### LambdaFunctionMonitoringProps <a name="LambdaFunctionMonitoringProps" id="cdk-monitoring-constructs.LambdaFunctionMonitoringProps"></a>
 
 #### Initializer <a name="Initializer" id="cdk-monitoring-constructs.LambdaFunctionMonitoringProps.Initializer"></a>
@@ -31357,6 +31452,13 @@ const lambdaFunctionMonitoringProps: LambdaFunctionMonitoringProps = { ... }
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addLatencyP50Alarm">addLatencyP50Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> \| <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addLatencyP90Alarm">addLatencyP90Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> \| <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addLatencyP99Alarm">addLatencyP99Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> \| <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addLatencyTM50Alarm">addLatencyTM50Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> \| <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addLatencyTM70Alarm">addLatencyTM70Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> \| <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addLatencyTM90Alarm">addLatencyTM90Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> \| <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addLatencyTM95Alarm">addLatencyTM95Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> \| <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addLatencyTM9999Alarm">addLatencyTM9999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> \| <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addLatencyTM999Alarm">addLatencyTM999Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> \| <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addLatencyTM99Alarm">addLatencyTM99Alarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> \| <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addLowTpsAlarm">addLowTpsAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LowTpsThreshold">LowTpsThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addMaxIteratorAgeAlarm">addMaxIteratorAgeAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.MaxAgeThreshold">MaxAgeThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addMaxLatencyAlarm">addMaxLatencyAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> \| <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}</code> | *No description.* |
@@ -31368,6 +31470,7 @@ const lambdaFunctionMonitoringProps: LambdaFunctionMonitoringProps = { ... }
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addThrottlesRateAlarm">addThrottlesRateAlarm</a></code> | <code>{[ key: string ]: <a href="#cdk-monitoring-constructs.ErrorRateThreshold">ErrorRateThreshold</a>}</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.isIterator">isIterator</a></code> | <code>boolean</code> | Indicates that the Lambda function handles an event source (e.g. DynamoDB event stream). This impacts what widgets are shown, as well as validates the ability to use addMaxIteratorAgeAlarm. |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.isOffsetLag">isOffsetLag</a></code> | <code>boolean</code> | Indicates that the Lambda function handles an event source which uses offsets for records (e.g. Kafka streams). This impacts what widgets are shown, as well as validates the ability to use addMaxOffsetLagAlarm. |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.latencyTypesToRender">latencyTypesToRender</a></code> | <code><a href="#cdk-monitoring-constructs.LatencyType">LatencyType</a>[]</code> | You can specify what latency types you want to be rendered in the dashboards. |
 
 ---
 
@@ -31707,6 +31810,76 @@ public readonly addLatencyP99Alarm: {[ key: string ]: LatencyThreshold | Latency
 
 ---
 
+##### `addLatencyTM50Alarm`<sup>Optional</sup> <a name="addLatencyTM50Alarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addLatencyTM50Alarm"></a>
+
+```typescript
+public readonly addLatencyTM50Alarm: {[ key: string ]: LatencyThreshold | LatencyTimeoutPercentageThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> | <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}
+
+---
+
+##### `addLatencyTM70Alarm`<sup>Optional</sup> <a name="addLatencyTM70Alarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addLatencyTM70Alarm"></a>
+
+```typescript
+public readonly addLatencyTM70Alarm: {[ key: string ]: LatencyThreshold | LatencyTimeoutPercentageThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> | <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}
+
+---
+
+##### `addLatencyTM90Alarm`<sup>Optional</sup> <a name="addLatencyTM90Alarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addLatencyTM90Alarm"></a>
+
+```typescript
+public readonly addLatencyTM90Alarm: {[ key: string ]: LatencyThreshold | LatencyTimeoutPercentageThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> | <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}
+
+---
+
+##### `addLatencyTM95Alarm`<sup>Optional</sup> <a name="addLatencyTM95Alarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addLatencyTM95Alarm"></a>
+
+```typescript
+public readonly addLatencyTM95Alarm: {[ key: string ]: LatencyThreshold | LatencyTimeoutPercentageThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> | <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}
+
+---
+
+##### `addLatencyTM9999Alarm`<sup>Optional</sup> <a name="addLatencyTM9999Alarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addLatencyTM9999Alarm"></a>
+
+```typescript
+public readonly addLatencyTM9999Alarm: {[ key: string ]: LatencyThreshold | LatencyTimeoutPercentageThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> | <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}
+
+---
+
+##### `addLatencyTM999Alarm`<sup>Optional</sup> <a name="addLatencyTM999Alarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addLatencyTM999Alarm"></a>
+
+```typescript
+public readonly addLatencyTM999Alarm: {[ key: string ]: LatencyThreshold | LatencyTimeoutPercentageThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> | <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}
+
+---
+
+##### `addLatencyTM99Alarm`<sup>Optional</sup> <a name="addLatencyTM99Alarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addLatencyTM99Alarm"></a>
+
+```typescript
+public readonly addLatencyTM99Alarm: {[ key: string ]: LatencyThreshold | LatencyTimeoutPercentageThreshold};
+```
+
+- *Type:* {[ key: string ]: <a href="#cdk-monitoring-constructs.LatencyThreshold">LatencyThreshold</a> | <a href="#cdk-monitoring-constructs.LatencyTimeoutPercentageThreshold">LatencyTimeoutPercentageThreshold</a>}
+
+---
+
 ##### `addLowTpsAlarm`<sup>Optional</sup> <a name="addLowTpsAlarm" id="cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.addLowTpsAlarm"></a>
 
 ```typescript
@@ -31820,6 +31993,23 @@ public readonly isOffsetLag: boolean;
 - *Default:* false
 
 Indicates that the Lambda function handles an event source which uses offsets for records (e.g. Kafka streams). This impacts what widgets are shown, as well as validates the ability to use addMaxOffsetLagAlarm.
+
+---
+
+##### `latencyTypesToRender`<sup>Optional</sup> <a name="latencyTypesToRender" id="cdk-monitoring-constructs.LambdaFunctionMonitoringProps.property.latencyTypesToRender"></a>
+
+```typescript
+public readonly latencyTypesToRender: LatencyType[];
+```
+
+- *Type:* <a href="#cdk-monitoring-constructs.LatencyType">LatencyType</a>[]
+- *Default:* p50, p90, p99 (@see DefaultLatencyTypesToRender)
+
+You can specify what latency types you want to be rendered in the dashboards.
+
+Note: any latency type with an alarm will be also added automatically.
+If the list is undefined, default values will be shown.
+If the list is empty, only the latency types with an alarm will be shown (if any).
 
 ---
 
@@ -79115,6 +79305,8 @@ public createTpsWidget(width: number, height: number): GraphWidget
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.lambdaInsightsEnabled">lambdaInsightsEnabled</a></code> | <code>boolean</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.latencyAlarmFactory">latencyAlarmFactory</a></code> | <code><a href="#cdk-monitoring-constructs.LatencyAlarmFactory">LatencyAlarmFactory</a></code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.latencyAnnotations">latencyAnnotations</a></code> | <code>aws-cdk-lib.aws_cloudwatch.HorizontalAnnotation[]</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.latencyMetrics">latencyMetrics</a></code> | <code>{[ key: string ]: aws-cdk-lib.aws_cloudwatch.MathExpression \| aws-cdk-lib.aws_cloudwatch.Metric}</code> | *No description.* |
+| <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.latencyTypesToRender">latencyTypesToRender</a></code> | <code>string[]</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.maxIteratorAgeAnnotations">maxIteratorAgeAnnotations</a></code> | <code>aws-cdk-lib.aws_cloudwatch.HorizontalAnnotation[]</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.maxIteratorAgeMetric">maxIteratorAgeMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.MathExpression \| aws-cdk-lib.aws_cloudwatch.Metric</code> | *No description.* |
 | <code><a href="#cdk-monitoring-constructs.LambdaFunctionMonitoring.property.maxLatencyMetric">maxLatencyMetric</a></code> | <code>aws-cdk-lib.aws_cloudwatch.MathExpression \| aws-cdk-lib.aws_cloudwatch.Metric</code> | *No description.* |
@@ -79328,6 +79520,26 @@ public readonly latencyAnnotations: HorizontalAnnotation[];
 ```
 
 - *Type:* aws-cdk-lib.aws_cloudwatch.HorizontalAnnotation[]
+
+---
+
+##### `latencyMetrics`<sup>Required</sup> <a name="latencyMetrics" id="cdk-monitoring-constructs.LambdaFunctionMonitoring.property.latencyMetrics"></a>
+
+```typescript
+public readonly latencyMetrics: {[ key: string ]: MathExpression | Metric};
+```
+
+- *Type:* {[ key: string ]: aws-cdk-lib.aws_cloudwatch.MathExpression | aws-cdk-lib.aws_cloudwatch.Metric}
+
+---
+
+##### `latencyTypesToRender`<sup>Required</sup> <a name="latencyTypesToRender" id="cdk-monitoring-constructs.LambdaFunctionMonitoring.property.latencyTypesToRender"></a>
+
+```typescript
+public readonly latencyTypesToRender: string[];
+```
+
+- *Type:* string[]
 
 ---
 

--- a/lib/monitoring/aws-lambda/LambdaFunctionMonitoring.ts
+++ b/lib/monitoring/aws-lambda/LambdaFunctionMonitoring.ts
@@ -57,6 +57,12 @@ import {
   MonitoringNamingStrategy,
 } from "../../dashboard";
 
+const DefaultLatencyTypesToRender = [
+  LatencyType.P50,
+  LatencyType.P90,
+  LatencyType.P99,
+];
+
 export interface LambdaFunctionMonitoringOptions extends BaseMonitoringProps {
   /**
    * Indicates that the Lambda function handles an event source (e.g. DynamoDB event stream).
@@ -89,6 +95,43 @@ export interface LambdaFunctionMonitoringOptions extends BaseMonitoringProps {
     string,
     LatencyThreshold | LatencyTimeoutPercentageThreshold
   >;
+  readonly addLatencyTM50Alarm?: Record<
+    string,
+    LatencyThreshold | LatencyTimeoutPercentageThreshold
+  >;
+  readonly addLatencyTM70Alarm?: Record<
+    string,
+    LatencyThreshold | LatencyTimeoutPercentageThreshold
+  >;
+  readonly addLatencyTM90Alarm?: Record<
+    string,
+    LatencyThreshold | LatencyTimeoutPercentageThreshold
+  >;
+  readonly addLatencyTM95Alarm?: Record<
+    string,
+    LatencyThreshold | LatencyTimeoutPercentageThreshold
+  >;
+  readonly addLatencyTM99Alarm?: Record<
+    string,
+    LatencyThreshold | LatencyTimeoutPercentageThreshold
+  >;
+  readonly addLatencyTM999Alarm?: Record<
+    string,
+    LatencyThreshold | LatencyTimeoutPercentageThreshold
+  >;
+  readonly addLatencyTM9999Alarm?: Record<
+    string,
+    LatencyThreshold | LatencyTimeoutPercentageThreshold
+  >;
+
+  /**
+   * You can specify what latency types you want to be rendered in the dashboards.
+   * Note: any latency type with an alarm will be also added automatically.
+   * If the list is undefined, default values will be shown.
+   * If the list is empty, only the latency types with an alarm will be shown (if any).
+   * @default - p50, p90, p99 (@see DefaultLatencyTypesToRender)
+   */
+  readonly latencyTypesToRender?: LatencyType[];
 
   readonly addFaultCountAlarm?: Record<string, ErrorCountThreshold>;
   readonly addFaultRateAlarm?: Record<string, ErrorRateThreshold>;
@@ -195,6 +238,9 @@ export class LambdaFunctionMonitoring extends Monitoring {
   readonly p90LatencyMetric: MetricWithAlarmSupport;
   readonly p99LatencyMetric: MetricWithAlarmSupport;
   readonly maxLatencyMetric: MetricWithAlarmSupport;
+  // keys are LatencyType, but JSII doesn't like non-string types
+  readonly latencyMetrics: Record<string, MetricWithAlarmSupport>;
+  readonly latencyTypesToRender: string[];
   readonly faultCountMetric: MetricWithAlarmSupport;
   readonly faultRateMetric: MetricWithAlarmSupport;
   readonly invocationCountMetric: MetricWithAlarmSupport;
@@ -265,18 +311,18 @@ export class LambdaFunctionMonitoring extends Monitoring {
     this.tpsMetric = this.metricFactory.metricInvocationRate(
       RateComputationMethod.PER_SECOND,
     );
-    this.p50LatencyMetric = this.metricFactory.metricLatencyInMillis(
-      LatencyType.P50,
-    );
-    this.p90LatencyMetric = this.metricFactory.metricLatencyInMillis(
-      LatencyType.P90,
-    );
-    this.p99LatencyMetric = this.metricFactory.metricLatencyInMillis(
-      LatencyType.P99,
-    );
-    this.maxLatencyMetric = this.metricFactory.metricLatencyInMillis(
-      LatencyType.MAX,
-    );
+    this.latencyMetrics = {};
+    Object.values(LatencyType).forEach((latencyType) => {
+      this.latencyMetrics[latencyType] =
+        this.metricFactory.metricLatencyInMillis(latencyType);
+    });
+    this.latencyTypesToRender = [
+      ...(props.latencyTypesToRender ?? DefaultLatencyTypesToRender),
+    ];
+    this.p50LatencyMetric = this.latencyMetrics[LatencyType.P50];
+    this.p90LatencyMetric = this.latencyMetrics[LatencyType.P90];
+    this.p99LatencyMetric = this.latencyMetrics[LatencyType.P99];
+    this.maxLatencyMetric = this.latencyMetrics[LatencyType.MAX];
     this.faultCountMetric = this.metricFactory.metricFaultCount();
     this.faultRateMetric = this.metricFactory.metricFaultRate();
     this.invocationCountMetric = this.metricFactory.metricInvocationCount();
@@ -453,49 +499,35 @@ export class LambdaFunctionMonitoring extends Monitoring {
         this.addAlarm(createdAlarm);
       }
     }
-    for (const disambiguator in props.addLatencyP50Alarm) {
-      const alarmProps = props.addLatencyP50Alarm[disambiguator];
-      const createdAlarm = this.latencyAlarmFactory.addLatencyAlarm(
-        this.p50LatencyMetric,
-        LatencyType.P50,
-        this.convertToLatencyThreshold(alarmProps, props.lambdaFunction),
-        disambiguator,
-      );
-      this.latencyAnnotations.push(createdAlarm.annotation);
-      this.addAlarm(createdAlarm);
-    }
-    for (const disambiguator in props.addLatencyP90Alarm) {
-      const alarmProps = props.addLatencyP90Alarm[disambiguator];
-      const createdAlarm = this.latencyAlarmFactory.addLatencyAlarm(
-        this.p90LatencyMetric,
-        LatencyType.P90,
-        this.convertToLatencyThreshold(alarmProps, props.lambdaFunction),
-        disambiguator,
-      );
-      this.latencyAnnotations.push(createdAlarm.annotation);
-      this.addAlarm(createdAlarm);
-    }
-    for (const disambiguator in props.addLatencyP99Alarm) {
-      const alarmProps = props.addLatencyP99Alarm[disambiguator];
-      const createdAlarm = this.latencyAlarmFactory.addLatencyAlarm(
-        this.p99LatencyMetric,
-        LatencyType.P99,
-        this.convertToLatencyThreshold(alarmProps, props.lambdaFunction),
-        disambiguator,
-      );
-      this.latencyAnnotations.push(createdAlarm.annotation);
-      this.addAlarm(createdAlarm);
-    }
-    for (const disambiguator in props.addMaxLatencyAlarm) {
-      const alarmProps = props.addMaxLatencyAlarm[disambiguator];
-      const createdAlarm = this.latencyAlarmFactory.addLatencyAlarm(
-        this.maxLatencyMetric,
-        LatencyType.MAX,
-        this.convertToLatencyThreshold(alarmProps, props.lambdaFunction),
-        disambiguator,
-      );
-      this.latencyAnnotations.push(createdAlarm.annotation);
-      this.addAlarm(createdAlarm);
+    const latencyAlarmDefinitions = {
+      [LatencyType.P50]: props.addLatencyP50Alarm,
+      [LatencyType.P90]: props.addLatencyP90Alarm,
+      [LatencyType.P99]: props.addLatencyP99Alarm,
+      [LatencyType.MAX]: props.addMaxLatencyAlarm,
+      [LatencyType.TM50]: props.addLatencyTM50Alarm,
+      [LatencyType.TM70]: props.addLatencyTM70Alarm,
+      [LatencyType.TM90]: props.addLatencyTM90Alarm,
+      [LatencyType.TM95]: props.addLatencyTM95Alarm,
+      [LatencyType.TM99]: props.addLatencyTM99Alarm,
+      [LatencyType.TM999]: props.addLatencyTM999Alarm,
+      [LatencyType.TM9999]: props.addLatencyTM9999Alarm,
+    };
+    for (const [latencyType, alarmDefinition] of Object.entries(
+      latencyAlarmDefinitions,
+    )) {
+      for (const disambiguator in alarmDefinition) {
+        const alarmProps = alarmDefinition[disambiguator];
+        const latencyTypeEnum = latencyType as LatencyType;
+        const createdAlarm = this.latencyAlarmFactory.addLatencyAlarm(
+          this.latencyMetrics[latencyTypeEnum],
+          latencyTypeEnum,
+          this.convertToLatencyThreshold(alarmProps, props.lambdaFunction),
+          disambiguator,
+        );
+        this.latencyAnnotations.push(createdAlarm.annotation);
+        this.latencyTypesToRender.push(latencyTypeEnum);
+        this.addAlarm(createdAlarm);
+      }
     }
 
     for (const disambiguator in props.addFaultCountAlarm) {
@@ -765,15 +797,15 @@ export class LambdaFunctionMonitoring extends Monitoring {
   }
 
   createLatencyWidget(width: number, height: number) {
+    const left = Array.from(new Set(this.latencyTypesToRender))
+      .sort()
+      .map((type) => this.latencyMetrics[type]);
+
     return new GraphWidget({
       width,
       height,
       title: "Latency",
-      left: [
-        this.p50LatencyMetric,
-        this.p90LatencyMetric,
-        this.p99LatencyMetric,
-      ],
+      left,
       leftYAxis: TimeAxisMillisFromZero,
       leftAnnotations: this.latencyAnnotations,
     });

--- a/test/monitoring/aws-lambda/LambdaFunctionMonitoring.test.ts
+++ b/test/monitoring/aws-lambda/LambdaFunctionMonitoring.test.ts
@@ -780,3 +780,44 @@ test("snapshot test: latency alarms with percentage of timeout with specific tim
   expect(numAlarmsCreated).toStrictEqual(4);
   expect(Template.fromStack(stack)).toMatchSnapshot();
 });
+
+test("snapshot test: trimmed mean latency alarms", () => {
+  const stack = new Stack();
+
+  const scope = new TestMonitoringScope(stack, "Scope");
+
+  const lambdaFunction = Function.fromFunctionArn(
+    stack,
+    "Function",
+    "arn:aws:lambda:us-west-2:123456789012:function:DummyLambda",
+  );
+
+  let numAlarmsCreated = 0;
+
+  const monitoring = new LambdaFunctionMonitoring(scope, {
+    lambdaFunction,
+    humanReadableName: "Dummy Lambda for testing",
+    alarmFriendlyName: "DummyLambda",
+    addLatencyTM90Alarm: {
+      Warning: {
+        maxLatency: Duration.millis(150),
+        datapointsToAlarm: 3,
+      },
+    },
+    addLatencyTM99Alarm: {
+      Warning: {
+        maxLatencyPercentageOfTimeout: 90,
+        datapointsToAlarm: 22,
+      },
+    },
+    useCreatedAlarms: {
+      consume(alarms: AlarmWithAnnotation[]) {
+        numAlarmsCreated = alarms.length;
+      },
+    },
+  });
+
+  addMonitoringDashboardsToStack(stack, monitoring);
+  expect(numAlarmsCreated).toStrictEqual(2);
+  expect(Template.fromStack(stack)).toMatchSnapshot();
+});

--- a/test/monitoring/aws-lambda/__snapshots__/LambdaFunctionMonitoring.test.ts.snap
+++ b/test/monitoring/aws-lambda/__snapshots__/LambdaFunctionMonitoring.test.ts.snap
@@ -274,6 +274,10 @@ Object {
               Object {
                 "Ref": "Function76856677",
               },
+              "\\",{\\"label\\":\\"Maximum\\",\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"",
+              Object {
+                "Ref": "Function76856677",
+              },
               "\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"stat\\":\\"p50\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"",
               Object {
                 "Ref": "Function76856677",
@@ -929,6 +933,10 @@ Object {
               Object {
                 "Ref": "Function76856677",
               },
+              "\\",{\\"label\\":\\"Maximum\\",\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"",
+              Object {
+                "Ref": "Function76856677",
+              },
               "\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"stat\\":\\"p50\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"",
               Object {
                 "Ref": "Function76856677",
@@ -1472,6 +1480,10 @@ Object {
                 "Ref": "AWS::Region",
               },
               "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"",
+              Object {
+                "Ref": "Function76856677",
+              },
+              "\\",{\\"label\\":\\"Maximum\\",\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"",
               Object {
                 "Ref": "Function76856677",
               },
@@ -2474,6 +2486,10 @@ Object {
               Object {
                 "Ref": "Function76856677",
               },
+              "\\",{\\"label\\":\\"Maximum\\",\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"",
+              Object {
+                "Ref": "Function76856677",
+              },
               "\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"stat\\":\\"p50\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"",
               Object {
                 "Ref": "Function76856677",
@@ -2887,6 +2903,10 @@ Object {
                 "Ref": "AWS::Region",
               },
               "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"",
+              Object {
+                "Ref": "Function76856677",
+              },
+              "\\",{\\"label\\":\\"Maximum\\",\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"",
               Object {
                 "Ref": "Function76856677",
               },
@@ -3889,6 +3909,10 @@ Object {
               Object {
                 "Ref": "Function76856677",
               },
+              "\\",{\\"label\\":\\"Maximum\\",\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"",
+              Object {
+                "Ref": "Function76856677",
+              },
               "\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"stat\\":\\"p50\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"",
               Object {
                 "Ref": "Function76856677",
@@ -4277,7 +4301,7 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"stat\\":\\"p50\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"P90 (avg: \${AVG})\\",\\"stat\\":\\"p90\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"P99 (avg: \${AVG})\\",\\"stat\\":\\"p99\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"P50 > 1500 for 11 datapoints within 55 minutes\\",\\"value\\":1500,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"P90 > 2700 for 22 datapoints within 110 minutes\\",\\"value\\":2700,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"P99 > 2970 for 33 datapoints within 165 minutes\\",\\"value\\":2970,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Maximum > 2400 for 3 datapoints within 15 minutes\\",\\"value\\":2400,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"Maximum\\",\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"stat\\":\\"p50\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"P90 (avg: \${AVG})\\",\\"stat\\":\\"p90\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"P99 (avg: \${AVG})\\",\\"stat\\":\\"p99\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"P50 > 1500 for 11 datapoints within 55 minutes\\",\\"value\\":1500,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"P90 > 2700 for 22 datapoints within 110 minutes\\",\\"value\\":2700,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"P99 > 2970 for 33 datapoints within 165 minutes\\",\\"value\\":2970,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Maximum > 2400 for 3 datapoints within 15 minutes\\",\\"value\\":2400,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -4454,7 +4478,7 @@ Object {
               Object {
                 "Ref": "AWS::Region",
               },
-              "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"stat\\":\\"p50\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"P90 (avg: \${AVG})\\",\\"stat\\":\\"p90\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"P99 (avg: \${AVG})\\",\\"stat\\":\\"p99\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"P50 > 1500 for 11 datapoints within 55 minutes\\",\\"value\\":1500,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"P90 > 2700 for 22 datapoints within 110 minutes\\",\\"value\\":2700,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"P99 > 2970 for 33 datapoints within 165 minutes\\",\\"value\\":2970,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Maximum > 2400 for 3 datapoints within 15 minutes\\",\\"value\\":2400,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"Maximum\\",\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"stat\\":\\"p50\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"P90 (avg: \${AVG})\\",\\"stat\\":\\"p90\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"P99 (avg: \${AVG})\\",\\"stat\\":\\"p99\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"P50 > 1500 for 11 datapoints within 55 minutes\\",\\"value\\":1500,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"P90 > 2700 for 22 datapoints within 110 minutes\\",\\"value\\":2700,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"P99 > 2970 for 33 datapoints within 165 minutes\\",\\"value\\":2970,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"Maximum > 2400 for 3 datapoints within 15 minutes\\",\\"value\\":2400,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -4647,6 +4671,10 @@ Object {
                 "Ref": "AWS::Region",
               },
               "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"",
+              Object {
+                "Ref": "Function76856677",
+              },
+              "\\",{\\"label\\":\\"Maximum\\",\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"",
               Object {
                 "Ref": "Function76856677",
               },
@@ -4888,6 +4916,10 @@ Object {
                 "Ref": "AWS::Region",
               },
               "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"",
+              Object {
+                "Ref": "Function76856677",
+              },
+              "\\",{\\"label\\":\\"Maximum\\",\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"",
               Object {
                 "Ref": "Function76856677",
               },
@@ -5153,6 +5185,216 @@ Object {
                 "Ref": "Function76856677",
               },
               "\\",{\\"label\\":\\"Faults (avg)\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`snapshot test: trimmed mean latency alarms 1`] = `
+Object {
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
+  "Resources": Object {
+    "Alarm7103F465": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyLambdaLatencyTM90WarningFC789E9A",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":4,\\"x\\":6,\\"y\\":0,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"annotations\\":{\\"alarms\\":[\\"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "ScopeTestDummyLambdaLatencyTM99Warning5A7A0C59",
+                  "Arn",
+                ],
+              },
+              "\\"]},\\"yAxis\\":{}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "Resource": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Lambda Function **[Dummy Lambda for testing](https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/functions/DummyLambda)**\\"}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"TPS\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\"}],[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"Invocations\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"stat\\":\\"p50\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"P90 (avg: \${AVG})\\",\\"stat\\":\\"p90\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"P99 (avg: \${AVG})\\",\\"stat\\":\\"p99\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"TM90 (avg: \${AVG})\\",\\"stat\\":\\"tm90\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"TM99 (avg: \${AVG})\\",\\"stat\\":\\"tm99\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"TM90 > 150 for 3 datapoints within 15 minutes\\",\\"value\\":150,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TM99 > 2700 for 22 datapoints within 110 minutes\\",\\"value\\":2700,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":12,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"Faults (avg)\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":18,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Rates\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"Throttles (avg)\\"}],[\\"AWS/Lambda\\",\\"ProvisionedConcurrencySpilloverInvocations\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"Provisioned Concurrency Spillovers (avg)\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":0,\\"y\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Invocations\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"Invocations\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"Throttles\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"Throttles\\",\\"stat\\":\\"Sum\\"}],[\\"AWS/Lambda\\",\\"ConcurrentExecutions\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"Concurrent\\",\\"stat\\":\\"Maximum\\"}],[\\"AWS/Lambda\\",\\"ProvisionedConcurrencySpilloverInvocations\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"Provisioned Concurrency Spillovers\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":8,\\"y\\":6,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"Faults\\",\\"stat\\":\\"Sum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Count\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":5,\\"x\\":16,\\"y\\":11,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Iterator\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"IteratorAge\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"Iterator Age\\",\\"stat\\":\\"Maximum\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}}]}",
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::CloudWatch::Dashboard",
+    },
+    "ScopeTestDummyLambdaLatencyTM90WarningFC789E9A": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM90 latency is too high.",
+        "AlarmName": "Test-DummyLambda-Latency-TM90-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 3,
+        "EvaluationPeriods": 3,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM90",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": "DummyLambda",
+                  },
+                ],
+                "MetricName": "Duration",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 300,
+              "Stat": "tm90",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 150,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "ScopeTestDummyLambdaLatencyTM99Warning5A7A0C59": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmDescription": "TM99 latency is too high.",
+        "AlarmName": "Test-DummyLambda-Latency-TM99-Warning",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "DatapointsToAlarm": 22,
+        "EvaluationPeriods": 22,
+        "Metrics": Array [
+          Object {
+            "Id": "m1",
+            "Label": "TM99",
+            "MetricStat": Object {
+              "Metric": Object {
+                "Dimensions": Array [
+                  Object {
+                    "Name": "FunctionName",
+                    "Value": "DummyLambda",
+                  },
+                ],
+                "MetricName": "Duration",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 300,
+              "Stat": "tm99",
+            },
+            "ReturnData": true,
+          },
+        ],
+        "Threshold": 2700,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "Summary68521F81": Object {
+      "Properties": Object {
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"### Lambda Function **[Dummy Lambda for testing](https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/functions/DummyLambda)**\\"}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"TPS\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[{\\"label\\":\\"TPS\\",\\"expression\\":\\"FILL(requests,0) / PERIOD(requests)\\"}],[\\"AWS/Lambda\\",\\"Invocations\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"Invocations\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"P50 (avg: \${AVG})\\",\\"stat\\":\\"p50\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"P90 (avg: \${AVG})\\",\\"stat\\":\\"p90\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"P99 (avg: \${AVG})\\",\\"stat\\":\\"p99\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"TM90 (avg: \${AVG})\\",\\"stat\\":\\"tm90\\"}],[\\"AWS/Lambda\\",\\"Duration\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"TM99 (avg: \${AVG})\\",\\"stat\\":\\"tm99\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"TM90 > 150 for 3 datapoints within 15 minutes\\",\\"value\\":150,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TM99 > 2700 for 22 datapoints within 110 minutes\\",\\"value\\":2700,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"ms\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":16,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Errors (rate)\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"metrics\\":[[\\"AWS/Lambda\\",\\"Errors\\",\\"FunctionName\\",\\"DummyLambda\\",{\\"label\\":\\"Faults (avg)\\"}]],\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}}]}",
             ],
           ],
         },


### PR DESCRIPTION
Fixes #461

## Motivation

`LambdaFunctionMonitoring` only supports percentile latency alarms (`addLatencyP50Alarm`/`P90`/`P99`/`addMaxLatencyAlarm`), while `ApiGatewayMonitoring` and `ApiGatewayV2HttpApiMonitoring` gained the full trimmed-mean matrix in #81 and #444.

Trimmed mean matters most for low-volume Lambda functions. At a handful of invocations per 5-minute period, p90 degenerates into the period maximum, so a single slow invocation (a cold start, one slow downstream call) breaches the alarm and pages the operator. `tm90` averages the fastest 90% of the period, discarding the isolated outlier while still tracking sustained slowness. All the plumbing already exists in the library (`LatencyType.TM*`, `getLatencyTypeStatistic`, `LatencyAlarmFactory.addLatencyAlarm`); it just was never exposed on Lambda monitoring. Several teams currently work around this by subclassing `LambdaFunctionMonitoring`.

## Changes

Mirrors the `ApiGatewayMonitoring` implementation:

- New props on `LambdaFunctionMonitoringOptions`: `addLatencyTM50Alarm`, `addLatencyTM70Alarm`, `addLatencyTM90Alarm`, `addLatencyTM95Alarm`, `addLatencyTM99Alarm`, `addLatencyTM999Alarm`, `addLatencyTM9999Alarm`. They accept the same `LatencyThreshold | LatencyTimeoutPercentageThreshold` union as the existing percentile props, so `maxLatencyPercentageOfTimeout` works for TM types too.
- New `latencyTypesToRender` prop plus `latencyMetrics` record, same shape and doc comment as API Gateway. The latency widget renders the default p50/p90/p99 set plus any latency type that has an alarm.
- The four copy-pasted per-type alarm loops are replaced by one map-driven loop (`latencyAlarmDefinitions`), same as API Gateway.
- `p50LatencyMetric`/`p90LatencyMetric`/`p99LatencyMetric`/`maxLatencyMetric` are kept as aliases into `latencyMetrics`, so the public API is strictly additive.

`createLatencyWidget`, the `DefaultLatencyTypesToRender` constant, and the field declarations are identical to their `ApiGatewayMonitoring` counterparts, so the two monitorings stay consistent for the next person who touches either.

## Behavior notes

- Percentile alarm behavior, names, and thresholds are unchanged.
- One deliberate widget change (reflected in updated snapshots): for users of `addMaxLatencyAlarm`, the `Maximum` series is now rendered on the latency widget alongside its annotation. Previously the annotation was drawn on a widget that did not graph the series it alarmed on. This matches the API Gateway behavior where any alarmed latency type is rendered.

## Testing

- New snapshot test `trimmed mean latency alarms` covering `addLatencyTM90Alarm` (absolute threshold) and `addLatencyTM99Alarm` (`maxLatencyPercentageOfTimeout`), asserting 2 alarms created and the template snapshot (alarms emit `"Stat": "tm90"` / `"Stat": "tm99"`).
- Full suite green on the current rebase: 81 suites, 411 tests, 277 snapshots passing.
- `npx projen build` equivalents run clean locally: `jsii` compile (0 errors), `eslint --fix` (no changes), `jsii-docgen` (`API.md` regenerates byte-identical to the committed version), `jsii-rosetta extract`, and `package:js`. `git status` is clean afterwards, so the build's self-mutation check has nothing to report.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
