### PR TITLE
feat(alarm): use single-glyph Unicode comparison operators in default alarm annotations

### DIFF
--- a/lib/common/alarm/IAlarmAnnotationStrategy.ts
+++ b/lib/common/alarm/IAlarmAnnotationStrategy.ts
@@ -83,12 +83,33 @@ export abstract class FillingAlarmAnnotationStrategy
 }
 
 /**
- * Default annotation strategy that returns the built-in alarm annotation.
+ * Mapping of two-character comparison operator sequences (as rendered by
+ * Alarm.toAnnotation) to their single-glyph Unicode equivalents.
+ */
+const OPERATOR_GLYPHS: Record<string, string> = {
+  ">=": "≥",
+  "<=": "≤",
+};
+
+/**
+ * Default annotation strategy that returns the built-in alarm annotation,
+ * with two-character comparison operators (>=, <=) replaced by their
+ * single-glyph Unicode equivalents (≥, ≤) for readability.
  */
 export class DefaultAlarmAnnotationStrategy extends FillingAlarmAnnotationStrategy {
   protected createAnnotationToFill(
     props: AlarmAnnotationStrategyProps,
   ): HorizontalAnnotation {
-    return props.alarm.toAnnotation();
+    const annotation = props.alarm.toAnnotation();
+    if (annotation.label) {
+      let label = annotation.label;
+      for (const [ascii, glyph] of Object.entries(OPERATOR_GLYPHS)) {
+        // Operators are space-padded in the label produced by toAnnotation,
+        // so pad the search string to avoid touching metric names.
+        label = label.replace(` ${ascii} `, ` ${glyph} `);
+      }
+      return { ...annotation, label };
+    }
+    return annotation;
   }
 }

--- a/test/common/alarm/IAlarmAnnotationStrategy.test.ts
+++ b/test/common/alarm/IAlarmAnnotationStrategy.test.ts
@@ -1,0 +1,58 @@
+import { Duration, Stack } from "aws-cdk-lib";
+import {
+  Alarm,
+  ComparisonOperator,
+  Metric,
+  TreatMissingData,
+} from "aws-cdk-lib/aws-cloudwatch";
+
+import {
+  AlarmAnnotationStrategyProps,
+  DefaultAlarmAnnotationStrategy,
+  noopAction,
+} from "../../../lib";
+
+function createTestAnnotation(comparisonOperator: ComparisonOperator) {
+  const stack = new Stack();
+  const metric = new Metric({
+    namespace: "DummyNamespace",
+    metricName: "DummyMetric",
+    period: Duration.minutes(5),
+  });
+  const alarm = new Alarm(stack, "DummyAlarm", {
+    metric,
+    threshold: 10,
+    comparisonOperator,
+    evaluationPeriods: 3,
+    datapointsToAlarm: 3,
+    treatMissingData: TreatMissingData.MISSING,
+  });
+  const props: AlarmAnnotationStrategyProps = {
+    action: noopAction(),
+    alarm,
+    comparisonOperator,
+    datapointsToAlarm: 3,
+    evaluationPeriods: 3,
+    fillAlarmRange: false,
+    metric,
+    threshold: 10,
+  };
+  return new DefaultAlarmAnnotationStrategy().createAnnotation(props);
+}
+
+test.each([
+  [ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD, "≥"],
+  [ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD, "≤"],
+  [ComparisonOperator.GREATER_THAN_THRESHOLD, ">"],
+  [ComparisonOperator.LESS_THAN_THRESHOLD, "<"],
+])("annotation label for %s uses the %s glyph", (operator, glyph) => {
+  const annotation = createTestAnnotation(operator);
+  expect(annotation.label).toContain(` ${glyph} 10`);
+});
+
+test("annotation label does not contain two-character ASCII operators", () => {
+  const annotation = createTestAnnotation(
+    ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+  );
+  expect(annotation.label).not.toContain(">=");
+});

--- a/test/monitoring/aws-lambda/__snapshots__/LambdaFunctionMonitoring.test.ts.snap
+++ b/test/monitoring/aws-lambda/__snapshots__/LambdaFunctionMonitoring.test.ts.snap
@@ -266,7 +266,7 @@ Object {
               Object {
                 "Ref": "Function76856677",
               },
-              "\\",{\\"label\\":\\"Invocations\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"TPS <= 0 for 1 datapoints within 5 minutes\\",\\"value\\":0,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TPS > 20 for 1 datapoints within 5 minutes\\",\\"value\\":20,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Invocations\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"TPS ≤ 0 for 1 datapoints within 5 minutes\\",\\"value\\":0,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TPS > 20 for 1 datapoints within 5 minutes\\",\\"value\\":20,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -925,7 +925,7 @@ Object {
               Object {
                 "Ref": "Function76856677",
               },
-              "\\",{\\"label\\":\\"Invocations\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"TPS <= 0 for 1 datapoints within 5 minutes\\",\\"value\\":0,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TPS > 20 for 1 datapoints within 5 minutes\\",\\"value\\":20,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Invocations\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"TPS ≤ 0 for 1 datapoints within 5 minutes\\",\\"value\\":0,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TPS > 20 for 1 datapoints within 5 minutes\\",\\"value\\":20,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -1475,7 +1475,7 @@ Object {
               Object {
                 "Ref": "Function76856677",
               },
-              "\\",{\\"label\\":\\"Invocations\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"TPS <= 0 for 1 datapoints within 5 minutes\\",\\"value\\":0,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TPS > 20 for 1 datapoints within 5 minutes\\",\\"value\\":20,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Invocations\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"TPS ≤ 0 for 1 datapoints within 5 minutes\\",\\"value\\":0,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TPS > 20 for 1 datapoints within 5 minutes\\",\\"value\\":20,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -2478,7 +2478,7 @@ Object {
               Object {
                 "Ref": "Function76856677",
               },
-              "\\",{\\"label\\":\\"Invocations\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"TPS <= 0 for 1 datapoints within 5 minutes\\",\\"value\\":0,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TPS > 20 for 1 datapoints within 5 minutes\\",\\"value\\":20,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Invocations\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"TPS ≤ 0 for 1 datapoints within 5 minutes\\",\\"value\\":0,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TPS > 20 for 1 datapoints within 5 minutes\\",\\"value\\":20,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -2898,7 +2898,7 @@ Object {
               Object {
                 "Ref": "Function76856677",
               },
-              "\\",{\\"label\\":\\"Invocations\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"TPS <= 0 for 1 datapoints within 5 minutes\\",\\"value\\":0,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TPS > 20 for 1 datapoints within 5 minutes\\",\\"value\\":20,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Invocations\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"TPS ≤ 0 for 1 datapoints within 5 minutes\\",\\"value\\":0,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TPS > 20 for 1 datapoints within 5 minutes\\",\\"value\\":20,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":6,\\"height\\":5,\\"x\\":6,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },
@@ -3901,7 +3901,7 @@ Object {
               Object {
                 "Ref": "Function76856677",
               },
-              "\\",{\\"label\\":\\"Invocations\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"TPS <= 0 for 1 datapoints within 5 minutes\\",\\"value\\":0,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TPS > 20 for 1 datapoints within 5 minutes\\",\\"value\\":20,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
+              "\\",{\\"label\\":\\"Invocations\\",\\"stat\\":\\"Sum\\",\\"visible\\":false,\\"id\\":\\"requests\\"}]],\\"annotations\\":{\\"horizontal\\":[{\\"label\\":\\"TPS ≤ 0 for 1 datapoints within 5 minutes\\",\\"value\\":0,\\"yAxis\\":\\"left\\"},{\\"label\\":\\"TPS > 20 for 1 datapoints within 5 minutes\\",\\"value\\":20,\\"yAxis\\":\\"left\\"}]},\\"yAxis\\":{\\"left\\":{\\"min\\":0,\\"label\\":\\"Rate\\",\\"showUnits\\":false}}}},{\\"type\\":\\"metric\\",\\"width\\":8,\\"height\\":6,\\"x\\":8,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Latency\\",\\"region\\":\\"",
               Object {
                 "Ref": "AWS::Region",
               },


### PR DESCRIPTION
## What

`DefaultAlarmAnnotationStrategy` passes `Alarm.toAnnotation()` through unchanged, so alarm annotation labels render comparison operators as the two-character ASCII sequences `>=` and `<=` (e.g. `TPS <= 0 for 1 datapoints within 5 minutes`). This change replaces them with the single Unicode glyphs `≥` and `≤` in the rendered label. Bare `>` and `<` are unchanged.

The substitution only matches space-padded operators, so metric names containing these character sequences are not affected.

## Why

The single glyphs are more readable on dashboard widgets, where annotation labels are often truncated and visually dense.

## Testing

- New unit test `test/common/alarm/IAlarmAnnotationStrategy.test.ts` covering all four comparison operators and asserting the ASCII digraphs no longer appear.
- Full test suite passes (82 suites, 416 tests); 3 snapshots updated in `LambdaFunctionMonitoring.test.ts.snap` where the diff is exactly `TPS <= 0` → `TPS ≤ 0`.

## Notes for reviewers

This changes rendered dashboard output for consumers using the default annotation strategy. Happy to gate it behind an opt-in prop on the strategy if you'd prefer the current rendering stay the default.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license.